### PR TITLE
fix(audit): close redaction leaks, complete the trail, reconcile filters

### DIFF
--- a/docs/reference/commands/jit_audit.md
+++ b/docs/reference/commands/jit_audit.md
@@ -7,8 +7,8 @@ Show the audit log: what jit commands ran, when, by whom, and every unlock
 jit audit prints the application audit trail, most recent first: one line for
 every jit command that ran (what, when, which user and parent process, and
 whether it succeeded), interleaved with every local-auth event the service saw
-(each unlock and each DECLINED prompt, with how you were asked, what triggered
-it, and the secret names each one touched).
+(each unlock, each APPROVED disclosed grant, and each DECLINED prompt, with how
+you were asked, what triggered it, and the secret names each one touched).
 
 Together they answer "what happened on this machine, and who did it": the
 command lines are the actions, the auth lines are the approvals those actions
@@ -27,7 +27,8 @@ a flood of throwaway processes push every real event out of the history.
 Output is a grouped text timeline, newest first. --format logfmt prints one
 key=value line per event instead, so it reads and greps like a real service
 log. Narrow either without grep using the flags: --kind
-cmd,unlock,use,lock,service,error, --status ok|failed|denied, --since and --until
+cmd,unlock,use,grant,lock,service,error, --status ok|failed|denied|approved,
+--since and --until
 (an age like 2h/3d or a date), --parent (the launching ancestor, e.g. claude),
 --secret (a secret name an unlock touched), --user, and --grep (a regexp over the
 line). --limit caps how many of the newest MATCHING entries print. Add --follow
@@ -55,12 +56,12 @@ jit audit [flags]
   -f, --follow          print the matching tail, then stream new entries live (text only)
       --format string   output format: "text" (default), "logfmt" (one key=value line per event), or "json" (default "text")
       --grep string     only entries whose rendered line matches this regular expression
-      --kind strings    only these kinds (comma-separated): cmd, unlock, use, lock, service, error
+      --kind strings    only these kinds (comma-separated): cmd, unlock, use, grant, lock, service, error
       --limit int       show at most this many recent matching entries (0 for all) (default 50)
       --parent string   only entries whose launched-by ancestor contains this (e.g. claude)
       --secret string   only auth events that touched a secret whose name contains this
       --since string    only entries at or after this time: an age (2h, 90m, 3d) or a date ("2026-07-23" or "2026-07-23 09:00")
-      --status string   only this status: ok, failed, or denied
+      --status string   only this status: ok, failed, denied, or approved
       --until string    only entries at or before this time (same forms as --since)
       --user string     only commands this user ran (auth events carry no user)
 ```

--- a/docs/service/provenance.md
+++ b/docs/service/provenance.md
@@ -35,8 +35,8 @@ is not authenticating one, and jit doesn't pretend otherwise (see
   triggered it while it's still up - it answers immediately instead of
   waiting for the prompt to resolve.
 - `jit audit` prints the durable audit log: every jit command that ran,
-  interleaved with every unlock, denial, use, and lock the service has seen
-  and what caused each. It's logfmt, newest first, so it greps like a real
+  interleaved with every unlock, grant, denial, use, and lock the service has
+  seen and what caused each. It's logfmt, newest first, so it greps like a real
   service log:
 
   ```

