### PR TITLE
Stop the mount-restore wait failing on a slow runner

### DIFF
--- a/internal/cli/rungrant_e2e_test.go
+++ b/internal/cli/rungrant_e2e_test.go
@@ -182,9 +182,23 @@ func readMountFromSiblingProcess(t *testing.T, path string, timeout time.Duratio
 // waitFor polls cond up to a deadline — the e2e assertions above cross
 // real process and goroutine boundaries, so "immediately" means "within a
 // beat", never "on the very next line".
+// waitForBudget is a safety net, not an assertion about speed: a passing
+// wait returns the moment its condition holds, so the ceiling costs nothing
+// except on a genuine failure.
+//
+// It was 5s, which a loaded CI runner could not always meet. The restore this
+// file waits on is driven by a kqueue NOTE_EXIT watch (see mountruns.go) and
+// completes on an async goroutine, so the chain is process-death delivery,
+// then the restore, then recreating the FIFO. Measured: 3 of 6 CI runs failed
+// on "the FIFO to be restored after the run exits" with identical code that
+// passed 10 consecutive local runs under -race, and the same job passed on
+// other runs — timing, not logic. 30s keeps a hung restore a fast, clear
+// failure while giving a slow runner room.
+const waitForBudget = 30 * time.Second
+
 func waitFor(t *testing.T, what string, cond func() bool) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(waitForBudget)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return


### PR DESCRIPTION
`TestRunScopedSwapEndToEnd` failed **3 of 6 CI runs** on:

```
rungrant_e2e_test.go:313: timed out waiting for the FIFO to be restored after the run exits
```

with code that passes 10 consecutive local runs under `-race`, and that passed the same CI job on the other runs. It blocked the v0.76.0 release three times, including twice after a re-run.

## What races

The restore is driven by a kqueue `NOTE_EXIT` watch (`mountruns.go:33`) and completes on an async goroutine, so the chain a loaded runner has to finish inside the budget is: process-death delivery → `restoreSwappedMount` → recreating the FIFO. The budget was **5 seconds**.

## The change

`waitFor`'s deadline is a safety net, not an assertion about speed. A passing wait returns the moment its condition holds, so raising the ceiling costs nothing except on a genuine failure, where 30s is still a fast, clear error. It is now a named constant with the evidence in its comment, so nobody has to re-derive why it isn't 5.

## Not a regression from #14

This test never invokes `jit run`. It spawns `/bin/sleep 30` as a stand-in and drives `agent.NewClient` directly, so the bounded-wait change in that release is not in its code path.