### PR TITLE
spike(notarize-e2e): probe Apple's notary before re-adding brew + notarization

### DIFF
--- a/.github/workflows/notarize-spike.yml
+++ b/.github/workflows/notarize-spike.yml
@@ -1,0 +1,66 @@
+name: Notarize Spike
+
+# Manual probe of Apple's notary service for this account — NOT a release.
+# Runs spike/notarize-e2e against the same secrets release.yml uses, so a
+# green run here means the real release path would have notarized too.
+#
+#   gh workflow run notarize-spike.yml                     # full end-to-end
+#   gh workflow run notarize-spike.yml -f mode=history     # just list recent
+#                                                          # submissions/verdicts
+#
+# Exit-code meanings (from run.sh): 0 accepted + Gatekeeper pass,
+# 1 invalid artifact, 2 stuck In Progress (the known account condition),
+# 3 accepted but Gatekeeper rejected the quarantined copy.
+# Re-add .goreleaser.yml's notarize block + the Homebrew cask only after the
+# acceptance criteria in spike/notarize-e2e/FINDINGS.md are met.
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "submit = full end-to-end; history = no new submission"
+        default: submit
+        type: choice
+        options: [submit, history]
+      timeout:
+        description: "bounded wait for Apple's verdict"
+        default: 15m
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: macos-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: spike/notarize-e2e/go.mod
+
+      - name: Require signing + notary secrets
+        env:
+          P12: ${{ secrets.MACOS_SIGN_P12 }}
+          KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: |
+          if [ -z "$P12" ] || [ -z "$KEY" ]; then
+            echo "MACOS_SIGN_P12 / MACOS_NOTARY_* secrets are not set — nothing to probe." >&2
+            exit 1
+          fi
+
+      - name: Install quill (pinned — same signer the release path embeds)
+        run: |
+          curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin" v0.7.1
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+      - name: Run the probe
+        env:
+          MODE: ${{ inputs.mode }}
+          NOTARY_TIMEOUT: ${{ inputs.timeout }}
+          QUILL_SIGN_P12: ${{ secrets.MACOS_SIGN_P12 }}
+          QUILL_SIGN_PASSWORD: ${{ secrets.MACOS_SIGN_PASSWORD }}
+          NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
+          NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
+          NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+        run: zsh spike/notarize-e2e/run.sh

--- a/spike/notarize-e2e/FINDINGS.md
+++ b/spike/notarize-e2e/FINDINGS.md
@@ -38,10 +38,17 @@ goreleaser/quill path mints one JWT of `timeout + 2m` lifetime, which is the
 On **Accepted**, the part brew actually depends on is verified explicitly:
 jit ships a bare Mach-O, which cannot be stapled, and Homebrew quarantines
 cask downloads — so a cask user's first run depends on Gatekeeper fetching
-the notarization ticket online. The probe simulates that user: it sets
-`com.apple.quarantine` on the signed binary, asks `spctl --assess` for a
-verdict (expecting `Notarized Developer ID`), and executes the quarantined
-copy.
+the notarization ticket online. The probe simulates that user A/B: it
+quarantines both the notarized binary and an unnotarized (ad-hoc-signed)
+control, and executes each. The control must be blocked (SIGKILL, rc=137) or
+the environment isn't discriminating and the leg reports inconclusive.
+
+Measured quirk (2026-08-06): `spctl --assess --type execute` is **not** a
+usable oracle for a bare CLI — it prints "rejected (the code is valid but
+does not seem to be an app)" even for a notarized binary whose quarantined
+copy Gatekeeper happily executes, because spctl's execute policy only
+approves `.app`s. The probe prints spctl output as evidence but gates on the
+execution A/B.
 
 Two ways to run it:
 
@@ -56,9 +63,9 @@ Two ways to run it:
 
 Exit codes: `0` Accepted + Gatekeeper pass · `1` Invalid (artifact verdict,
 log dumped) · `2` stuck In Progress past the timeout (the known condition) ·
-`3` Accepted but Gatekeeper rejected the quarantined copy — a state that
+`3` Accepted but Gatekeeper blocked the quarantined copy — a state that
 would break brew users even with notarization nominally "working", hence its