--- a/internal/audit/tokenpatterns_test.go
+++ b/internal/audit/tokenpatterns_test.go
@@ -324,6 +324,20 @@ func TestEveryRecognizedFormatIsRedactedInTheAuditLog(t *testing.T) {
 	// known prefix can trigger redaction.
 	const shortBody = "aB3xKq9Zm1"
 
+	// shortPrefixCoverage classifies the formats whose regex carries no literal
+	// prefix >=3 chars for the short-token assertion below to key on. Each is
+	// paired with the concrete token(s) that MUST still redact — via a real
+	// short prefix auditlog lists explicitly, or (Twilio) a body long enough for
+	// the entropy floor to catch. A NEW short-prefix format is absent from this
+	// map and so FAILS the test until it is consciously classified here; that is
+	// the drift alarm the old silent `continue` swallowed, which let a whole
+	// branch add formats with no coverage check.
+	shortPrefixCoverage := map[string][]string{
+		"AWS Access Key ID":     {"AKIA" + shortBody, "ASIA" + shortBody},                     // AKIA/ASIA are in secretPrefixes
+		"HashiCorp Vault Token": {"hvs." + shortBody, "hvb." + shortBody, "hvr." + shortBody}, // hvs./hvb./hvr. are in secretPrefixes
+		"Twilio Account SID":    {"AC" + hexBody(32)},                                         // no usable prefix; the 34-char SID trips the entropy floor (built at runtime so the source carries no literal SID)
+	}
+
 	for _, tp := range knownTokenPatterns {
 		// Private-key bodies never appear as a log argument (and FindFileTokens
 		// cedes them to ScanPrivateKeys); connection strings are matched by
@@ -337,7 +351,25 @@ func TestEveryRecognizedFormatIsRedactedInTheAuditLog(t *testing.T) {
 		src := strings.TrimPrefix(tp.pattern.String(), `\b`)
 		prefix, _ := regexp.MustCompile(src).LiteralPrefix()
 		if len(prefix) < 3 {
-			continue // no distinctive literal to key on (e.g. "sk-" variants share a stem)
+			// No distinctive literal to key on (e.g. AWS's AKIA|ASIA alternation
+			// leaves no common prefix). Assert the format's explicit coverage
+			// instead, and fail loudly if the format is new and unclassified.
+			tokens, ok := shortPrefixCoverage[tp.vendor]
+			if !ok {
+				t.Errorf("%s: regex %q has no literal prefix >=3 chars for the drift guard to key on, "+
+					"and it is not classified in shortPrefixCoverage. Either add its real prefix to "+
+					"secretPrefixes in internal/auditlog/auditlog.go and list a covering token here, or "+
+					"(if only the entropy floor covers it) add a long representative token here.",
+					tp.vendor, tp.pattern.String())
+				continue
+			}
+			for _, token := range tokens {
+				if auditlog.RedactText(token) == token {
+					t.Errorf("%s: covering token %q is NOT redacted in the audit log — its auditlog coverage has regressed.",
+						tp.vendor, token)
+				}
+			}
+			continue
 		}
 
 		token := prefix + shortBody

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -170,6 +170,14 @@ func (l *Logger) Load(max int) []Record {
 // cutting on a line boundary. Temp-file + rename, so a crash mid-trim leaves
 // the original intact rather than a half-written log. Cheap to call before
 // each append; a stat that shows the file is small returns immediately.
+//
+// The mutex serializes trim and append within one process, but every jit CLI
+// invocation is a separate process with its own Logger, so a trim in one can
+// rename the file out from under an append fd another already opened, and that
+// one record is lost to the orphaned inode. The window only opens once the
+// file is over maxBytes, and this trail is best-effort by contract (a lost
+// bookkeeping line must never fail the command that ran), so it is left as a
+// known, bounded gap rather than paid for with cross-process file locking.
 func (l *Logger) Trim() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -337,13 +345,25 @@ func Redact(args []string) []string {
 }
 
 func redactArg(a string) string {
-	// KEY=VALUE or --flag=VALUE: mask the value, keep the name.
+	// KEY=VALUE or --flag=VALUE: mask the value, keep the name legible.
 	if eq := strings.IndexByte(a, '='); eq > 0 {
 		name, val := a[:eq], a[eq+1:]
-		if val != "" && looksSecret(val) {
-			return name + "=" + redactToken
+		// A base64 token that merely ends in '=' padding ("AAAA…==") is not a
+		// KEY=VALUE — everything after its first '=' is just more '='. Only a
+		// value with real content past the padding is a genuine assignment; a
+		// padding-only tail falls through to the whole-argument test below so
+		// such a token can't slip past by being mis-split.
+		if strings.Trim(val, "=") != "" {
+			// The value half is a value, not a positional path, so it is judged
+			// by looksSecretToken — which still refuses a leading-slash path
+			// (its whole-token match drops the '/') but does not wave through a
+			// base64 credential just because it contains '/' or '+', the way
+			// the path-shy looksSecret does for a bare argument.
+			if looksSecretToken(val) {
+				return name + "=" + redactToken
+			}
+			return a
 		}
-		return a
 	}
 	if looksSecret(a) {
 		return redactToken

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -125,6 +125,52 @@ func TestRedactMasksSecretLookingTokens(t *testing.T) {
 			in:   []string{"AKIAIOSFODNN7EXAMPLE"},
 			want: []string{redactToken},
 		},
+		{
+			// A bare base64 token ending in '=' padding must not be misread as
+			// KEY=VALUE (name=the token, value="=") and slip through unmasked.
+			name: "padded base64 bare is masked, not misread as KEY=VALUE",
+			in:   []string{"SGVsbG9Xb3JsZERlYWRiZWVmMDAxMjM0NQ=="},
+			want: []string{redactToken},
+		},
+		{
+			// A base64 credential containing '/' must be masked when it is a
+			// flag or env value; the path-shy whole-arg test used to wave it
+			// through as if the '/' made it a file path.
+			name: "flag value base64 containing slash is masked",
+			in:   []string{"--token=aB3xKq9ZmQpLrStUvWxYz012+ab/cdEF"},
+			want: []string{"--token=" + redactToken},
+		},
+		{
+			name: "env value base64 containing slash is masked",
+			in:   []string{"AWS_SECRET=aB3xKq9ZmQpLrStUvWxYz012+ab/cdEF"},
+			want: []string{"AWS_SECRET=" + redactToken},
+		},
+		{
+			// The path-safety the '/' masking must not cost: an absolute path
+			// given as a flag value stays legible.
+			name: "absolute path as a flag value survives",
+			in:   []string{"--config=/etc/app/config.yaml"},
+			want: []string{"--config=/etc/app/config.yaml"},
+		},
+		{
+			name: "deep alnum path as a bare positional survives",
+			in:   []string{"scan", "/Users/me/project7/config8/data9zzzzzz"},
+			want: []string{"scan", "/Users/me/project7/config8/data9zzzzzz"},
+		},
+		{
+			// A long env-var/flag name must not stop the value from being
+			// masked: the value split, not the name's shape, decides.
+			name: "long key name still masks a prefixed value",
+			in:   []string{"MY_VERY_LONG_ENVIRONMENT_VARIABLE_NAME_XYZ=ghp_16charsAtLeastxxxxxxxxxxxxxxxxxx"},
+			want: []string{"MY_VERY_LONG_ENVIRONMENT_VARIABLE_NAME_XYZ=" + redactToken},
+		},
+		{
+			// A legible key=value whose value is not a secret is left intact —
+			// the whole-arg fallback must not over-mask an ordinary assignment.
+			name: "ordinary key=value survives with its name",
+			in:   []string{"commit=a1b2c3d4e5f6a7b8c9d0"},
+			want: []string{"commit=a1b2c3d4e5f6a7b8c9d0"},
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -61,14 +61,17 @@ type auditFilter struct {
 // actually renders, so `--kind command` and `--kind start` do what a reader
 // means rather than silently matching nothing.
 var auditKindAliases = map[string]string{
-	"cmd":     "cmd",
-	"command": "cmd",
-	"unlock":  "unlock",
-	"use":     "use",
-	"lock":    "lock",
-	"service": "service",
-	"start":   "service",
-	"error":   "error",
+	"cmd":      "cmd",
+	"command":  "cmd",
+	"unlock":   "unlock",
+	"use":      "use",
+	"lock":     "lock",
+	"service":  "service",
+	"start":    "service",
+	"error":    "error",
+	"grant":    "grant",
+	"approve":  "grant",
+	"approved": "grant",
 }
 
 // compileAuditFilter turns the raw flags into an auditFilter, rejecting an
@@ -87,7 +90,7 @@ func compileAuditFilter() (auditFilter, error) {
 				}
 				canon, ok := auditKindAliases[k]
 				if !ok {
-					return f, fmt.Errorf("unknown --kind %q: choose from cmd, unlock, use, lock, service, error (denials are --status denied)", k)
+					return f, fmt.Errorf("unknown --kind %q: choose from cmd, unlock, use, grant, lock, service, error (denials are --status denied)", k)
 				}
 				f.kinds[canon] = true
 			}
@@ -96,10 +99,10 @@ func compileAuditFilter() (auditFilter, error) {
 	if auditStatus != "" {
 		s := strings.ToLower(auditStatus)
 		switch s {
-		case "ok", "failed", "denied":
+		case "ok", "failed", "denied", "approved":
 			f.status = s
 		default:
-			return f, fmt.Errorf("unknown --status %q: choose from ok, failed, denied", auditStatus)
+			return f, fmt.Errorf("unknown --status %q: choose from ok, failed, denied, approved", auditStatus)
 		}
 	}
 	var err error
@@ -185,6 +188,12 @@ func parseAuditTime(s string) (time.Time, error) {
 		return time.Time{}, nil
 	}
 	if d, ok := parseFlexDuration(s); ok {
+		// A duration here is read as "that long ago"; a negative one would
+		// resolve into the future and silently match nothing. Reject it with a
+		// message that names the fix rather than leaving an empty result.
+		if d < 0 {
+			return time.Time{}, fmt.Errorf("a duration here means %q ago; drop the leading '-'", strings.TrimPrefix(s, "-"))
+		}
 		return time.Now().Add(-d), nil
 	}
 	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02 15:04", "2006-01-02", time.RFC3339} {
@@ -228,8 +237,8 @@ var auditCmd = &cobra.Command{
 	Long: "jit audit prints the application audit trail, most recent first: one line for\n" +
 		"every jit command that ran (what, when, which user and parent process, and\n" +
 		"whether it succeeded), interleaved with every local-auth event the service saw\n" +
-		"(each unlock and each DECLINED prompt, with how you were asked, what triggered\n" +
-		"it, and the secret names each one touched).\n\n" +
+		"(each unlock, each APPROVED disclosed grant, and each DECLINED prompt, with how\n" +
+		"you were asked, what triggered it, and the secret names each one touched).\n\n" +
 		"Together they answer \"what happened on this machine, and who did it\": the\n" +
 		"command lines are the actions, the auth lines are the approvals those actions\n" +
 		"needed. Command arguments are recorded with any secret-looking value masked, so\n" +
@@ -245,7 +254,8 @@ var auditCmd = &cobra.Command{
 		"Output is a grouped text timeline, newest first. --format logfmt prints one\n" +
 		"key=value line per event instead, so it reads and greps like a real service\n" +
 		"log. Narrow either without grep using the flags: --kind\n" +
-		"cmd,unlock,use,lock,service,error, --status ok|failed|denied, --since and --until\n" +
+		"cmd,unlock,use,grant,lock,service,error, --status ok|failed|denied|approved,\n" +
+		"--since and --until\n" +
 		"(an age like 2h/3d or a date), --parent (the launching ancestor, e.g. claude),\n" +
 		"--secret (a secret name an unlock touched), --user, and --grep (a regexp over the\n" +
 		"line). --limit caps how many of the newest MATCHING entries print. Add --follow\n" +
@@ -286,16 +296,19 @@ var auditCmd = &cobra.Command{
 		// --limit means "the newest N that MATCH" rather than "matches within
 		// the newest N" — the former is what a reader narrowing with a filter
 		// actually wants.
+		// --follow reads the files itself, starting the stream from the exact
+		// offset its initial tail consumed, so it never double-reads nor skips
+		// a line across the load; it does not share this snapshot.
+		if auditFollow {
+			return followAuditLog(cmd.Context(), cmd.OutOrStdout(), root, filter, auditLimit)
+		}
+
 		commands := auditlog.New(root, io.Discard).Load(0)
 		events := newHistoryLog(root, io.Discard).load(1 << 30)
 
 		if auditFormat == "json" {
 			keptCmds, keptEvents := filterSources(commands, events, filter, auditLimit)
 			return writeJSON(cmd.OutOrStdout(), auditJSON{Commands: keptCmds, AuthEvents: keptEvents})
-		}
-
-		if auditFollow {
-			return followAuditLog(cmd.Context(), cmd.OutOrStdout(), root, commands, events, filter, auditLimit)
 		}
 
 		printAuditLog(cmd.OutOrStdout(), commands, events, filter, auditLimit)
@@ -319,7 +332,7 @@ type auditJSON struct {
 // --follow re-reads), line is the display form that may carry ANSI color.
 type auditEntry struct {
 	t      time.Time
-	kind   string   // logfmt kind token: cmd | unlock | use | lock | service | error
+	kind   string   // logfmt kind token: cmd | unlock | use | grant | lock | service | error
 	status string   // ok | failed | denied, where the kind carries one; else ""
 	user   string   // command records only (auth events are all this machine's user)
 	parent string   // the ancestor that explains the call (launched-by)
@@ -388,24 +401,52 @@ func buildEntries(home string, commands []auditlog.Record, events []agent.Sessio
 // against the rendered entry so text and json narrow identically.
 func filterSources(commands []auditlog.Record, events []agent.SessionEvent, filter auditFilter, limit int) ([]auditlog.Record, []agent.SessionEvent) {
 	home, _ := os.UserHomeDir()
-	keptCmds := []auditlog.Record{}
-	for _, r := range commands {
+	// Choose the newest `limit` over the MERGED timeline — exactly the set the
+	// text and logfmt views show — rather than the newest `limit` of each
+	// source independently, which would return up to 2*limit rows and a
+	// different set than text for the same flags.
+	type ref struct {
+		t     time.Time
+		isCmd bool
+		idx   int
+	}
+	var refs []ref
+	for i, r := range commands {
 		if filter.keep(commandEntry(r)) {
+			refs = append(refs, ref{t: time.Unix(0, r.UnixNano), isCmd: true, idx: i})
+		}
+	}
+	for i, ev := range events {
+		if filter.keep(authEntry(home, ev)) {
+			refs = append(refs, ref{t: time.Unix(ev.UnixTime, 0), isCmd: false, idx: i})
+		}
+	}
+	// Newest first — same stable order buildEntries+sort uses (commands appended
+	// before events, so a tie keeps that order) — then cap the merged stream.
+	sort.SliceStable(refs, func(i, j int) bool { return refs[i].t.After(refs[j].t) })
+	if limit > 0 && len(refs) > limit {
+		refs = refs[:limit]
+	}
+	cmdSel, evtSel := map[int]bool{}, map[int]bool{}
+	for _, r := range refs {
+		if r.isCmd {
+			cmdSel[r.idx] = true
+		} else {
+			evtSel[r.idx] = true
+		}
+	}
+	// Restore each array to its native oldest-first order. Never nil, so the
+	// JSON renders [] not null.
+	keptCmds := []auditlog.Record{}
+	for i, r := range commands {
+		if cmdSel[i] {
 			keptCmds = append(keptCmds, r)
 		}
 	}
 	keptEvents := []agent.SessionEvent{}
-	for _, ev := range events {
-		if filter.keep(authEntry(home, ev)) {
+	for i, ev := range events {
+		if evtSel[i] {
 			keptEvents = append(keptEvents, ev)
-		}
-	}
-	if limit > 0 {
-		if len(keptCmds) > limit {
-			keptCmds = keptCmds[len(keptCmds)-limit:]
-		}
-		if len(keptEvents) > limit {
-			keptEvents = keptEvents[len(keptEvents)-limit:]
 		}
 	}
 	return keptCmds, keptEvents
@@ -421,8 +462,18 @@ const auditFollowPollInterval = 500 * time.Millisecond
 // (newest-first), the follow stream is chronological — the initial tail oldest-
 // first and each new line after it — so a live watch reads like `tail -f`
 // rather than scrolling backwards. Ends on ctrl-C / SIGTERM.
-func followAuditLog(ctx context.Context, w io.Writer, root string, commands []auditlog.Record, events []agent.SessionEvent, filter auditFilter, limit int) error {
+func followAuditLog(ctx context.Context, w io.Writer, root string, filter auditFilter, limit int) error {
 	home, _ := os.UserHomeDir()
+
+	auditPath := filepath.Join(root, auditlog.FileName)
+	histPath := filepath.Join(root, historyFileName)
+	// Read each file once for the opening tail, keeping the exact byte offset
+	// that read consumed, and begin the live stream from precisely there. Using
+	// the same read to produce both the tail and the follow offset (rather than
+	// a later stat) closes the window in which a line appended between the two
+	// is neither shown in the tail nor picked up as new.
+	offA, commands := readNewCommands(auditPath, 0)
+	offH, events := readNewEvents(histPath, 0)
 
 	entries := buildEntries(home, commands, events, filter)
 	sort.SliceStable(entries, func(i, j int) bool { return entries[i].t.Before(entries[j].t) })
@@ -437,13 +488,6 @@ func followAuditLog(ctx context.Context, w io.Writer, root string, commands []au
 	for _, e := range entries {
 		writeAuditFollowRow(w, e, cols)
 	}
-
-	auditPath := filepath.Join(root, auditlog.FileName)
-	histPath := filepath.Join(root, historyFileName)
-	// Start following from the current end of each file, so the tail just
-	// printed is not immediately reprinted as "new".
-	offA := fileSize(auditPath)
-	offH := fileSize(histPath)
 
 	ctx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 	defer stop()
@@ -481,17 +525,6 @@ func followAuditLog(ctx context.Context, w io.Writer, root string, commands []au
 			writeAuditFollowRow(w, e, cols)
 		}
 	}
-}
-
-// fileSize is a stat that reads 0 for a file that isn't there yet (the service
-// may not have run, or no command has been recorded), so a follow can start
-// before either log exists and pick them up when they appear.
-func fileSize(path string) int64 {
-	fi, err := os.Stat(path)
-	if err != nil {
-		return 0
-	}
-	return fi.Size()
 }
 
 // readNewCommands returns command records appended to path since off and the
@@ -597,11 +630,17 @@ func logfmtValue(v string) string {
 	if v == "" {
 		return `""`
 	}
-	if !strings.ContainsAny(v, " \t\"=") {
+	if !strings.ContainsAny(v, " \t\r\n\"=") {
 		return v
 	}
 	v = strings.ReplaceAll(v, `\`, `\\`)
 	v = strings.ReplaceAll(v, `"`, `\"`)
+	// Escape newlines and carriage returns to their two-character forms so one
+	// event never splits across physical lines — the whole promise of "one
+	// key=value line per event". Done after the backslash pass above so the
+	// backslash this inserts is not itself doubled.
+	v = strings.ReplaceAll(v, "\r", `\r`)
+	v = strings.ReplaceAll(v, "\n", `\n`)
 	return `"` + v + `"`
 }
 
@@ -892,10 +931,10 @@ func init() {
 	auditCmd.Flags().StringVar(&auditFormat, "format", "text", `output format: "text" (default), "logfmt" (one key=value line per event), or "json"`)
 	auditCmd.Flags().IntVar(&auditLimit, "limit", 50, "show at most this many recent matching entries (0 for all)")
 	auditCmd.Flags().BoolVarP(&auditFollow, "follow", "f", false, "print the matching tail, then stream new entries live (text only)")
-	auditCmd.Flags().StringSliceVar(&auditKinds, "kind", nil, "only these kinds (comma-separated): cmd, unlock, use, lock, service, error")
+	auditCmd.Flags().StringSliceVar(&auditKinds, "kind", nil, "only these kinds (comma-separated): cmd, unlock, use, grant, lock, service, error")
 	auditCmd.Flags().StringVar(&auditSince, "since", "", `only entries at or after this time: an age (2h, 90m, 3d) or a date ("2026-07-23" or "2026-07-23 09:00")`)
 	auditCmd.Flags().StringVar(&auditUntil, "until", "", "only entries at or before this time (same forms as --since)")
-	auditCmd.Flags().StringVar(&auditStatus, "status", "", "only this status: ok, failed, or denied")
+	auditCmd.Flags().StringVar(&auditStatus, "status", "", "only this status: ok, failed, denied, or approved")
 	auditCmd.Flags().StringVar(&auditUser, "user", "", "only commands this user ran (auth events carry no user)")
 	auditCmd.Flags().StringVar(&auditParent, "parent", "", "only entries whose launched-by ancestor contains this (e.g. claude)")
 	auditCmd.Flags().StringVar(&auditSecret, "secret", "", "only auth events that touched a secret whose name contains this")

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -444,8 +443,6 @@ func TestFollowPrintsInitialTail(t *testing.T) {
 	home := withFixtureHome(t)
 	seedAuditFixtures(t, home)
 	root := filepath.Join(home, "Library", "Application Support", "jitpass")
-	commands := auditlog.New(root, io.Discard).Load(0)
-	events := newHistoryLog(root, io.Discard).load(1 << 30)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -459,7 +456,7 @@ func TestFollowPrintsInitialTail(t *testing.T) {
 	} {
 		auditFormat = tc.format
 		var buf bytes.Buffer
-		if err := followAuditLog(ctx, &buf, root, commands, events, auditFilter{}, 50); err != nil {
+		if err := followAuditLog(ctx, &buf, root, auditFilter{}, 50); err != nil {
 			t.Fatalf("followAuditLog(%s): %v", tc.format, err)
 		}
 		if !strings.Contains(buf.String(), tc.want) {

--- a/internal/cli/auditrecord.go
+++ b/internal/cli/auditrecord.go
@@ -82,7 +82,7 @@ func recordAuditEvent(cmd *cobra.Command, cmdErr error, elapsed time.Duration) {
 	rec := auditlog.Record{
 		UnixNano:   time.Now().UnixNano(),
 		Command:    cmdPath,
-		Args:       sanitizeInvocationArgs(cmdPath, os.Args[1:]),
+		Args:       sanitizeInvocationArgs(cmdPath, os.Args[1:], cmd.Flags().Args(), cmdErr == nil),
 		UID:        os.Getuid(),
 		PID:        os.Getpid(),
 		PPID:       os.Getppid(),
@@ -123,20 +123,36 @@ func resolveInvoker() (parent, launchedBy string) {
 // sanitizeInvocationArgs redacts the recorded arguments. auditlog.Redact
 // handles credential-shaped tokens generically; on top of that, for commands
 // whose grammar puts a raw secret in a known position, that position is masked
-// unconditionally so a low-entropy secret can't slip through.
-func sanitizeInvocationArgs(cmdPath string, rawArgs []string) []string {
+// so a low-entropy secret can't slip through. positionals is the command's
+// parsed positional arguments (cobra's Flags().Args()) and parsedOK reports
+// whether flag parsing succeeded — together they tell a value that was passed
+// on the command line from one that wasn't.
+func sanitizeInvocationArgs(cmdPath string, rawArgs, positionals []string, parsedOK bool) []string {
 	args := auditlog.Redact(rawArgs)
-	if secretValueCommands[cmdPath] {
-		// Mask the last non-flag token: `jit vault set <path> <value>`, the
-		// value is the only thing it can be, and Redact may have left a weak
-		// one untouched.
-		for i := len(args) - 1; i >= 0; i-- {
-			if strings.HasPrefix(args[i], "-") {
-				continue
-			}
-			args[i] = "<redacted>"
-			break
+	if !secretValueCommands[cmdPath] {
+		return args
+	}
+	// Skip the value mask ONLY when we are certain no value was on the command
+	// line: a clean parse that yielded exactly the one <path> positional (the
+	// value came from the prompt or --stdin). Then masking the last token would
+	// redact the secret's PATH — a non-secret the log should keep.
+	//
+	// On a parse ERROR the positional count is unreliable — cobra returns none
+	// even when a value is present (`jit vault set --stdim path secret`, a
+	// mistyped flag) — so we must NOT infer "no value" from an empty slice, or a
+	// weak value would be logged in the clear. Fall back to masking in every
+	// case but the confirmed single-positional one.
+	if parsedOK && len(positionals) == 1 {
+		return args
+	}
+	// Mask the last non-flag token: where a value is present it is the value,
+	// the only thing it can be, and Redact may have left a weak one alone.
+	for i := len(args) - 1; i >= 0; i-- {
+		if strings.HasPrefix(args[i], "-") {
+			continue
 		}
+		args[i] = "<redacted>"
+		break
 	}
 	return args
 }

--- a/internal/cli/auditrecord_test.go
+++ b/internal/cli/auditrecord_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSanitizeInvocationArgsVaultSet checks that `jit vault set` masks the
+// value ONLY when a value was actually passed on the command line. With the
+// value coming from the prompt or --stdin (one positional), the last token is
+// the secret's PATH, and masking it would strip exactly the fact the audit log
+// exists to keep: which secret was set.
+func TestSanitizeInvocationArgsVaultSet(t *testing.T) {
+	const cmd = "jit vault set"
+	cases := []struct {
+		name        string
+		rawArgs     []string
+		positionals []string
+		parsedOK    bool
+		wantLast    string // expected final recorded token
+		wantMasked  bool
+	}{
+		{
+			name:        "value on the command line is masked",
+			rawArgs:     []string{"vault", "set", "stripe/live-key", "hunter2"},
+			positionals: []string{"stripe/live-key", "hunter2"},
+			parsedOK:    true,
+			wantLast:    "<redacted>",
+			wantMasked:  true,
+		},
+		{
+			name:        "value from prompt or stdin keeps the path",
+			rawArgs:     []string{"vault", "set", "stripe/live-key"},
+			positionals: []string{"stripe/live-key"},
+			parsedOK:    true,
+			wantLast:    "stripe/live-key",
+			wantMasked:  false,
+		},
+		{
+			name:        "stdin flag before the path keeps the path",
+			rawArgs:     []string{"vault", "set", "--stdin", "stripe/live-key"},
+			positionals: []string{"stripe/live-key"},
+			parsedOK:    true,
+			wantLast:    "stripe/live-key",
+			wantMasked:  false,
+		},
+		{
+			name:        "value present with a trailing flag still masks the value",
+			rawArgs:     []string{"vault", "set", "stripe/live-key", "hunter2", "--force"},
+			positionals: []string{"stripe/live-key", "hunter2"},
+			parsedOK:    true,
+			wantLast:    "--force",
+			wantMasked:  true,
+		},
+		{
+			// A mistyped flag before the positionals fails parsing, so cobra
+			// reports NO positionals even though a weak value is present. The
+			// mask must still fire — inferring "no value" from the empty slice
+			// would log the secret in the clear.
+			name:        "parse error with a value still masks it",
+			rawArgs:     []string{"vault", "set", "--stdim", "stripe/live-key", "hunter2"},
+			positionals: nil,
+			parsedOK:    false,
+			wantLast:    "<redacted>",
+			wantMasked:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sanitizeInvocationArgs(cmd, tc.rawArgs, tc.positionals, tc.parsedOK)
+			if got[len(got)-1] != tc.wantLast {
+				t.Errorf("last token = %q, want %q (got %v)", got[len(got)-1], tc.wantLast, got)
+			}
+			joined := strings.Join(got, " ")
+			if tc.wantMasked && !strings.Contains(joined, "<redacted>") {
+				t.Errorf("expected a masked value, got %v", got)
+			}
+			if !tc.wantMasked && strings.Contains(joined, "<redacted>") {
+				t.Errorf("path was masked but no value was passed: %v", got)
+			}
+			// The path itself must never be the thing that got redacted.
+			if !tc.wantMasked && !strings.Contains(joined, "stripe/live-key") {
+				t.Errorf("the secret path was lost from the record: %v", got)
+			}
+		})
+	}
+}

--- a/internal/cli/auditreport.go
+++ b/internal/cli/auditreport.go
@@ -71,9 +71,15 @@ func printAuditReport(w io.Writer, entries []auditEntry, filtered bool) {
 	fmt.Fprintln(w)
 	fmt.Fprint(w, "  ")
 	_, _ = cPath.Fprint(w, "→ ")
-	termtext.Wrap(w, 4, "    ",
-		cPath.Sprint("jit audit --status failed")+
-			cDim.Sprint("   only what went wrong · --format logfmt for the machine form"))
+	// Point at the most useful next filter. When any unlock was refused, name
+	// --status denied too, since it is now a distinct count in the header above.
+	hint := cPath.Sprint("jit audit --status failed") +
+		cDim.Sprint("   only what went wrong")
+	if _, denied := auditOutcomeCounts(entries); denied > 0 {
+		hint += cDim.Sprint(" · ") + cPath.Sprint("--status denied") + cDim.Sprint(" for refusals")
+	}
+	hint += cDim.Sprint(" · --format logfmt for the machine form")
+	termtext.Wrap(w, 4, "    ", hint)
 }
 
 func printAuditEmpty(w io.Writer, filtered bool) {
@@ -88,12 +94,10 @@ func printAuditEmpty(w io.Writer, filtered bool) {
 // what span, and how many of them failed. The logfmt view had no summary at
 // all, so "did anything go wrong today?" meant reading every line.
 func writeAuditHeader(w io.Writer, entries []auditEntry) {
-	failed := 0
-	for _, e := range entries {
-		if e.status == "failed" || e.status == "denied" {
-			failed++
-		}
-	}
+	// Count the two bad outcomes separately: they are distinct statuses a reader
+	// can filter on (--status failed vs --status denied), so collapsing them
+	// into one "failed" made the header disagree with the filter it points at.
+	failed, denied := auditOutcomeCounts(entries)
 	// Entries are newest-first.
 	newest, oldest := entries[0].t, entries[len(entries)-1].t
 	span := fmt.Sprintf("%s–%s", oldest.Format("15:04"), newest.Format("15:04"))
@@ -104,8 +108,25 @@ func writeAuditHeader(w io.Writer, entries []auditEntry) {
 	if failed > 0 {
 		head += fmt.Sprintf(" · %d failed", failed)
 	}
+	if denied > 0 {
+		head += fmt.Sprintf(" · %d denied", denied)
+	}
 	_, _ = cDim.Fprintln(w, head)
 	fmt.Fprintln(w)
+}
+
+// auditOutcomeCounts tallies failed commands and denied unlocks — the two
+// statuses the header calls out and the footer offers a filter for.
+func auditOutcomeCounts(entries []auditEntry) (failed, denied int) {
+	for _, e := range entries {
+		switch e.status {
+		case "failed":
+			failed++
+		case "denied":
+			denied++
+		}
+	}
+	return failed, denied
 }
 
 func sameDay(a, b time.Time) bool {
@@ -146,10 +167,33 @@ func groupAuditEntries(entries []auditEntry) []auditGroup {
 				p.status == e.status && p.kind == e.kind &&
 				p.t.Format("2006-01-02 15:04") == e.t.Format("2006-01-02 15:04") {
 				out[n-1].count++
+				// Fold in this event's secret names too: the rows share a
+				// subject but can have touched DIFFERENT secrets, and the
+				// labels are the one fact that answers "what did that ×N
+				// actually reach". Keeping only the first row's understated it.
+				out[n-1].e.labels = unionLabels(out[n-1].e.labels, e.labels)
 				continue
 			}
 		}
 		out = append(out, auditGroup{e: e, count: 1})
+	}
+	return out
+}
+
+// unionLabels returns the secret names in a followed by any in b not already
+// present, order-preserving and deduped. It never aliases either input, so
+// folding into a group can't mutate the backing entry's slice.
+func unionLabels(a, b []string) []string {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[string]bool, len(a)+len(b))
+	out := make([]string, 0, len(a)+len(b))
+	for _, l := range append(append([]string{}, a...), b...) {
+		if !seen[l] {
+			seen[l] = true
+			out = append(out, l)
+		}
 	}
 	return out
 }

--- a/internal/cli/auditreport_test.go
+++ b/internal/cli/auditreport_test.go
@@ -145,6 +145,47 @@ func TestAuditReportKeepsTheSecretsAnUnlockTouched(t *testing.T) {
 	}
 }
 
+// Two uses that fold into one ×N row can have touched DIFFERENT secrets; the
+// collapsed row must name all of them, not just the first's.
+func TestAuditReportUnionsLabelsAcrossCollapsedRows(t *testing.T) {
+	base := time.Date(2026, 7, 29, 19, 50, 30, 0, time.Local)
+	use := func(at time.Time, labels []string) auditEntry {
+		return auditEntry{t: at, kind: "use", subject: "credential served", parent: "claude", labels: labels}
+	}
+	out := renderReport([]auditEntry{
+		use(base, []string{"stripe/live-key"}),
+		use(base.Add(-time.Second), []string{"aws/deploy-role"}),
+	})
+	if !strings.Contains(out, "×2") {
+		t.Fatalf("expected the two uses to collapse into one row:\n%s", out)
+	}
+	for _, want := range []string{"stripe/live-key", "aws/deploy-role"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("collapsed row dropped the secret %q:\n%s", want, out)
+		}
+	}
+}
+
+// The header counts failed commands and denied unlocks separately, because
+// they are separate statuses the reader can filter on — lumping denials into
+// "failed" made the header disagree with the --status failed it points at.
+func TestAuditReportHeaderSeparatesFailedFromDenied(t *testing.T) {
+	now := time.Now()
+	out := renderReport([]auditEntry{
+		reportEntry(now, "jit vault get x", "claude", "failed"),
+		{t: now.Add(-time.Minute), kind: "unlock", status: "denied", subject: "unlock DENIED (Touch ID)"},
+	})
+	if !strings.Contains(out, "1 failed") || !strings.Contains(out, "1 denied") {
+		t.Errorf("header should count the failure and the denial separately:\n%s", out)
+	}
+	if strings.Contains(out, "2 failed") {
+		t.Errorf("the denial was lumped into 'failed':\n%s", out)
+	}
+	if !strings.Contains(out, "--status denied") {
+		t.Errorf("footer should offer --status denied when a denial is present:\n%s", out)
+	}
+}
+
 func TestAuditReportMarksALockAsAStateNotAFailure(t *testing.T) {
 	e := auditEntry{t: time.Now(), kind: "lock", subject: "session locked (5m0s idle timeout)"}
 	out := renderReport([]auditEntry{e})

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -292,10 +292,36 @@ func (e *ExitError) Error() string {
 // the question an audit trail exists to answer, and the failures are often the
 // interesting half.
 func Execute() error {
-	start := time.Now()
+	invocationStart = time.Now()
 	cmd, err := rootCmd.ExecuteC()
-	if recordInvocation != nil {
-		recordInvocation(cmd, err, time.Since(start))
+	// Skip when the command already recorded itself — only `jit run` does, just
+	// before syscall.Exec replaces this process (see recordRunInvocation), and a
+	// second line here on the rare path where exec returns would double-count it.
+	if recordInvocation != nil && !invocationRecorded {
+		recordInvocation(cmd, err, time.Since(invocationStart))
 	}
 	return err
+}
+
+// invocationStart is when Execute began. Shared with the one command that must
+// record itself before Execute regains control — `jit run`, which ends in
+// syscall.Exec and never returns.
+var invocationStart time.Time
+
+// invocationRecorded is set once a command has written its own audit line, so
+// Execute does not record it a second time.
+var invocationRecorded bool
+
+// recordRunInvocation writes `jit run`'s audit line just before syscall.Exec
+// replaces this process, since a successful run never returns to Execute to be
+// recorded there. It records success with the elapsed time up to the hand-off;
+// the rare syscall.Exec that then fails (the binary was already resolved and
+// found executable) is the one case this marks success though exec did not
+// start — a deliberate trade for recording the flagship command at all.
+func recordRunInvocation(cmd *cobra.Command) {
+	if recordInvocation == nil || invocationRecorded {
+		return
+	}
+	invocationRecorded = true
+	recordInvocation(cmd, nil, time.Since(invocationStart))
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -155,6 +155,11 @@ var runCmd = &cobra.Command{
 			}
 		}
 
+		// Record the invocation now: syscall.Exec replaces this process's image
+		// entirely and never returns on success, so Execute never regains
+		// control to record `jit run` the way it records every other command.
+		recordRunInvocation(cmd)
+
 		// syscall.Exec never returns on success — it replaces this
 		// process's image entirely — so an error here always means it
 		// failed to start, never that the target already ran.


### PR DESCRIPTION
A review of `jit audit` (the application audit-log surface) surfaced gaps across the writer, reader, and report. This branch fixes them, with a code review and security review folded in.

## Security-relevant fixes
- **Redaction (writer):** the argument redactor waved through base64 credentials carrying `=` padding or a `/`, treating them as file paths — a real credential could land in the audit log in the clear. Now masked, while legitimate path arguments stay legible. (A follow-up review of the first fix caught a regression where a long `KEY=` name leaked its prefixed value; replaced with a padding-aware split.)
- **`vault set` value masking:** keep the secret's *path* when the value comes from the prompt/`--stdin`, and still mask the value on a flag-parse error rather than inferring "no value" from cobra's empty positional slice (which a mistyped flag would otherwise leak).

## Trail completeness & filters
- `grant`/`approved` events are now filterable (`--kind grant` / `--status approved`) and documented, not merely displayed.
- `jit run` is recorded just before `syscall.Exec` replaces the process, so the flagship command is no longer absent from the command-record trail.
- `--format json --limit N` returns the same merged newest-N set as the text view (was up to 2×N).
- `--follow` reads each log once and streams from the exact consumed offset, closing a startup race that could drop or duplicate a line.

## Report & polish
- Collapsed rows union their secret labels (were dropping the folded events' names).
- The header counts `failed` and `denied` separately, so it agrees with the `--status` it points at.
- `--since -1h` is rejected instead of silently matching the future; logfmt values escape newlines/CR; the redaction drift-guard test no longer silently skips short-prefix formats.

## Tests / gate
New regression tests for each fix. `gofmt`/`go vet` clean, `go mod tidy` no drift, `docs-gen` regenerated, `go test -race ./...` → 17 packages ok, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)