### PR TITLE
ci(guard): skip merge commits in the authorship check

### DIFF
--- a/.github/workflows/authorship-guard.yml
+++ b/.github/workflows/authorship-guard.yml
@@ -50,11 +50,13 @@ jobs:
           fi
 
           # Inspect only the commits this push/PR introduces, never existing
-          # history: with no usable base we check just the new tip.
+          # history: with no usable base we check just the new tip. Skip merge
+          # commits — a GitHub-created merge carries the web-flow identity, not a
+          # human author, so it isn't ours to police.
           if [ -z "$base" ] || [ "$base" = "$ZERO" ]; then
-            commits=$(git rev-parse "$head")
+            commits=$(git rev-list --no-merges -1 "$head")
           else
-            commits=$(git rev-list "$base..$head")
+            commits=$(git rev-list --no-merges "$base..$head")
           fi
           [ -z "$commits" ] && { echo "OK: no new commits to check"; exit 0; }
 


### PR DESCRIPTION
## What

Adds `--no-merges` to the Authorship Guard's commit scan.

## Why

After #9 merged, the guard failed on `main` (run `fe9f90d`): GitHub's UI merge creates a merge commit stamped with the web-flow committer (`noreply@github.com`) and the merger's account email — never the approved project identity — so the guard flagged GitHub's own bookkeeping commit.

## Effect

- Real commits: still checked (a wrong-email commit is still blocked).
- GitHub-created merge commits: ignored.

Once merged, the guard goes green on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt9r6R5X4aVDN6t8wszBs7