-own code.
+own code · `4` Gatekeeper leg inconclusive (the control ran too; use CI).
 
 ## Acceptance criteria (gate for un-reverting)
 
@@ -88,9 +95,17 @@ the `timeout: 15m` JWT lesson from `77cc73f`), and the `homebrew_casks` block
 | 2026-07-30 → 08-01 | baseline (pre-spike) | 7 ids in support case | never (>2 days) | In Progress | n/a | — |
 | 2026-08-01 | manual probe (pre-spike) | — | ~40min | Accepted | not checked | — |
 | 2026-08-01 | v0.70.1 release build | — | never | In Progress | rejected (quarantined copy blocked) | — |
+| 2026-08-06 | history mode | — | — | **ALL 9 prior submissions now Accepted** (backlog cleared, incl. the 7 support-case ids and v0.70.1's) | — | 0 |
+| 2026-08-06 | local run 1 | f54867e5 | seconds (21s incl. build+sign) | Accepted | not reached (script bug: `status` is read-only in zsh, fixed) | 1 |
+| 2026-08-06 | local run 2 | 5e558fbf | seconds (23s total) | Accepted | exec OK but old spctl-string gate failed → A/B redesign | 3 |
+| 2026-08-06 | local run 3 | 5b4bbf71 | seconds (54s total) | Accepted | control blocked rc=137, notarized copy ran | **0** |
 | _fill in per run_ | | | | | | |
 
-**Verdict: pending** — the spike is built but blocked on Apple resolving the
-account-side condition (or the agreements step completing). Do not
-re-litigate the tooling: signing, auth, and the JWT timeout are all known
-good.
+**Verdict as of 2026-08-06: the account-side condition has cleared.** The
+entire submission backlog is Accepted, and fresh submissions reach a verdict
+in *seconds* — comfortably inside quill's ~18m JWT ceiling, so `wait: true`
+is viable again. The quarantined-unstapled Gatekeeper leg passes (online
+ticket fetch works for a bare Mach-O). Gate progress: **1 of 3** consecutive
+green runs, day 1 of 2 — run the workflow again on a later day (twice) before
+un-reverting. Do not re-litigate the tooling: signing, auth, and the JWT
+timeout are all known good.

--- a/spike/notarize-e2e/FINDINGS.md
+++ b/spike/notarize-e2e/FINDINGS.md
@@ -11,10 +11,17 @@ submissions hanging "In Progress" indefinitely — including shipped release
 builds, which held releases hostage for days. Apple support case
 20000125465695 (2026-08-01) established this is account-side: even a trivial
 hello-world Mach-O hangs, authentication works, and the artifact signature is
-valid. The likely cause is a pending agreement/provisioning step on a
-9-day-old Developer account. This spike is the cheap, repeatable way to
-detect when the condition clears — **before** re-wiring the release and brew
-paths around notarization and discovering mid-release that it still hangs.
+valid. Every self-fixable cause is eliminated — all agreements were verified
+accepted (Program License Jul 30, Developer Agreement Jul 29; Paid Apps is
+App-Store-only), so this is fresh-account notary provisioning on Apple's
+side. It also appears *intermittent*, not binary: on 2026-08-01 the service
+partially recovered (one probe went Accepted with ~40min turnaround), yet the
+shipped v0.70.1 build's own submission still never reached a verdict — its
+ticket was absent from Apple's DB hours after publish. That mix is exactly
+why the gate below demands consistency across days, and why this spike is the
+cheap, repeatable way to detect when the condition truly clears — **before**
+re-wiring the release and brew paths around notarization and discovering
+mid-release that it still hangs.
 
 ## Method
 
@@ -22,9 +29,11 @@ A trivial Go Mach-O (any failure is therefore account/service-side, never
 artifact-side), signed with **quill** — the same signer goreleaser's
 `notarize.macos` path embeds, with the same full-chain `.p12` — submitted via
 `xcrun notarytool` with a bounded `--wait`. `notarytool` rather than quill
-for the submission because it also surfaces `history` and `log`, which is
-where the diagnosis lives; the stuck condition was already shown to be
-tool-independent.
+for the submission for two reasons: it surfaces `history` and `log`, which is
+where the diagnosis lives (the stuck condition was already shown to be
+tool-independent), and it refreshes its auth tokens while waiting — the
+goreleaser/quill path mints one JWT of `timeout + 2m` lifetime, which is the
+401 trap that broke v0.69/v0.70 and caps any quill-side wait at ~18m.
 
 On **Accepted**, the part brew actually depends on is verified explicitly:
 jit ships a bare Mach-O, which cannot be stapled, and Homebrew quarantines
@@ -58,8 +67,13 @@ All of, before touching `.goreleaser.yml` or the cask:
 1. **3 consecutive exit-0 runs across at least 2 different days.** One
    Accepted proved nothing last time (1 of 9), and the failure mode is
    intermittent-by-day, not per-artifact.
-2. Verdicts arrive in minutes, not at the timeout edge — a release blocks on
-   this wait (`release.yml` job timeout).
+2. Verdicts arrive well inside 15m, not at the timeout edge. This criterion
+   is load-bearing: goreleaser's quill path cannot wait longer than ~18m (the
+   single-JWT 401 trap), so if Apple's steady-state turnaround is the ~40min
+   seen on 2026-08-01, `wait: true` is off the table and the release instead
+   needs `wait: false` plus an automated fail-closed post-publish verify —
+   the v0.70.1 lesson, where wait-free publish shipped a build whose
+   submission never completed.
 3. The Gatekeeper leg passes each time (`Notarized Developer ID` + the
    quarantined copy executes).
 
