### PR TITLE
scan: make --full read like jit scan, and fix the possessive in every evidence line

### DIFF
--- a/internal/audit/agentcache.go
+++ b/internal/audit/agentcache.go
@@ -569,7 +569,7 @@ func ScanAgentStores(cfg Config) ([]Finding, error) {
 			return
 		}
 		for i := range fs {
-			fs[i].Evidence = fmt.Sprintf("%s (found in %s's local store)", fs[i].Evidence, label)
+			fs[i].Evidence = fmt.Sprintf("%s (found in %s local store)", fs[i].Evidence, possessive(label))
 		}
 		findings = append(findings, fs...)
 	}

--- a/internal/audit/build.go
+++ b/internal/audit/build.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"strings"
 )
 
 // ValueFindingParams describes a discovered key/value pair a category
@@ -35,6 +36,19 @@ type ValueFindingParams struct {
 //   - Otherwise the value is masked (MaskValue) and checked for a
 //     production-indicator or public-IP match, which escalates severity to
 //     Critical unconditionally.
+//
+// possessive renders name's possessive form. A name already ending in "s"
+// takes a bare apostrophe, which is what stops the evidence line reading
+// "Database connection string with embedded credentials's known token format"
+// — a real string this package printed dozens of times in one report, because
+// every site built the possessive with a hand-written "%s's".
+func possessive(name string) string {
+	if strings.HasSuffix(name, "s") || strings.HasSuffix(name, "S") {
+		return name + "'"
+	}
+	return name + "'s"
+}
+
 func (c Config) ValueFinding(p ValueFindingParams) Finding {
 	f := c.baseFinding()
 	f.FindingType = p.FindingType
@@ -93,7 +107,7 @@ func (c Config) ValueFinding(p ValueFindingParams) Finding {
 		f.Severity = SeverityHigh
 		if verified {
 			f.Confidence = ConfidenceHigh
-			f.Evidence = fmt.Sprintf("value matches %s's known token format", vendor)
+			f.Evidence = fmt.Sprintf("value matches %s known token format", possessive(vendor))
 		} else {
 			f.Confidence = ConfidenceMedium
 			f.Evidence = fmt.Sprintf("value looks like it may be a %s (pattern not independently verified)", vendor)

--- a/internal/audit/build_test.go
+++ b/internal/audit/build_test.go
@@ -1,0 +1,25 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package audit
+
+import "testing"
+
+// The evidence line printed "…embedded credentials's known token format" dozens
+// of times in one real report, because every site built the possessive with a
+// hand-written "%s's". Vendor names ending in "s" are not rare here — several
+// pattern names end in "credentials", "Secrets" or "Keys".
+func TestPossessiveHandlesNamesEndingInS(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"Database connection string with embedded credentials", "Database connection string with embedded credentials'"},
+		{"JSON Web Token (JWT)", "JSON Web Token (JWT)'s"},
+		{"AWS Access Key ID", "AWS Access Key ID's"},
+		{"Claude Code", "Claude Code's"},
+		{"SOPS", "SOPS'"},
+	}
+	for _, c := range cases {
+		if got := possessive(c.in); got != c.want {
+			t.Errorf("possessive(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/audit/envfile.go
+++ b/internal/audit/envfile.go
@@ -327,7 +327,7 @@ func buildEnvFileFinding(cfg Config, path string, isTemplate bool) (Finding, boo
 		}
 		if tokenVerified {
 			f.Confidence = ConfidenceHigh
-			f.Evidence = fmt.Sprintf("contains a value matching %s's known token format", tokenVendor)
+			f.Evidence = fmt.Sprintf("contains a value matching %s known token format", possessive(tokenVendor))
 		} else {
 			f.Confidence = ConfidenceMedium
 			f.Evidence = fmt.Sprintf("contains a value that looks like it may be a %s (pattern not independently verified)", tokenVendor)

--- a/internal/audit/iac.go
+++ b/internal/audit/iac.go
@@ -486,7 +486,7 @@ func buildTfvarsFinding(cfg Config, path string) (Finding, error) {
 		leadVendor, leadKey = tokens[0].vendor, tokens[0].key
 		if tokens[0].verified {
 			f.Confidence = ConfidenceHigh
-			f.Evidence = fmt.Sprintf("contains a value matching %s's known token format", leadVendor)
+			f.Evidence = fmt.Sprintf("contains a value matching %s known token format", possessive(leadVendor))
 		} else {
 			f.Evidence = fmt.Sprintf("contains a value that looks like it may be a %s (pattern not independently verified)", leadVendor)
 		}

--- a/internal/audit/mcpconfig.go
+++ b/internal/audit/mcpconfig.go
@@ -338,7 +338,7 @@ func scanMCPServerHeaders(cfg Config, path, serverName string, entry mcpServerEn
 		}
 		evidence := fmt.Sprintf("sent as the %q header by MCP server %q; jit can't inject into a header the host itself sends", header, serverName)
 		if tokenOK {
-			evidence = fmt.Sprintf("%s's %q header carries a %s; jit can't inject into a header the host itself sends", serverName, header, vendor)
+			evidence = fmt.Sprintf("%s %q header carries a %s; jit can't inject into a header the host itself sends", possessive(serverName), header, vendor)
 		}
 		f := withContextEvidence(cfg.ValueFinding(ValueFindingParams{
 			FindingType:  FindingTypeMCPEmbeddedSecret,

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -480,10 +480,23 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 	}
 	sizeNote := ""
 	if summary.FilesScanned > 0 {
-		sizeNote = fmt.Sprintf(" (%s files)", groupDigits(summary.FilesScanned))
+		// Inflected and digit-grouped, the same composition the triage header
+		// uses: countWord would inflect but print a bare 25872.
+		sizeNote = fmt.Sprintf(" · %s %s", groupDigits(summary.FilesScanned),
+			pluralWord(summary.FilesScanned, "file", "files"))
 	}
-	termtext.Wrap(w, 0, "", fmt.Sprintf("jit scan — %s@%s — scanned %s%s — full inventory — %s",
-		who, host, where, sizeNote, formatDuration(summary.ScanDurationMs)))
+	// "jit scan --full  ~/ · 25,872 files · 12.2s" — the same header shape the
+	// triage view carries, because these are two views of one command and a
+	// reader moving between them should not have to re-learn the top of the
+	// page. It was an em-dash chain carrying user@host and a mid-line "full
+	// inventory": a second header shape in a tool that has one, spending its
+	// most prominent line on the reader's own username and hostname. Both are
+	// things the program knows and the reader already does, and `jit doctor`
+	// plus NDJSON's endpoint block are where machine identity earns its place.
+	// The command name carries "--full", so the words don't have to.
+	head := style.Bold.Sprint("jit scan --full") + "  " + where + sizeNote +
+		" · " + formatDuration(summary.ScanDurationMs)
+	termtext.Wrap(w, 0, "", head)
 
 	// The unfiltered notice sits ABOVE the numbers, not in a footnote: like
 	// the triage view's incomplete-scan banner, it changes what every count
@@ -664,10 +677,18 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 				"   the guided fix plan for the first flagged file")
 	}
 	fmt.Fprint(w, "  ")
-	termtext.Wrap(w, 2, "  ",
-		"No secret values are ever printed in full · "+
-			cmd.Sprint("jit scan --format ndjson")+
-			" for machines, same redaction")
+	// The way back. The triage view points here with "→ jit scan --full  the
+	// full inventory · ndjson for machines"; without the reverse link a reader
+	// who lands in the inventory first has no pointer to the view that tells
+	// them what to DO, and that view is the one the product leads with.
+	fmt.Fprintln(w)
+	fmt.Fprint(w, "  ")
+	_, _ = cmd.Fprint(w, style.GlyphAction+" ")
+	termtext.Wrap(w, 4, "    ",
+		cmd.Sprint("jit scan")+"   the action-first view · "+
+			cmd.Sprint("--format ndjson")+" for machines")
+	fmt.Fprint(w, "  ")
+	termtext.Wrap(w, 2, "  ", "No secret values are ever printed in full.")
 }
 
 // anyUnfilteredOnly reports whether any finding carries the [unfiltered]

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -485,7 +485,7 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 		sizeNote = fmt.Sprintf(" · %s %s", groupDigits(summary.FilesScanned),
 			pluralWord(summary.FilesScanned, "file", "files"))
 	}
-	// "jit scan --full  ~/ · 25,872 files · 12.2s" — the same header shape the
+	// "jit scan  ~/ · 25,872 files · 12.2s" — byte-for-byte the shape the
 	// triage view carries, because these are two views of one command and a
 	// reader moving between them should not have to re-learn the top of the
 	// page. It was an em-dash chain carrying user@host and a mid-line "full
@@ -493,8 +493,12 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 	// most prominent line on the reader's own username and hostname. Both are
 	// things the program knows and the reader already does, and `jit doctor`
 	// plus NDJSON's endpoint block are where machine identity earns its place.
-	// The command name carries "--full", so the words don't have to.
-	head := style.Bold.Sprint("jit scan --full") + "  " + where + sizeNote +
+	//
+	// "jit scan" and not "jit scan --full", even though this is the inventory:
+	// this function ALSO renders a targeted `jit scan <path>`, which reaches no
+	// --full flag. Naming the flag here told those readers they had passed
+	// something they hadn't. The view identifies itself by its shape.
+	head := style.Bold.Sprint("jit scan") + "  " + where + sizeNote +
 		" · " + formatDuration(summary.ScanDurationMs)
 	termtext.Wrap(w, 0, "", head)
 

--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -41,7 +41,7 @@ func TestWriteHumanReportNeverLeaksRawValue(t *testing.T) {
 		// own username and hostname — dropped 2026-08-06 so this view shares
 		// the triage header's shape. Machine identity lives in `jit doctor`
 		// and NDJSON's endpoint block, which is where it earns its place.
-		"jit scan --full",
+		"jit scan",
 		"✗ CRITICAL — exposure",
 		"Shell Configs",
 		"/Users/alex/.zshrc",

--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -37,7 +37,11 @@ func TestWriteHumanReportNeverLeaksRawValue(t *testing.T) {
 		t.Fatal("human report must never contain the raw secret value")
 	}
 	for _, want := range []string{
-		"alex@Alexs-MacBook-Pro",
+		// The header carries the COMMAND and what it covered, not the reader's
+		// own username and hostname — dropped 2026-08-06 so this view shares
+		// the triage header's shape. Machine identity lives in `jit doctor`
+		// and NDJSON's endpoint block, which is where it earns its place.
+		"jit scan --full",
 		"✗ CRITICAL — exposure",
 		"Shell Configs",
 		"/Users/alex/.zshrc",
@@ -45,7 +49,10 @@ func TestWriteHumanReportNeverLeaksRawValue(t *testing.T) {
 		"CRITICAL  AWS_SECRET_ACCESS_KEY",
 		preview,
 		"key name matches production-indicator pattern",
-		"jit scan --format ndjson",
+		"--format ndjson",
+		// The way back to the action-first view. Without it a reader who lands
+		// in the inventory has no pointer to the view the product leads with.
+		"the action-first view",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("report output missing expected substring %q\n--- full output ---\n%s", want, out)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -183,18 +183,20 @@ var scanCmd = &cobra.Command{
 
 		machineScan := scanFormat == "ndjson" || scanFormat == "markdown" || scanFormat == "md" || scanOutput != ""
 		progress := newProgress(cmd, machineScan)
-		// The trail is scaffolding for this view, not part of the result: the
-		// triage report is a page the reader works down, and sixteen settled
+		// The trail is scaffolding for either view, not part of the result: a
+		// scan report is a page the reader works down, and sixteen settled
 		// "✓ Scanned …" lines pushed its top off a short window. They still
 		// animate while the scan runs — a ten-second home walk must not look
 		// hung — and collapse to one line the moment it finishes.
 		//
-		// --full keeps its trail. That view IS an inventory by category, so
-		// the per-category lines above it read as a table of contents rather
-		// than as noise.
-		if !scanFull {
-			progress.Collapse()
-		}
+		// --full used to keep its trail, on the reasoning that per-category
+		// lines above an inventory read as a table of contents. They don't:
+		// the actual table of contents is the category count table three lines
+		// below the header, which carries the same sixteen names AND their
+		// counts. So the trail was sixteen lines of duplication at the top of
+		// the longest view in the tool, and it was the largest remaining
+		// difference between the two views of one command.
+		progress.Collapse()
 		cfg.Progress = func(category string) {
 			progress.Step("Scanning "+category+"…", "Scanned "+category)
 		}


### PR DESCRIPTION
Follow-up to #23, from reading the shipped v0.79.0 output on a real machine rather than a fixture. Three commits.

## `--full` now opens and closes like `jit scan`

Two views of one command had two different header shapes, so a reader moving between them re-learned the top of the page:

```
before:  jit scan — menit@MBP-menit — scanned ~/ (25,872 files) — full inventory — 12.2s
after:   jit scan  ~/ · 25,872 files · 12.2s
```

Same bold command, same `·` separator run, no `user@host`, no mid-line "full inventory". Dropping `user@host` is the call the triage header already made: it spent the report's most prominent line on the reader's own username and hostname, which the program knows and the reader already does. `jit doctor` and NDJSON's `endpoint` block are where machine identity earns its place.

The sixteen settled `✓ Scanned …` lines now collapse to one in `--full` too. They had been kept deliberately, on the reasoning that per-category lines above an inventory read as a table of contents — but the actual table of contents is the category count table three lines below the header, carrying the same sixteen names **and** their counts. So it was sixteen lines of duplication at the top of the longest view in the tool. The old reasoning is recorded in the comment next to the change rather than deleted.

And `--full` gained the way back: triage points at it, nothing pointed the other way, so a reader who landed in the inventory had no pointer to the view the product leads with.

## A bug the first commit introduced, caught by running both forms

`WriteHumanReport` is not the `--full` renderer — it is the *non-triage* renderer, and a targeted `jit scan <path>` goes through it with no `--full` flag anywhere. The first commit had put `jit scan --full` in the header, so a plain targeted scan announced a flag the user never typed. The header says `jit scan`; the view identifies itself by its shape.

Nothing in `report.go` names its callers, so reading it would not have shown this. Running `jit scan <path>` and `jit scan --full <path>` side by side did.

## `credentials's`

Five sites built a possessive with a hand-written `%s's`, and vendor names ending in `s` are not rare here — several pattern names end in `credentials`, `Secrets` or `Keys`. The result, printed dozens of times in one real `--full` report:

```
value matches Database connection string with embedded credentials's known token format
```

One `possessive()` helper gives a name already ending in `s` a bare apostrophe. All five sites route through it: the generic evidence builder, `.env`, IaC, the MCP header note, and the agent-cache "found in X's local store" suffix. Tested directly, with the offending string named in the test so the next reader knows what it is for.

## Verification

Full CI gate on the final commit: `go build`, `gofmt -l`, `go vet`, `go mod verify`, `staticcheck`, `govulncheck`, `gosec`, `go test -race -timeout 6m ./...` — all clean. Both output changes were previewed at 100/60/50 columns before any code was edited, per the repo's rule.

One stale assertion updated rather than deleted: `TestWriteHumanReportNeverLeaksRawValue` required the substring `alex@Alexs-MacBook-Pro`. It now asserts the new header and footer intent, and records why the identity is gone so it is not re-added as a "missing" assertion.

## Deliberately not in this PR

Found in the same output, each needing either plumbing or your eye on a preview:

- **The `~/` scope lie** — a targeted scan prints `~/` regardless of target, and `FilesScanned` comes back 0 so the count vanishes (`jit scan  ~/ · 1ms`). Needs `ScanSummary` to carry the real targets; affects both views.
- **Two manifest rows render identically** — `…/ai_tooling/mcp_servers/okta-mcp-server/.env` twice, two *different* files, on the screen that asks you to approve rewriting them. Head-truncation at 56 columns cuts inside a 65-character shared tail.
- **The vendor column is padded to the longest name**, pushing every mask ~68 columns right. The same defect `maxManifestPathCol` fixed in the manifest, unfixed in this table.
- **jit reports its own source** — `tokenpatterns.go` as an exposed database password, because its comments document `postgres://user:password@localhost/db`.
- Shell-escaped paths leaking into prose lists; `same pattern in N files` vs `same value in N files` for one idea.

🤖 Generated with [Claude Code](https://claude.com/claude-code)