### PR TITLE
feat(scan): show how to read the line a history finding points at

### DIFF
--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -232,11 +232,21 @@ type Finding struct {
 	ScanTime       string   `json:"scan_time"`
 	Endpoint       Endpoint `json:"endpoint"`
 
-	FindingType              string  `json:"finding_type"`
-	Severity                 string  `json:"severity"`
-	FilePath                 string  `json:"file_path"`
-	Line                     *int    `json:"line"`
-	KeyName                  *string `json:"key_name"`
+	FindingType string  `json:"finding_type"`
+	Severity    string  `json:"severity"`
+	FilePath    string  `json:"file_path"`
+	Line        *int    `json:"line"`
+	KeyName     *string `json:"key_name"`
+	// EndLine closes a finding that spans lines — today only a PEM key block
+	// pasted into shell history, where Line alone names the header and leaves
+	// the reader guessing how far the block runs.
+	//
+	// Deliberately NOT serialized. The NDJSON envelope is the documented
+	// schema in RFC.md §4, and adding a field to it is a schema version bump
+	// and a contract with every consumer; this exists to let the human-facing
+	// report print a range it already knows. Give it a json tag and a version
+	// when a consumer actually asks for it, not before.
+	EndLine                  *int    `json:"-"`
 	ValuePreview             *string `json:"value_preview"`
 	ProductionIndicatorMatch bool    `json:"production_indicator_match"`
 	PublicIPMatch            *string `json:"public_ip_match"`

--- a/internal/audit/shellhistory.go
+++ b/internal/audit/shellhistory.go
@@ -174,6 +174,7 @@ func scanShellHistoryFile(cfg Config, path string) ([]Finding, error) {
 
 	type hit struct {
 		line   int
+		end    int // last line of a key block; 0 when it was never closed
 		value  string
 		vendor string
 		count  int
@@ -181,25 +182,42 @@ func scanShellHistoryFile(cfg Config, path string) ([]Finding, error) {
 	order := []string{}
 	byVendor := map[string]*hit{}
 
+	// openKey is the key block whose END marker has not been seen yet. A key
+	// is the one credential shape that spans lines, and the report needs both
+	// ends of it: "delete those lines by hand" is unfollowable if the reader
+	// is told only where the block starts.
+	var openKey *hit
+
 	scanner := newLineScanner(f)
 	lineNum := 0
 	for scanner.Scan() {
+		raw := scanner.Text()
 		lineNum++
-		cmd, _, ok := historyCommand(scanner.Text())
-		if !ok {
-			continue
-		}
-		if !historyLineMayHoldToken(cmd) {
-			continue
-		}
-		for _, tk := range matchLineTokens(cmd) {
-			h, seen := byVendor[tk.Vendor]
-			if !seen {
-				h = &hit{line: lineNum, value: tk.Value, vendor: tk.Vendor}
-				byVendor[tk.Vendor] = h
-				order = append(order, tk.Vendor)
+		// Nested rather than the two early `continue`s this replaced: the END
+		// marker has to be tested against every RAW line, and the body of a
+		// pasted key is not a history entry at all, so historyCommand rejects
+		// exactly the lines the closing marker lives on.
+		if cmd, _, ok := historyCommand(raw); ok && historyLineMayHoldToken(cmd) {
+			for _, tk := range matchLineTokens(cmd) {
+				h, seen := byVendor[tk.Vendor]
+				if !seen {
+					h = &hit{line: lineNum, value: tk.Value, vendor: tk.Vendor}
+					byVendor[tk.Vendor] = h
+					order = append(order, tk.Vendor)
+					if IsPrivateKeyVendor(tk.Vendor) {
+						openKey = h
+					}
+				}
+				h.count++
 			}
-			h.count++
+		}
+		// Tested AFTER the line's own tokens, and against the same raw line,
+		// so a key pasted as ONE history entry closes on the line it opened:
+		// its BEGIN and END markers are both in that single line, and a block
+		// that starts and ends at 2866 is the truthful answer there.
+		if openKey != nil && isKeyBlockEnd(raw) {
+			openKey.end = lineNum
+			openKey = nil
 		}
 	}
 
@@ -208,7 +226,7 @@ func scanShellHistoryFile(cfg Config, path string) ([]Finding, error) {
 		h := byVendor[vendor]
 		ln := h.line
 		if IsPrivateKeyVendor(vendor) {
-			findings = append(findings, cfg.privateKeyInHistoryFinding(path, vendor, ln, h.count))
+			findings = append(findings, cfg.privateKeyInHistoryFinding(path, vendor, ln, h.end, h.count))
 			continue
 		}
 		f := cfg.ValueFinding(ValueFindingParams{
@@ -246,11 +264,19 @@ func scanShellHistoryFile(cfg Config, path string) ([]Finding, error) {
 // by clicking a button in a dashboard, and whatever it authorizes (a
 // production host, a signing identity) it authorizes until someone
 // regenerates and redistributes it.
-func (c Config) privateKeyInHistoryFinding(path, vendor string, line, count int) Finding {
+func (c Config) privateKeyInHistoryFinding(path, vendor string, line, end, count int) Finding {
 	f := c.baseFinding()
 	f.FindingType = FindingTypeShellHistorySecret
 	f.FilePath = path
 	f.Line = &line
+	// Set whenever the block CLOSED, including when it closed on the line it
+	// opened — a key pasted as one history entry is a one-line block, and
+	// "line 2866 through line 2866" is a known extent, not a missing one.
+	// Only an unclosed block (end 0) leaves this nil, because there the file
+	// genuinely does not say how far the key runs.
+	if end >= line {
+		f.EndLine = &end
+	}
 	f.KeyName = &vendor
 	f.Severity = SeverityCritical
 	f.Confidence = ConfidenceHigh
@@ -518,6 +544,25 @@ func matchLineTokens(line string) []FileToken {
 // regenerate the key, which no command of jit's can do.
 func IsPrivateKeyVendor(vendor string) bool {
 	return strings.HasSuffix(vendor, "Private Key")
+}
+
+// isKeyBlockEnd reports whether a raw history line carries the closing marker
+// of a PEM key block.
+//
+// Substring rather than a regexp, and matched on "END" plus "PRIVATE KEY"
+// separately, because the two markers are not always adjacent on the line
+// being tested: a key pasted as one history entry has the whole body sitting
+// between them. What this must NOT do is bound the distance between them or
+// insist on the surrounding dashes — a quoted paste, a heredoc, and a
+// `ssh-keygen -f /dev/stdout` capture all punctuate the marker differently,
+// and a missed END costs the reader the end of the range while a false one
+// costs a range that stops early.
+func isKeyBlockEnd(line string) bool {
+	i := strings.Index(line, "END")
+	if i < 0 {
+		return false
+	}
+	return strings.Contains(line[i:], "PRIVATE KEY")
 }
 
 // IsShellHistoryPath reports whether path is one of the history files this

--- a/internal/audit/shellhistory_test.go
+++ b/internal/audit/shellhistory_test.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -656,6 +657,223 @@ func TestShellHistoryTriageCopy(t *testing.T) {
 	plural := manualAction(f, manualContext{secrets: 2, copies: 1}, home)
 	if !strings.Contains(plural, "rotate them") || !strings.Contains(plural, "the lines") {
 		t.Errorf("plural action reads wrong: %q", plural)
+	}
+}
+
+// The address in a history detail line is a coordinate, not a filename, and a
+// reader who cannot open it reads it as text to search for — which finds
+// nothing and looks like a false positive. Every history problem that carries
+// a line number must also carry a way to reach it.
+func TestShellHistoryViewHint(t *testing.T) {
+	home := "/home/u"
+	line := 4821
+	token := "GitHub Personal Access Token"
+	key := "OpenSSH Private Key"
+	base := Finding{
+		FindingType: FindingTypeShellHistorySecret,
+		FilePath:    filepath.Join(home, ".zsh_history"),
+		Line:        &line,
+		Severity:    SeverityHigh,
+		Remedy:      RemedyManual,
+	}
+
+	tf := base
+	tf.KeyName = &token
+	hint := manualViewHint(tf, home)
+	if hint != "to see that line: sed -n '4821p' ~/.zsh_history" {
+		t.Errorf("token hint = %q", hint)
+	}
+
+	// The key case is addressed by a self-locating grep instead: zsh trims
+	// $HISTFILE and shifts every line number below the cut, and a stale
+	// `sed -n` prints an unrelated command with no error at all.
+	// A key block whose extent is known is addressed as a span, and the hint
+	// shows those exact lines: the reader's next move is to delete them, and
+	// checking what you are about to remove is reasonable.
+	end := 4826
+	kf := base
+	kf.KeyName = &key
+	kf.EndLine = &end
+	kf.Severity = SeverityCritical
+	kh := manualViewHint(kf, home)
+	if kh != "to see them: sed -n '4821,4826p' ~/.zsh_history" {
+		t.Errorf("key hint = %q", kh)
+	}
+
+	// Without an end line there is no honest span to print, so it degrades to
+	// locating the markers rather than inventing a window — a guessed range
+	// either stops mid-key or prints unrelated history.
+	open := kf
+	open.EndLine = nil
+	oh := manualViewHint(open, home)
+	if strings.Contains(oh, "sed") {
+		t.Errorf("unclosed key block got a range it does not have: %q", oh)
+	}
+	if !strings.Contains(oh, "grep") || !strings.Contains(oh, "PRIVATE KEY") {
+		t.Errorf("fallback does not locate the key: %q", oh)
+	}
+	// -o carries the fallback's whole safety property. Without it grep prints
+	// the matching LINE, which for a key pasted as one history entry is the
+	// key — and the fallback is precisely the case where jit does not know
+	// what it is about to print.
+	if !strings.Contains(oh, "-no") {
+		t.Errorf("fallback would print the matching line, not the marker: %q", oh)
+	}
+	if strings.Contains(oh, ".*") {
+		t.Errorf("fallback pattern can span into the key body: %q", oh)
+	}
+	// Both forms have to survive a 60-column terminal unwrapped, or they get
+	// copied in halves. 8 columns of indent, then the hint.
+	for _, h := range []string{kh, oh} {
+		if n := 8 + len(h); n > 60 {
+			t.Errorf("hint wraps at 60 columns (%d): %q", n, h)
+		}
+	}
+
+	// Nothing else gets a hint: a plain path is already openable, and the red
+	// section does not hand out commands it has no reason to.
+	other := Finding{
+		FindingType: FindingTypePrivateKeyRisk,
+		FilePath:    filepath.Join(home, ".ssh", "id_rsa"),
+		Remedy:      RemedyManual,
+	}
+	if got := manualViewHint(other, home); got != "" {
+		t.Errorf("non-history finding got a hint: %q", got)
+	}
+	// A history finding with no line number has no address to explain.
+	noline := tf
+	noline.Line = nil
+	if got := manualViewHint(noline, home); got != "" {
+		t.Errorf("line-less history finding got a hint: %q", got)
+	}
+}
+
+// What the hint prints is a property of a shell, not of a Go string, so drive
+// the scanner over each shape a key reaches history in and then RUN the hint
+// it produces. Two obligations, and which one applies depends on whether jit
+// knows the block's extent:
+//
+//   - a closed block is addressed as a span and shows those lines, key body
+//     included — the deliberate choice (2026-08-05) that the reader gets to
+//     see what they are about to delete;
+//   - anything else falls back to locating markers, and there the output must
+//     hold no key material, because jit does not know how far the block runs
+//     and a command that guesses would print whatever it happened to cover.
+func TestShellHistoryViewHintRuns(t *testing.T) {
+	const body = "b3BlbnNzaC1rZXktdjEAAAAABG5vbmVTECRETBODY"
+	dir := t.TempDir()
+
+	for _, c := range []struct {
+		name    string
+		lines   []string
+		wantEnd int  // 0 when the finding should carry no range
+		shows   bool // whether the hint is allowed to print the body
+	}{
+		// The header is line 2 in each case; writeHistory adds no preamble.
+		{"multi-line paste", []string{
+			": 1:0;cat > k <<EOF",
+			"-----BEGIN OPENSSH PRIVATE KEY-----",
+			body,
+			"-----END OPENSSH PRIVATE KEY-----",
+		}, 4, true},
+		// BEGIN and END share the line, so the block opens and closes at 2.
+		// That is a known extent, so it shows the line — which for this shape
+		// is the whole key, exactly as the multi-line case is.
+		{"single-entry paste", []string{
+			": 1:0;true",
+			`: 2:0;echo "-----BEGIN OPENSSH PRIVATE KEY-----` + body + `-----END OPENSSH PRIVATE KEY-----" > k`,
+		}, 2, true},
+		{"truncated block", []string{
+			": 1:0;ssh-keygen -t rsa",
+			"-----BEGIN RSA PRIVATE KEY-----",
+			body,
+		}, 0, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			path := writeHistory(t, dir, strings.ReplaceAll(c.name, " ", "_"), c.lines...)
+			findings, err := scanShellHistoryFile(Config{}, path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var key *Finding
+			for i := range findings {
+				if findings[i].KeyName != nil && IsPrivateKeyVendor(*findings[i].KeyName) {
+					key = &findings[i]
+				}
+			}
+			if key == nil {
+				t.Fatalf("no private key finding from %v", c.lines)
+			}
+			switch {
+			case c.wantEnd == 0 && key.EndLine != nil:
+				t.Fatalf("EndLine = %d, want none", *key.EndLine)
+			case c.wantEnd != 0 && key.EndLine == nil:
+				t.Fatalf("EndLine = none, want %d", c.wantEnd)
+			case c.wantEnd != 0 && *key.EndLine != c.wantEnd:
+				t.Fatalf("EndLine = %d, want %d", *key.EndLine, c.wantEnd)
+			}
+
+			hint := manualViewHint(*key, dir)
+			var cmd string
+			var ok bool
+			for _, lead := range []string{"to see them: ", "to see it: ", "to find it: "} {
+				if cmd, ok = strings.CutPrefix(hint, lead); ok {
+					break
+				}
+			}
+			if !ok {
+				t.Fatalf("hint is no longer a runnable command: %q", hint)
+			}
+			// The hint shortens $HOME, which is not this test's temp dir.
+			cmd = strings.Replace(cmd, ShortenHome(dir, path), path, 1)
+			out, err := exec.Command("sh", "-c", cmd).Output()
+			if err != nil {
+				t.Fatalf("hint command failed: %v (%q)", err, cmd)
+			}
+			got := string(out)
+			if leaked := strings.Contains(got, body); leaked != c.shows {
+				t.Errorf("hint printed key material = %v, want %v\ncommand: %s\noutput:\n%s",
+					leaked, c.shows, cmd, got)
+			}
+			if c.shows && !strings.Contains(got, "BEGIN") {
+				t.Errorf("range hint missed the start of the block:\n%s", got)
+			}
+		})
+	}
+}
+
+// A merged group keeps one hint per address, for the same reason it keeps one
+// detail line per address: a single hint would send the reader to whichever
+// line happened to sort first.
+func TestShellHistoryViewHintSurvivesMerge(t *testing.T) {
+	home := "/home/u"
+	l1, l2 := 12, 900
+	vendor := "GitHub Personal Access Token"
+	mk := func(path string, line *int) Finding {
+		return Finding{
+			FindingType: FindingTypeShellHistorySecret,
+			FilePath:    filepath.Join(home, path),
+			Line:        line,
+			KeyName:     &vendor,
+			Severity:    SeverityHigh,
+			Remedy:      RemedyManual,
+			CauseGroup:  path,
+		}
+	}
+	groups := triageGroupManual([]Finding{mk(".zsh_history", &l1), mk(".bash_history", &l2)}, home)
+
+	var hints []string
+	for _, g := range groups {
+		if len(g.hints) != len(g.details) {
+			t.Fatalf("hints (%d) and details (%d) fell out of step", len(g.hints), len(g.details))
+		}
+		hints = append(hints, g.hints...)
+	}
+	joined := strings.Join(hints, "\n")
+	for _, want := range []string{"12p", "900p", "~/.zsh_history", "~/.bash_history"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("merged hints lost %q:\n%s", want, joined)
+		}
 	}
 }
 

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -203,6 +203,23 @@ func WriteTriageReport(w io.Writer, findings []Finding, summary ScanSummary, hom
 				_, _ = dim.Fprintf(w, "%s%s\n", triageNoteIndent,
 					termtext.TruncHead(d, termtext.Width()-len(triageNoteIndent)))
 			}
+			// The viewing hint sits with the address it explains and ABOVE the
+			// arrow, per design/output-style.md: an explanation never follows
+			// the action line, because the action is meant to be the last
+			// thing on screen. Reading order comes out as the reader's own
+			// order anyway — here is the coordinate, here is how to reach it,
+			// here is what to do once you have.
+			//
+			// Dim and glyphless, matching the address line it follows. A glyph
+			// would claim this line carries a state of its own, which is the
+			// distinction printStatusWarnNote exists to keep.
+			for _, h := range g.hints {
+				if h == "" {
+					continue
+				}
+				fmt.Fprint(w, triageNoteIndent)
+				termtext.Wrap(w, len(triageNoteIndent), triageNoteIndent+"  ", dim.Sprint(h))
+			}
 			fmt.Fprint(w, triageNoteIndent)
 			// The arrow is cyan because it is the action motif; the
 			// instruction after it is default weight. Amber used to paint the
@@ -421,7 +438,13 @@ type triageManualGroup struct {
 	// details holds one exemplar line per distinct file set. A merged group
 	// keeps them all: each set is a different pile of files to go and fix, so
 	// collapsing to one exemplar would hide paths the reader needs.
-	details  []string
+	details []string
+	// hints holds the optional "how do I look at that?" line for each entry in
+	// details, same index, "" where a problem needs none. Parallel to details
+	// for the reason details is a slice at all: a hint names one exact address,
+	// so a merged group keeping two addresses must keep both hints or send the
+	// reader to a line that is not the one under discussion.
+	hints    []string
 	action   string
 	secrets  int
 	critical bool
@@ -535,6 +558,7 @@ func triageGroupManual(findings []Finding, home string) []triageManualGroup {
 			sortKey:  rankOf(worst.Severity),
 			title:    manualTitle(p.causes, p.files, worst),
 			details:  []string{manualDetail(p.files, worst, home)},
+			hints:    []string{manualViewHint(worst, home)},
 			action:   manualAction(worst, ctx, home),
 			noun:     manualNoun(worst),
 			files:    len(p.files),
@@ -570,6 +594,7 @@ func mergeManualGroups(groups []triageManualGroup, home string) []triageManualGr
 		m.secrets += g.secrets
 		m.files += g.files
 		m.details = append(m.details, g.details...)
+		m.hints = append(m.hints, g.hints...)
 		m.critical = m.critical || g.critical
 		if g.sortKey < m.sortKey {
 			m.sortKey = g.sortKey
@@ -717,11 +742,101 @@ func manualDetail(files []string, worst Finding, home string) string {
 	// already the location.
 	if IsShellHistoryPath(first) && worst.Line != nil {
 		shown = fmt.Sprintf("%s:%d", shown, *worst.Line)
+		// A key block is an extent, not a point, and the instruction below is
+		// to delete it. Naming both ends turns the address into the answer —
+		// but a block that opened and closed on one line is a point, and
+		// "2866-2866" would be a stutter that reads as a bug.
+		if worst.EndLine != nil && *worst.EndLine != *worst.Line {
+			shown = fmt.Sprintf("%s-%d", shown, *worst.EndLine)
+		}
 	}
 	if len(files) == 1 {
 		return shown
 	}
 	return fmt.Sprintf("%s … and %d more", shown, len(files)-1)
+}
+
+// manualViewHint returns the dim line, printed under the address line and
+// above the action, that shows the reader how to LOOK at that address — or ""
+// for problems that need no such line. It stays dim rather than cyan, command
+// and all, matching the "jit migrate undo" mention in the green section's
+// note: cyan marks the thing the report is asking you to run, and neither of
+// those is that.
+//
+// Only shell history gets one, and only because only shell history is
+// addressed by line number: "~/.gemini/oauth_creds.json" is a file you open,
+// while "~/.zsh_history:2866" is a coordinate inside 3,000 lines that a reader
+// has no obvious way to reach. A user hit exactly this (2026-08-05), read the
+// ":2866" as text to search for, ran `grep 2866`, found nothing, and concluded
+// the finding was a false positive. An address the report will not help you
+// open is an address that reads as wrong.
+//
+// This is deliberately in tension with manualDetail's rule that the red
+// section describes rather than asking the user to run things on these exact
+// paths. That rule is about FIXES — jit does not offer to repair what only the
+// user can repair. Reading is not fixing, and the instruction directly above
+// ("delete those lines by hand") is unfollowable without it.
+//
+// The private-key case gets a self-locating grep rather than the line number,
+// because the line number is the one part of this report with a shelf life:
+// zsh trims $HISTFILE to $SAVEHIST and rewrites it, dropping lines off the top
+// and shifting every number below. A stale `sed -n '2866p'` prints an
+// unrelated command with no error, which is worse than no hint — it looks like
+// proof the finding was wrong. Grepping the header re-derives the address at
+// the moment the user reads it. Printing that header leaks nothing: it is a
+// constant, which is the same reason privateKeyInHistoryFinding refuses to
+// treat it as a value.
+//
+// Tokens get no equivalent anchor on purpose. The only text that would locate
+// a token line is the token, and a hint that greps for a secret prints the
+// secret — so they keep the line number, where a stale hit shows a command
+// that plainly holds no credential rather than a convincing wrong answer.
+func manualViewHint(f Finding, home string) string {
+	if f.FindingType != FindingTypeShellHistorySecret || f.Line == nil {
+		return ""
+	}
+	path := shellSafePath(home, f.FilePath)
+	// A closed key block gets the range printed, because the reader's next
+	// move is to inspect those exact lines before deleting them, and checking
+	// what you are about to remove from your own history is a reasonable thing
+	// to want. This command's output IS the key — an explicit product
+	// decision (2026-08-05), taken knowing it puts key material in the
+	// terminal's scrollback. It stays consistent with the report's "no secret
+	// values are ever printed in full" footer only in the narrow sense that
+	// jit prints a command and the reader chooses to run it.
+	if f.KeyName != nil && IsPrivateKeyVendor(*f.KeyName) && f.EndLine != nil {
+		// Singular form for a one-line block, both because "'2866,2866p'" is
+		// noise and because the sentence above it says "line", not "lines".
+		if *f.EndLine == *f.Line {
+			return fmt.Sprintf("to see it: sed -n '%dp' %s", *f.Line, path)
+		}
+		return fmt.Sprintf("to see them: sed -n '%d,%dp' %s", *f.Line, *f.EndLine, path)
+	}
+	// No range means the block never closed in this file, so there is no
+	// honest span to print — sed would need an end line invented for it, and
+	// a guessed window either stops mid-key or dumps unrelated history. Fall
+	// back to locating the markers.
+	if f.KeyName != nil && IsPrivateKeyVendor(*f.KeyName) {
+		// -n for the address, -o because the whole safety property lives in
+		// that flag: without it grep prints the matching LINE, and a key
+		// pasted as one history entry is a line that holds the entire key.
+		// With it the output is the literal "PRIVATE KEY" and nothing else,
+		// whatever the line contains.
+		//
+		// The pattern is that bare literal rather than an anchored BEGIN
+		// header, which buys three things at once. It is short enough to stay
+		// unwrapped at 60 columns. It matches the END marker too, so the
+		// reader gets the RANGE to delete from one command instead of the
+		// header alone. And it needs no vendor alternation — RSA, OPENSSH,
+		// ECDSA and EC headers all contain it.
+		//
+		// Two shapes read correctly out of the same output: the same line
+		// number twice means the key sits on one line, and a single hit means
+		// the block was truncated (header pasted, END never recorded, or the
+		// file trimmed between them).
+		return fmt.Sprintf("to find it: grep -no 'PRIVATE KEY' %s", path)
+	}
+	return fmt.Sprintf("to see that line: sed -n '%dp' %s", *f.Line, path)
 }
 
 // selfRotating reports whether f's file is one the owning tool rewrites for


### PR DESCRIPTION
## The problem

`jit scan` addresses a shell-history finding by line number and then tells you to fix it by hand:

```
    ! OpenSSH private key material typed at the shell  (1)
      ~/.zsh_history:2866
      → regenerate the key and replace it wherever it is authorized, then delete those lines by hand
```

Live testing on a real machine found what that costs. The reader took the `:2866` for text to search for, ran `grep 2866 ~/.zsh_history`, matched only their own unrelated commands, and concluded the finding was a false positive. It was not: the key header really was on line 2866. An address the report will not help you open reads as a wrong address.

## The change

Every history problem now carries a line showing how to see what it points at:

```
    ! OpenSSH private key material typed at the shell  (1)
      ~/.zsh_history:2866-2871
      to see them: sed -n '2866,2871p' ~/.zsh_history
      → regenerate the key and replace it wherever it is authorized, then delete those lines by hand
```

It sits **above** the arrow, per `design/output-style.md`: an explanation never follows the action line.

Getting the command right for a private key meant teaching the scanner where a key block ends. It holds a key hit open on a header match and closes it on the first line carrying an END marker, which also turns the address into a span, so the report now names exactly what to delete.

| history shape | address | hint |
|---|---|---|
| multi-line paste | `:2866-2871` | `sed -n '2866,2871p'` |
| key on one line | `:2866` | `sed -n '2866p'` |
| END marker never recorded | `:2866` | `grep -no 'PRIVATE KEY'` |
| token (not a key) | `:1204` | `sed -n '1204p'` |

## Decisions worth reviewing

**The range hint prints key material, on purpose.** The next move is to delete those lines, and checking what you are about to remove from your own history is reasonable. The report's "no secret values are ever printed in full" footer stays true in the narrow sense that jit prints a command and the reader chooses to run it. Flagging it because it is a deliberate reversal, not an oversight.

**The fallback must not print it, and its test proves that by running it.** When the block never closed, jit does not know how far it runs, so a `sed` window would either stop mid-key or dump unrelated history. It locates the markers instead. `-o` is what makes that safe: without it `grep` prints the matching *line*, and a key pasted as one history entry is a line that holds the whole key. `TestShellHistoryViewHintRuns` builds all three shapes, executes the generated command, and asserts which of them may and may not contain the body, so the two obligations cannot be swapped later by an edit that reads like a cleanup.

**`Finding.EndLine` is `json:"-"`.** The NDJSON envelope is the documented schema in RFC.md section 4; adding a field is a version bump and a contract with every consumer. This exists so the human report can print a range it already knows. The tradeoff is that the terminal and the machine output now disagree about what jit knows, which is worth exposing as a follow-up (`0.17.0`, plus a row in `docs/reference/scan-ndjson.md`) if you want consumers to act on ranges.

**Departure from `manualDetail`'s comment.** That comment says the red section "does not ask the user to run anything on these exact paths." That rule is about fixes; reading is not fixing, and the instruction directly above it is unfollowable without this. Documented at the call site rather than quietly ignored.

## Testing

`gofmt`, `go vet`, `staticcheck ./...`, full `go test -race`, `go mod tidy` and `docs-gen` all clean, no drift. New coverage: hint content and both branches, the parallel-with-details invariant under group merging, scanner end-line detection across all three key shapes, and the executed-command test above (verified non-vacuous: dropping `-o` fails it with the body printed).

Note for the reviewer: `TestRunScopedSwapEndToEnd` in `internal/cli` flaked once under full-suite parallel load (FIFO restore timeout). It passes 3/3 in isolation and 3/3 on pristine `main`. Pre-existing timing flake, unrelated to this change, but worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BUNJwdAFA7J4Kj39RT8C2n