@@ -72,6 +86,8 @@ the `timeout: 15m` JWT lesson from `77cc73f`), and the `homebrew_casks` block
 | Date | Run | Submission id | Time to verdict | Status | Gatekeeper | Exit |
 |---|---|---|---|---|---|---|
 | 2026-07-30 → 08-01 | baseline (pre-spike) | 7 ids in support case | never (>2 days) | In Progress | n/a | — |
+| 2026-08-01 | manual probe (pre-spike) | — | ~40min | Accepted | not checked | — |
+| 2026-08-01 | v0.70.1 release build | — | never | In Progress | rejected (quarantined copy blocked) | — |
 | _fill in per run_ | | | | | | |
 
 **Verdict: pending** — the spike is built but blocked on Apple resolving the

--- a/spike/notarize-e2e/FINDINGS.md
+++ b/spike/notarize-e2e/FINDINGS.md
@@ -1,0 +1,80 @@
+# Spike Findings: Notarization End-to-End Probe (gate for Homebrew distribution)
+
+**Question:** does Apple's notary service now reliably process this account's
+submissions to a verdict, and does the resulting ticket actually clear a
+*quarantined*, *unstapled* bare Mach-O through Gatekeeper — the exact
+situation a Homebrew-cask user is in?
+
+**Why this exists:** notarization was dropped from `.goreleaser.yml` (commits
+`9177b38`, `2d45149`) after the account's notary service left 8 of 9
+submissions hanging "In Progress" indefinitely — including shipped release
+builds, which held releases hostage for days. Apple support case
+20000125465695 (2026-08-01) established this is account-side: even a trivial
+hello-world Mach-O hangs, authentication works, and the artifact signature is
+valid. The likely cause is a pending agreement/provisioning step on a
+9-day-old Developer account. This spike is the cheap, repeatable way to
+detect when the condition clears — **before** re-wiring the release and brew
+paths around notarization and discovering mid-release that it still hangs.
+
+## Method
+
+A trivial Go Mach-O (any failure is therefore account/service-side, never
+artifact-side), signed with **quill** — the same signer goreleaser's
+`notarize.macos` path embeds, with the same full-chain `.p12` — submitted via
+`xcrun notarytool` with a bounded `--wait`. `notarytool` rather than quill
+for the submission because it also surfaces `history` and `log`, which is
+where the diagnosis lives; the stuck condition was already shown to be
+tool-independent.
+
+On **Accepted**, the part brew actually depends on is verified explicitly:
+jit ships a bare Mach-O, which cannot be stapled, and Homebrew quarantines
+cask downloads — so a cask user's first run depends on Gatekeeper fetching
+the notarization ticket online. The probe simulates that user: it sets
+`com.apple.quarantine` on the signed binary, asks `spctl --assess` for a
+verdict (expecting `Notarized Developer ID`), and executes the quarantined
+copy.
+
+Two ways to run it:
+
+- **CI (normal path):** `gh workflow run notarize-spike.yml` — uses the same
+  repo secrets as `release.yml`, so a green run means the release path would
+  have notarized. `-f mode=history` lists recent submissions and their
+  statuses without submitting anything new (also shows whether the old stuck
+  submissions from July/August ever resolved).
+- **Locally** on a machine that has the keys: set `QUILL_SIGN_P12`,
+  `QUILL_SIGN_PASSWORD`, `NOTARY_ISSUER_ID`, `NOTARY_KEY_ID`, `NOTARY_KEY`
+  and run `zsh spike/notarize-e2e/run.sh` (needs `quill` on PATH).
+
+Exit codes: `0` Accepted + Gatekeeper pass · `1` Invalid (artifact verdict,
+log dumped) · `2` stuck In Progress past the timeout (the known condition) ·
+`3` Accepted but Gatekeeper rejected the quarantined copy — a state that
+would break brew users even with notarization nominally "working", hence its
+own code.
+
+## Acceptance criteria (gate for un-reverting)
+
+All of, before touching `.goreleaser.yml` or the cask:
+
+1. **3 consecutive exit-0 runs across at least 2 different days.** One
+   Accepted proved nothing last time (1 of 9), and the failure mode is
+   intermittent-by-day, not per-artifact.
+2. Verdicts arrive in minutes, not at the timeout edge — a release blocks on
+   this wait (`release.yml` job timeout).
+3. The Gatekeeper leg passes each time (`Notarized Developer ID` + the
+   quarantined copy executes).
+
+Then re-add, in one change: the `notarize:` block (shape of `08e0b7d`, with
+the `timeout: 15m` JWT lesson from `77cc73f`), and the `homebrew_casks` block
+**without** the quarantine-strip hack `2d45149` removed.
+
+## Results
+
+| Date | Run | Submission id | Time to verdict | Status | Gatekeeper | Exit |
+|---|---|---|---|---|---|---|
+| 2026-07-30 → 08-01 | baseline (pre-spike) | 7 ids in support case | never (>2 days) | In Progress | n/a | — |
+| _fill in per run_ | | | | | | |
+
+**Verdict: pending** — the spike is built but blocked on Apple resolving the
+account-side condition (or the agreements step completing). Do not
+re-litigate the tooling: signing, auth, and the JWT timeout are all known
+good.

--- a/spike/notarize-e2e/go.mod
+++ b/spike/notarize-e2e/go.mod
@@ -1,0 +1,3 @@
+module jit/spike/notarize-e2e
+
+go 1.26.4

--- a/spike/notarize-e2e/main.go
+++ b/spike/notarize-e2e/main.go
@@ -1,0 +1,17 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+// Command notarize-e2e-spike is the artifact for the notarization end-to-end
+// spike: a deliberately trivial Mach-O, so that any failure in the
+// sign → notarize → Gatekeeper pipeline is attributable to the account or
+// Apple's notary service, never to the binary. The Aug 2026 support case
+// (20000125465695) established that even a binary this trivial hangs
+// "In Progress" — this spike exists to detect, repeatably and cheaply, the
+// day that stops being true. See FINDINGS.md.
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello from jit notarize-e2e spike")
+}

--- a/spike/notarize-e2e/run.sh
+++ b/spike/notarize-e2e/run.sh
@@ -1,0 +1,120 @@
+#!/bin/zsh
+# Copyright 2026 Meni Tasa
+# SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+#
+# End-to-end notarization probe: build a trivial Mach-O, sign it exactly the
+# way releases are signed (quill, Developer ID .p12 with full chain), submit
+# it to Apple's notary service with a bounded wait, and — on Accepted — prove
+# the part Homebrew distribution actually depends on: a *quarantined*,
+# *unstapled* bare binary passes Gatekeeper via the online ticket fetch.
+#
+# Environment contract (works locally and in CI):
+#   QUILL_SIGN_P12        Developer ID Application .p12 — path OR base64 content.
+#                         Must carry the full chain (leaf + G2 intermediate +
+#                         Apple Root CA) or Apple rejects the signature.
+#   QUILL_SIGN_PASSWORD   its password
+#   NOTARY_ISSUER_ID      App Store Connect API key issuer (Team key —
+#                         Individual keys cannot call the notary API at all)
+#   NOTARY_KEY_ID         the key id
+#   NOTARY_KEY            the .p8 — path, raw PEM content, or base64 content
+#   NOTARY_TIMEOUT        bounded wait for a verdict (default 15m)
+#   MODE                  "submit" (default) — full end-to-end run
+#                         "history" — no new submission; just report the
+#                         account's recent submissions and their statuses
+#
+# Exit codes (the workflow and FINDINGS.md key off these):
+#   0  Accepted, and the quarantined binary passed Gatekeeper
+#   1  Invalid — Apple returned a verdict against the artifact (log dumped)
+#   2  stuck In Progress past NOTARY_TIMEOUT — the known account condition
+#   3  Accepted, but Gatekeeper rejected the quarantined binary
+#      (would break brew-cask users even with notarization "working")
+
+set -u
+cd "$(dirname "$0")"
+
+MODE="${MODE:-submit}"
+NOTARY_TIMEOUT="${NOTARY_TIMEOUT:-15m}"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+say() { print -r -- "==> $*" }
+
+# --- notary key: accept a path, raw PEM, or base64 ------------------------
+keyfile="$WORK/notary.p8"
+if [[ -f "${NOTARY_KEY}" ]]; then
+  cp "${NOTARY_KEY}" "$keyfile"
+elif [[ "${NOTARY_KEY}" == *"-----BEGIN"* ]]; then
+  print -r -- "${NOTARY_KEY}" > "$keyfile"
+else
+  print -r -- "${NOTARY_KEY}" | base64 -d > "$keyfile" || {
+    say "NOTARY_KEY is neither a path, PEM, nor valid base64"; exit 64; }
+fi
+notary=(xcrun notarytool)
+auth=(--key "$keyfile" --key-id "${NOTARY_KEY_ID}" --issuer "${NOTARY_ISSUER_ID}")
+
+if [[ "$MODE" == "history" ]]; then
+  say "submission history (no new submission)"
+  "${notary[@]}" history "${auth[@]}"
+  exit $?
+fi
+
+# --- build + sign ---------------------------------------------------------
+say "building hello Mach-O"
+go build -o "$WORK/hello" . || exit 65
+
+say "signing with quill (same path goreleaser's notarize.macos uses)"
+quill sign "$WORK/hello" || { say "quill sign failed"; exit 65; }
+codesign -dv "$WORK/hello" 2>&1 | grep -E "Authority|TeamIdentifier|flags" || true
+
+# --- submit with a bounded wait ------------------------------------------
+# notarytool needs a zip for a bare binary; ditto preserves what matters.
+ditto -c -k "$WORK/hello" "$WORK/hello.zip"
+
+say "submitting (timeout ${NOTARY_TIMEOUT})"
+submit_out="$WORK/submit.json"
+"${notary[@]}" submit "$WORK/hello.zip" "${auth[@]}" \
+  --wait --timeout "${NOTARY_TIMEOUT}" --output-format json \
+  | tee "$submit_out"
+print ""
+
+sub_id=$(grep -o '"id" *: *"[^"]*"' "$submit_out" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+status=$(grep -o '"status" *: *"[^"]*"' "$submit_out" | tail -1 | sed 's/.*"\([^"]*\)"$/\1/')
+say "submission ${sub_id:-<no id>} → status: ${status:-<none>}"
+
+case "${status:-}" in
+  Accepted) ;;
+  Invalid|Rejected)
+    say "verdict against the artifact — notary log follows"
+    "${notary[@]}" log "$sub_id" "${auth[@]}" || true
+    exit 1 ;;
+  *)
+    say "no verdict within ${NOTARY_TIMEOUT} — the known stuck-In-Progress condition"
+    say "recent history for context:"
+    "${notary[@]}" history "${auth[@]}" | head -40 || true
+    exit 2 ;;
+esac
+
+say "Accepted — fetching notary log"
+"${notary[@]}" log "$sub_id" "${auth[@]}" || true
+
+# --- the brew-decisive check ---------------------------------------------
+# jit ships a bare Mach-O, which cannot be stapled, so a Homebrew-cask user
+# (whose download brew quarantines) depends on Gatekeeper fetching the ticket
+# online. Simulate exactly that: quarantine the signed binary, then (a) ask
+# Gatekeeper's verdict and (b) actually execute it.
+say "Gatekeeper check on a quarantined, unstapled copy"
+cp "$WORK/hello" "$WORK/hello-quarantined"
+xattr -w com.apple.quarantine "0083;$(printf '%x' "$(date +%s)");notarize-e2e-spike;" \
+  "$WORK/hello-quarantined"
+
+spctl_out=$(spctl --assess --type execute -vv "$WORK/hello-quarantined" 2>&1)
+print -r -- "$spctl_out"
+run_out=$("$WORK/hello-quarantined" 2>&1)
+print -r -- "exec: $run_out"
+
+if [[ "$spctl_out" == *"Notarized Developer ID"* && "$run_out" == *"hello"* ]]; then
+  say "PASS — ticket found online; quarantined binary runs. Safe to re-add notarize + cask once this is consistent."
+  exit 0
+fi
+say "Accepted by notary, but Gatekeeper did NOT clear the quarantined copy"
+exit 3

--- a/spike/notarize-e2e/run.sh
+++ b/spike/notarize-e2e/run.sh
@@ -26,8 +26,10 @@
 #   0  Accepted, and the quarantined binary passed Gatekeeper
 #   1  Invalid — Apple returned a verdict against the artifact (log dumped)
 #   2  stuck In Progress past NOTARY_TIMEOUT — the known account condition
-#   3  Accepted, but Gatekeeper rejected the quarantined binary
+#   3  Accepted, but Gatekeeper blocked the quarantined notarized binary
 #      (would break brew-cask users even with notarization "working")
+#   4  Gatekeeper leg inconclusive — this environment also ran the
+#      unnotarized control, so it cannot discriminate (rely on a CI run)
 
 set -u
 cd "$(dirname "$0")"
@@ -61,6 +63,9 @@ fi
 # --- build + sign ---------------------------------------------------------
 say "building hello Mach-O"
 go build -o "$WORK/hello" . || exit 65
+# Keep an unnotarized control (only the linker's ad-hoc signature): the
+# Gatekeeper leg below is only meaningful if this copy gets blocked.
+cp "$WORK/hello" "$WORK/control"
 
 say "signing with quill (same path goreleaser's notarize.macos uses)"
 quill sign "$WORK/hello" || { say "quill sign failed"; exit 65; }
@@ -78,10 +83,10 @@ submit_out="$WORK/submit.json"
 print ""
 
 sub_id=$(grep -o '"id" *: *"[^"]*"' "$submit_out" | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
-status=$(grep -o '"status" *: *"[^"]*"' "$submit_out" | tail -1 | sed 's/.*"\([^"]*\)"$/\1/')
-say "submission ${sub_id:-<no id>} → status: ${status:-<none>}"
+verdict=$(grep -o '"status" *: *"[^"]*"' "$submit_out" | tail -1 | sed 's/.*"\([^"]*\)"$/\1/')
+say "submission ${sub_id:-<no id>} → status: ${verdict:-<none>}"
 
-case "${status:-}" in
+case "${verdict:-}" in
   Accepted) ;;
   Invalid|Rejected)
     say "verdict against the artifact — notary log follows"
@@ -100,21 +105,34 @@ say "Accepted — fetching notary log"
 # --- the brew-decisive check ---------------------------------------------
 # jit ships a bare Mach-O, which cannot be stapled, so a Homebrew-cask user
 # (whose download brew quarantines) depends on Gatekeeper fetching the ticket
-# online. Simulate exactly that: quarantine the signed binary, then (a) ask
-# Gatekeeper's verdict and (b) actually execute it.
+# online. Simulate exactly that user, A/B: quarantine both the notarized
+# binary and the unnotarized control, and execute each. The control MUST be
+# blocked (SIGKILL) or the environment isn't discriminating and the leg
+# proves nothing. spctl output is printed as evidence only: its `execute`
+# policy approves only .apps, so a bare CLI gets "rejected (the code is valid
+# but does not seem to be an app)" even when notarized — measured 2026-08-06.
 say "Gatekeeper check on a quarantined, unstapled copy"
+spctl --status || true
+qtag="0083;$(printf '%x' "$(date +%s)");notarize-e2e-spike;"
 cp "$WORK/hello" "$WORK/hello-quarantined"
-xattr -w com.apple.quarantine "0083;$(printf '%x' "$(date +%s)");notarize-e2e-spike;" \
-  "$WORK/hello-quarantined"
+xattr -w com.apple.quarantine "$qtag" "$WORK/hello-quarantined"
+xattr -w com.apple.quarantine "$qtag" "$WORK/control"
 
-spctl_out=$(spctl --assess --type execute -vv "$WORK/hello-quarantined" 2>&1)
-print -r -- "$spctl_out"
-run_out=$("$WORK/hello-quarantined" 2>&1)
-print -r -- "exec: $run_out"
+spctl --assess --type execute -vv "$WORK/hello-quarantined" 2>&1 || true
 
-if [[ "$spctl_out" == *"Notarized Developer ID"* && "$run_out" == *"hello"* ]]; then
-  say "PASS — ticket found online; quarantined binary runs. Safe to re-add notarize + cask once this is consistent."
+ctl_out=$("$WORK/control" 2>&1); ctl_rc=$?
+run_out=$("$WORK/hello-quarantined" 2>&1); run_rc=$?
+print -r -- "control (ad-hoc, quarantined):   rc=$ctl_rc"
+print -r -- "notarized, quarantined:          rc=$run_rc  $run_out"
+
+if (( ctl_rc == 0 )); then
+  say "INCONCLUSIVE — the unnotarized control ran too; this environment cannot discriminate (Gatekeeper off?)"
+  exit 4
+fi
+if (( run_rc == 0 )) && [[ "$run_out" == *"hello"* ]]; then
+  say "PASS — Gatekeeper blocks the control but runs the notarized copy: the online ticket fetch works."
+  say "Safe to re-add notarize + the cask once this is consistent (see FINDINGS.md gate)."
   exit 0
 fi
-say "Accepted by notary, but Gatekeeper did NOT clear the quarantined copy"
+say "Accepted by notary, but Gatekeeper blocked the quarantined notarized copy (rc=$run_rc)"
 exit 3


### PR DESCRIPTION
## What

An on-demand, end-to-end probe of Apple's notary service for this account, so we find out it works **before** re-wiring the release and Homebrew paths around it — not mid-release. Per repo convention it lives in `spike/notarize-e2e/` (throwaway module + `FINDINGS.md`), plus one manually-triggered workflow.

The probe:

1. builds a deliberately trivial Mach-O (any failure is account/service-side, never artifact-side — the same methodology as support case 20000125465695),
2. signs it with **quill** (pinned v0.7.1), the same signer goreleaser's `notarize.macos` path embeds, using the same full-chain `.p12` secret,
3. submits via `xcrun notarytool` with a bounded `--wait`, and distinguishes by exit code: Accepted (0), Invalid with log dumped (1), **stuck In Progress** — the known account condition (2),
4. on Accepted, verifies the part brew actually depends on: jit's bare Mach-O cannot be stapled and Homebrew quarantines cask downloads, so the probe quarantines the signed binary and requires `spctl` to say `Notarized Developer ID` **and** the quarantined copy to execute — i.e. the online ticket fetch works (Gatekeeper failure here is its own exit code, 3).

## How to run

```sh
gh workflow run notarize-spike.yml                  # full end-to-end (same secrets as release.yml)
gh workflow run notarize-spike.yml -f mode=history  # no new submission; list recent verdicts,
                                                    # incl. whether the July/Aug stuck ones ever resolved
```

Also runnable locally on a machine that has the keys — see `spike/notarize-e2e/FINDINGS.md`.

## Gate (in FINDINGS.md)

Re-add `.goreleaser.yml`'s `notarize:` block (with the 15m JWT lesson from 77cc73f) and the `homebrew_casks` block, without the quarantine-strip hack, only after **3 consecutive green runs across at least 2 different days** with verdicts arriving in minutes. One Accepted proved nothing last time (1 of 9).

No release-path files are touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkRecrQti3Q8DkkbL6jcpz