### PR TITLE
test: make the safety net capable of failing (tranche A)

### DIFF
--- a/internal/audit/finding_test.go
+++ b/internal/audit/finding_test.go
@@ -1,0 +1,65 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package audit
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// findingTypeDecl matches a finding type as declared in finding.go's const
+// block, e.g. `FindingTypeExposedSecret = "exposed_secret"` — trailing #nosec
+// comments and gofmt's alignment padding included.
+var findingTypeDecl = regexp.MustCompile(`(?m)^\s*FindingType[A-Za-z0-9]+\s*=\s*"([a-z_0-9]+)"`)
+
+// TestAllFindingTypesListsEveryDeclaredType closes the hole in every test that
+// walks AllFindingTypes (scan_test, markdown, ndjson, the report): each proves
+// "every type SOMEONE REMEMBERED TO REGISTER is handled", never "every type
+// exists". The slice is hand-maintained, so a new const that never gets a line
+// added is invisible to all of them at once.
+//
+// That is not hypothetical — it is the failure AllFindingTypes' own comment
+// records, and the same shape as kindMCP in internal/cli: a finding absent
+// from this slice is silently dropped from scan_summary's
+// findings_by_category, from the markdown report, and from the NDJSON stream,
+// while every existing test stays green.
+//
+// Both directions, because a stale entry is the mirror failure: a slice naming
+// a const that was renamed or removed emits a category key for a finding type
+// nothing can ever produce.
+func TestAllFindingTypesListsEveryDeclaredType(t *testing.T) {
+	const src = "finding.go"
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("reading %s: %v", src, err)
+	}
+
+	matches := findingTypeDecl.FindAllStringSubmatch(string(data), -1)
+	// Without this the guard passes vacuously the day the constants are
+	// renamed or moved to another file.
+	if len(matches) < 10 {
+		t.Fatalf("found only %d FindingType constants in %s — the guard would pass vacuously; fix findingTypeDecl", len(matches), src)
+	}
+
+	listed := make(map[string]bool, len(AllFindingTypes))
+	for _, ft := range AllFindingTypes {
+		listed[ft] = true
+	}
+	declared := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		declared[m[1]] = true
+		if !listed[m[1]] {
+			t.Errorf("finding type %q is declared in %s but missing from AllFindingTypes; "+
+				"it would be dropped from findings_by_category, the markdown report and the "+
+				"NDJSON stream, with every existing test still green", m[1], src)
+		}
+	}
+	for _, ft := range AllFindingTypes {
+		if !declared[ft] {
+			t.Errorf("AllFindingTypes lists %q, which no FindingType constant in %s declares; "+
+				"scan_summary carries a category key nothing can ever produce", ft, src)
+		}
+	}
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -987,6 +988,51 @@ func TestEveryCheckKindHasALabel(t *testing.T) {
 		}
 		if !strings.HasPrefix(label, "[") || !strings.HasSuffix(label, "]") {
 			t.Errorf("findingLabel(%q) = %q, want the bracketed `[category]` header shape", k, label)
+		}
+	}
+}
+
+// checkKindDecl matches a kind as declared in profilecheck.go's const block,
+// e.g. `kindMCP checkKind = "mcp"`.
+var checkKindDecl = regexp.MustCompile(`(?m)^\s*kind[A-Za-z0-9]+\s+checkKind\s*=\s*"([a-z_0-9]+)"`)
+
+// TestAllCheckKindsListsEveryDeclaredKind is the guard the two tests above
+// depend on and cannot provide. Both walk allCheckKinds, so they prove "every
+// kind someone remembered to register renders" — a kind declared without a
+// line added to the slice is invisible to both, which is precisely how kindMCP
+// shipped with no findingLabel in the first place. allCheckKinds' own comment
+// records that incident; the enumeration it introduced is still typed by hand.
+//
+// Both directions: a stale entry names a kind nothing can produce, and the
+// completeness tests would then assert a label for a value doctor never emits.
+func TestAllCheckKindsListsEveryDeclaredKind(t *testing.T) {
+	const src = "profilecheck.go"
+	data, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("reading %s: %v", src, err)
+	}
+
+	matches := checkKindDecl.FindAllStringSubmatch(string(data), -1)
+	if len(matches) < 15 {
+		t.Fatalf("found only %d checkKind constants in %s — the guard would pass vacuously; fix checkKindDecl", len(matches), src)
+	}
+
+	listed := make(map[string]bool, len(allCheckKinds))
+	for _, k := range allCheckKinds {
+		listed[string(k)] = true
+	}
+	declared := make(map[string]bool, len(matches))
+	for _, m := range matches {
+		declared[m[1]] = true
+		if !listed[m[1]] {
+			t.Errorf("checkKind %q is declared in %s but missing from allCheckKinds; "+
+				"neither TestEveryCheckKindHasALabel nor TestEveryCheckKindFormatsABody "+
+				"can see it, which is how kindMCP shipped unlabeled", m[1], src)
+		}
+	}
+	for _, k := range allCheckKinds {
+		if !declared[string(k)] {
+			t.Errorf("allCheckKinds lists %q, which no checkKind constant in %s declares", k, src)
 		}
 	}
 }

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -52,6 +52,36 @@ func TestStatusEverythingEmpty(t *testing.T) {
 	}
 }
 
+// TestShortVersion pins goPseudoVersion against literal inputs, because the
+// two places the status row is asserted — status_test.go's "jit " + …
+// expectation above and status_agent_test.go's wantVersions — both BUILD the
+// expected string by calling shortVersion, the production expression under
+// test. Both sides of those comparisons move together, so a broken regexp
+// keeps them green while `jit status` prints a build-system artifact nobody
+// reads. Those two lines were shortVersion's only appearances in any test.
+func TestShortVersion(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		// A released binary carries a plain version and must pass through.
+		{"v0.67.0", "v0.67.0"},
+		{"0.67.0", "0.67.0"},
+		// Go's pseudo-version tail for a checkout with a preceding tag…
+		{"v0.67.0-0.20260801120000-abcdef123456", "v0.67.0"},
+		// …and the +dirty variant a modified tree produces.
+		{"v0.67.0-0.20260801120000-abcdef123456+dirty", "v0.67.0"},
+		// The untagged shape, where the "0." group is absent.
+		{"v0.0.0-20260801120000-abcdef123456", "v0.0.0"},
+		// A genuine prerelease suffix is short and meaningful: keep it.
+		{"v0.67.0-rc1", "v0.67.0-rc1"},
+		// Only the TAIL is a pseudo-version; the same shape mid-string is not.
+		{"v0.67.0-0.20260801120000-abcdef123456-rc1", "v0.67.0-0.20260801120000-abcdef123456-rc1"},
+		{"", ""},
+	} {
+		if got := shortVersion(tc.in); got != tc.want {
+			t.Errorf("shortVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestStatusVaultReportsSecretCount(t *testing.T) {
 	home := withFixtureHome(t)
 	withFixtureCwd(t)

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -404,7 +404,13 @@ func TestSignatureRequirementFormIsInline(t *testing.T) {
 // genuine ones included. That failure is indistinguishable from a real
 // rejection at the call site, so it is pinned here rather than discovered by a
 // user whose upgrade stopped working.
-func TestVerifyStagedSignature(t *testing.T) {
+// The two halves are separate tests on purpose. They used to share one, and
+// the positive half's t.Skip — reached on any machine with no Developer
+// ID-signed app in /Applications, which is the CI case — marks the WHOLE test
+// SKIP in Go, taking the already-executed negative half's result with it. So
+// the half that guards "the upgrade path installs an unsigned build" reported
+// no result at all exactly where nobody is watching.
+func TestVerifyStagedSignatureRefusesUnsignedAndMissing(t *testing.T) {
 	if _, err := os.Stat("/usr/bin/codesign"); err != nil {
 		t.Skip("codesign unavailable")
 	}
@@ -424,17 +430,28 @@ func TestVerifyStagedSignature(t *testing.T) {
 	if err := verifyStagedSignature(ctx, filepath.Join(t.TempDir(), "absent")); err == nil {
 		t.Error("a missing file passed signature verification")
 	}
+}
 
-	// The positive half: the requirement FORM has to match a real Developer ID
-	// signature. Checked against whatever Developer-ID-signed code this machine
-	// happens to have, substituting that binary's own team, since jit's own
-	// signed release isn't available in a test.
+// The positive half: the requirement FORM has to match a real Developer ID
+// signature, which is the direction that fails closed into "nobody can ever
+// upgrade". Checked against whatever Developer-ID-signed code this machine
+// happens to have, substituting that binary's own team, since jit's own signed
+// release isn't available in a test.
+//
+// Skipping here now costs only this assertion. It remains a machine-dependent
+// check, and the durable fix is pipeline-side: nothing in CI or the release
+// workflow ever compares what goreleaser/quill PRODUCES against the codesign
+// requirement verifyStagedSignature ENFORCES.
+func TestVerifyStagedSignatureAcceptsARealDeveloperIDSignature(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/codesign"); err != nil {
+		t.Skip("codesign unavailable")
+	}
 	signed, team := findDeveloperIDSigned(t)
 	if signed == "" {
 		t.Skip("no Developer ID signed binary available to validate the requirement form")
 	}
 	req := signatureRequirement(team)
-	out, err := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "-R", req, signed).CombinedOutput()
+	out, err := exec.CommandContext(context.Background(), "/usr/bin/codesign", "--verify", "--strict", "-R", req, signed).CombinedOutput()
 	if err != nil {
 		t.Fatalf("the requirement form jit uses rejected a genuine Developer ID signature (%s, team %s): %v\n%s\n"+
 			"every jit upgrade would fail closed with this form", signed, team, err, out)

--- a/internal/keychainwrap/interop_test.go
+++ b/internal/keychainwrap/interop_test.go
@@ -1,0 +1,194 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package keychainwrap
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// fixedMEK is an agent.MEKFetcher that hands out the SAME master key this
+// package's Wrapper is holding, so both wrappers are operating on one vault —
+// which is the only configuration in which the interop property below is even
+// a question. A fresh copy per call, because every consumer of a fetched MEK
+// in both packages does `defer wipe(mek)` on what it gets back.
+type fixedMEK []byte
+
+func (f fixedMEK) FetchMEK(string) ([]byte, error) {
+	out := make([]byte, len(f))
+	copy(out, f)
+	return out, nil
+}
+
+// interopPair builds a keychainwrap.Wrapper and an agent.Server sharing one
+// MEK. The Server is never Listen()ed: WrapKeyLabeled/UnwrapKeyLabeled are the
+// agent unlocking ITSELF in-process (server.go), so there is no socket, no
+// peer and no consent gate on this path — exactly the code a DEK crossing
+// between the two wrappers actually travels through.
+func interopPair(t *testing.T) (*Wrapper, *agent.Server) {
+	t.Helper()
+
+	w := testWrapper(noChallenge)
+	cleanupTestMEK(t, w)
+	if err := w.EnsureMEK(); err != nil {
+		t.Fatalf("EnsureMEK: %v", err)
+	}
+	mek, err := w.fetchMEK("interop test")
+	if err != nil {
+		t.Fatalf("fetchMEK: %v", err)
+	}
+	t.Cleanup(w.Close)
+
+	srv := agent.NewServer(
+		filepath.Join(t.TempDir(), "agent.sock"),
+		func() agent.MEKFetcher { return fixedMEK(mek) },
+		time.Minute,
+	)
+	return w, srv
+}
+
+// interopClasses spans the shapes the AAD derivation has to get right: the
+// legacy empty class (v1/v2 secrets, written before provenance existed and
+// byte-compatible with the pre-AAD wraps), an ordinary class, and one
+// carrying an underscore.
+var interopClasses = []string{"", vault.ClassManual, vault.ClassAWS, vault.ClassShellHistory}
+
+// TestDEKWrapsInteropAcrossAgentAndKeychain is the check vault.LabeledKeyWrapper
+// demands in prose and nothing enforced: "Both wrappers (agent and
+// keychainwrap) MUST bind it identically: a DEK wrapped by one and unwrapped
+// by the other has to agree on the AAD."
+//
+// That is not a hypothetical crossing. Whether a given secret's DEK was
+// wrapped through the agent or through keychainwrap directly depends only on
+// whether the service happened to be running when it was written, so a single
+// vault routinely holds both — and any process may later read either one
+// through whichever wrapper is available to it.
+//
+// Both packages carry their own full copy of seal/open, each citing the other,
+// and both report a mismatch with the identical message "unwrap failed (wrong
+// MEK, wrong class, or corrupted data)". So a divergence does not read as a
+// code change; it reads to the user as vault corruption, on some secrets and
+// not others. The natural hardening move on an AAD — a domain separator or a
+// version prefix, `"v3|" + class` — made in one package and not the other is
+// enough to do it.
+//
+// Deliberately driven through the exported wrappers rather than seal/open,
+// which are unexported in both packages: the property covers nonce placement,
+// nonce size and cipher choice too, not just the one line deriving the AAD.
+func TestDEKWrapsInteropAcrossAgentAndKeychain(t *testing.T) {
+	w, srv := interopPair(t)
+	dek := bytes.Repeat([]byte{0x5A}, 32)
+
+	for _, class := range interopClasses {
+		name := class
+		if name == "" {
+			name = "legacy-empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Run("agent wraps, keychain unwraps", func(t *testing.T) {
+				wrapped, err := srv.WrapKeyLabeled(dek, "interop/secret", class)
+				if err != nil {
+					t.Fatalf("agent WrapKeyLabeled: %v", err)
+				}
+				got, err := w.UnwrapKeyLabeled(wrapped, "interop/secret", class)
+				if err != nil {
+					t.Fatalf("keychainwrap could not unwrap a DEK the agent wrapped: %v; "+
+						"the two wrappers have diverged and secrets written while the "+
+						"service was running are now undecryptable without it", err)
+				}
+				if !bytes.Equal(got, dek) {
+					t.Errorf("round trip returned a different DEK: got %x, want %x", got, dek)
+				}
+			})
+
+			t.Run("keychain wraps, agent unwraps", func(t *testing.T) {
+				wrapped, err := w.WrapKeyLabeled(dek, "interop/secret", class)
+				if err != nil {
+					t.Fatalf("keychainwrap WrapKeyLabeled: %v", err)
+				}
+				got, err := srv.UnwrapKeyLabeled(wrapped, "interop/secret", class)
+				if err != nil {
+					t.Fatalf("the agent could not unwrap a DEK keychainwrap wrapped: %v; "+
+						"the two wrappers have diverged and secrets written with the "+
+						"service down are now undecryptable through it", err)
+				}
+				if !bytes.Equal(got, dek) {
+					t.Errorf("round trip returned a different DEK: got %x, want %x", got, dek)
+				}
+			})
+		})
+	}
+}
+
+// TestClassBindingIsAuthoritativeAcrossWrappers pins the other half of the
+// contract: the class is AAD, so presenting a different one has to fail the
+// auth tag no matter which wrapper sealed the DEK.
+//
+// Without this, the interop test above still passes against a pair of
+// wrappers that BOTH ignore class entirely — identical, interoperable, and
+// with the consent gate's authoritative input reduced to a caller-supplied
+// string it can lie about freely.
+func TestClassBindingIsAuthoritativeAcrossWrappers(t *testing.T) {
+	w, srv := interopPair(t)
+	dek := bytes.Repeat([]byte{0x5A}, 32)
+
+	agentWrapped, err := srv.WrapKeyLabeled(dek, "interop/secret", vault.ClassAWS)
+	if err != nil {
+		t.Fatalf("agent WrapKeyLabeled: %v", err)
+	}
+	keychainWrapped, err := w.WrapKeyLabeled(dek, "interop/secret", vault.ClassAWS)
+	if err != nil {
+		t.Fatalf("keychainwrap WrapKeyLabeled: %v", err)
+	}
+
+	if _, err := w.UnwrapKeyLabeled(agentWrapped, "interop/secret", vault.ClassDocker); err == nil {
+		t.Error("keychainwrap unwrapped an agent-wrapped DEK under the wrong class; " +
+			"class is not bound as AAD and the consent gate can be lied to")
+	}
+	if _, err := srv.UnwrapKeyLabeled(keychainWrapped, "interop/secret", vault.ClassDocker); err == nil {
+		t.Error("the agent unwrapped a keychainwrap-wrapped DEK under the wrong class; " +
+			"class is not bound as AAD and the consent gate can be lied to")
+	}
+}
+
+// TestLabelIsNotBoundAcrossWrappers is the negative of the pair: label is
+// caller-reported audit data and MUST NOT reach the AAD, in either package.
+//
+// It is the mistake the two are shaped to invite — WrapKeyLabeled takes label
+// and class adjacently, and binding "both identifiers, for safety" looks like
+// hardening. It would instead make every unwrap depend on a string the writer
+// chose and the reader has to guess: vault falls back to the unlabeled methods
+// whenever the wrapper doesn't implement LabeledKeyWrapper, so the same DEK is
+// legitimately unwrapped under "" and under its path.
+func TestLabelIsNotBoundAcrossWrappers(t *testing.T) {
+	w, srv := interopPair(t)
+	dek := bytes.Repeat([]byte{0x5A}, 32)
+
+	agentWrapped, err := srv.WrapKeyLabeled(dek, "stripe/live-key", vault.ClassManual)
+	if err != nil {
+		t.Fatalf("agent WrapKeyLabeled: %v", err)
+	}
+	if _, err := w.UnwrapKeyLabeled(agentWrapped, "a totally different label", vault.ClassManual); err != nil {
+		t.Errorf("keychainwrap rejected a differently-labeled unwrap: %v; "+
+			"label has been bound into the AAD, which makes audit metadata "+
+			"load-bearing for decryption", err)
+	}
+
+	keychainWrapped, err := w.WrapKeyLabeled(dek, "stripe/live-key", vault.ClassManual)
+	if err != nil {
+		t.Fatalf("keychainwrap WrapKeyLabeled: %v", err)
+	}
+	if _, err := srv.UnwrapKeyLabeled(keychainWrapped, "", vault.ClassManual); err != nil {
+		t.Errorf("the agent rejected an unlabeled unwrap of a labeled wrap: %v; "+
+			"label has been bound into the AAD, which breaks vault's own "+
+			"fallback to the unlabeled KeyWrapper methods", err)
+	}
+}

--- a/internal/lineage/grant_test.go
+++ b/internal/lineage/grant_test.go
@@ -7,7 +7,12 @@ package lineage
 
 import (
 	"os"
+	"os/exec"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
 )
 
 // The gate-logic tests live with mountManager (internal/cli), against
@@ -53,5 +58,107 @@ func TestFIFOHoldersNoHoldersOnUntouchedPath(t *testing.T) {
 	}
 	if len(holders) != 0 {
 		t.Errorf("holders = %v for a path nothing holds, want none", holders)
+	}
+}
+
+// TestFIFOHoldersSeesARealHolderAndExcludesSelf is the positive half of the
+// primitive the Tier 3-4 real-vs-decoy gate reads (internal/cli/mountgrants.go
+// calls this for real; the gate-logic tests there fake it through
+// grantHoldersFn, so this file is the only place the kernel walk itself is
+// observed).
+//
+// The one test that existed pointed at a path nothing holds, so pids was
+// always nil and the whole positive contract went unenforced — a stub
+// `return nil, true` passed it. What that stub would do in production is
+// serve decoy content to a legitimately granted reader forever, since a
+// holder set that never contains anyone can never contain the grant's tree.
+//
+// The writer side is opened by the TEST process on purpose. That is not a
+// convenience: it reproduces the exact condition FIFOHolders documents as its
+// reason for excluding the caller — "the agent holds the write side of its own
+// mount at scan time". A self-exclusion regression would put the agent's own
+// pid in the holder set of every mount it serves.
+func TestFIFOHoldersSeesARealHolderAndExcludesSelf(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mount.fifo")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	// A real FIFO that exists but nobody has opened — distinct from the
+	// nonexistent path above, and the state every mount is in between serves.
+	holders, ok := FIFOHolders(path)
+	if !ok {
+		t.Skip("holder enumeration reported structural uncertainty on this machine; the gate would fail closed")
+	}
+	if len(holders) != 0 {
+		t.Fatalf("holders = %v on a FIFO nobody has opened, want none", holders)
+	}
+
+	cmd := exec.Command("cat", path)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting holder: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+	holder := int32(cmd.Process.Pid) // #nosec G115 -- a pid always fits int32 on darwin
+
+	// cat blocks in open() until a writer appears, and a blocked open holds no
+	// fd yet. Connect the write end so its open completes and it genuinely
+	// holds the read fd — same rendezvous TestPathHeldOpenSeesRealHolder...
+	// relies on.
+	opened := make(chan *os.File, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err != nil {
+			openErr <- err
+			return
+		}
+		opened <- f
+	}()
+	var w *os.File
+	select {
+	case w = <-opened:
+	case err := <-openErr:
+		t.Fatalf("opening for write: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the holder to connect")
+	}
+	defer func() { _ = w.Close() }()
+
+	// Both opens return at the rendezvous, but "returned" and "visible in the
+	// fd table proc_pidfdinfo reports" are not the same instant. Poll rather
+	// than assert once: this guards a security gate, and a flaky test on one
+	// is worse than a slow one. Self-exclusion is checked on every pass, since
+	// a violation there is not timing-dependent.
+	deadline := time.Now().Add(5 * time.Second)
+	self := int32(os.Getpid()) // #nosec G115 -- a pid always fits int32 on darwin
+	var sawHolder, lastOK bool
+	var last []int32
+	for time.Now().Before(deadline) {
+		last, lastOK = FIFOHolders(path)
+		if !lastOK {
+			t.Skip("holder enumeration reported structural uncertainty mid-test; the gate would fail closed")
+		}
+		for _, p := range last {
+			if p == self {
+				t.Fatalf("FIFOHolders returned the calling process (pid %d) while it held the write side; "+
+					"the agent would appear as a holder of every mount it serves", self)
+			}
+			if p == holder {
+				sawHolder = true
+			}
+		}
+		if sawHolder {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !sawHolder {
+		t.Errorf("FIFOHolders = %v, missing pid %d (cat) which provably holds the FIFO's read end; "+
+			"a missed holder means a granted reader is served decoys", last, holder)
 	}
 }

--- a/internal/lineage/lineage_test.go
+++ b/internal/lineage/lineage_test.go
@@ -63,9 +63,25 @@ func TestIdentifyFIFOReaderFindsRealReader(t *testing.T) {
 	}
 	defer f.Close()
 
-	pid, execPath, ok := IdentifyFIFOReader(path)
+	// Poll rather than probe once: the write-open returning means cat's
+	// read-open COMPLETED, but "completed" and "visible in the fd table
+	// proc_pidfdinfo reports" are not the same instant, and under parallel
+	// CI load the gap is real — this test failed single-shot on a loaded
+	// macOS runner (2026-08-07) with the reader provably connected. Same
+	// rendezvous-vs-fd-table reasoning as TestFIFOHoldersSeesARealHolder.
+	var pid int32
+	var execPath string
+	var ok bool
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		pid, execPath, ok = IdentifyFIFOReader(path)
+		if ok || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 	if !ok {
-		t.Fatal("IdentifyFIFOReader did not find the connected reader")
+		t.Fatal("IdentifyFIFOReader did not find the connected reader within 5s")
 	}
 	if pid != int32(cmd.Process.Pid) {
 		t.Errorf("identified pid = %d, want %d (the real reader)", pid, cmd.Process.Pid)

--- a/internal/migrate/agentcache_test.go
+++ b/internal/migrate/agentcache_test.go
@@ -130,8 +130,11 @@ func TestOverlappingNeedlesSpliceLongestFirst(t *testing.T) {
 }
 
 // The rewrite lands by rename, which replaces the path. An agent still
-// holding the old descriptor would keep appending to an unlinked inode.
-func TestCleanAgentCachesSkipsAFileWrittenUnderIt(t *testing.T) {
+// holding the old descriptor would keep appending to an unlinked inode —
+// hence the live-writer check this test's fixture approaches but, as written,
+// deliberately does not trigger (see the assertions below). Named for what it
+// actually establishes rather than for the skip it never provokes.
+func TestCleanAgentCachesKeepsContentAppendedBeforeTheSweep(t *testing.T) {
 	home := t.TempDir()
 	path := filepath.Join(home, ".claude", "projects", "p", "live.jsonl")
 	writeCacheTree(t, path, `{"text":"`+cacheKey+`"}`+"\n")
@@ -155,13 +158,33 @@ func TestCleanAgentCachesSkipsAFileWrittenUnderIt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The append happened before the sweep read the file, so this run should
-	// succeed; what must hold either way is that nothing appended is lost.
-	if strings.Contains(readCacheFile(t, path), cacheKey) && len(got.Edited) > 0 {
-		t.Error("reported an edit but the credential is still there")
+	// The append happens BEFORE the sweep, so the live-writer check (which
+	// compares a stat taken during the walk against one taken just before the
+	// rename) must not fire: this run has to succeed outright. The mid-sweep
+	// race the check actually guards sits between jit's read and its rename
+	// and is not reproducible deterministically from outside the package, so
+	// what is pinned here is the surrounding contract — the sweep edits the
+	// file, the credential goes, and nothing written before it started is lost.
+	//
+	// The assertion used to be `credential still present && len(Edited) > 0`,
+	// a conjunction no implementation can fail: a no-op sweep leaves Edited
+	// empty (second clause false) and a working one removes the credential
+	// (first clause false). Skipped — the record this test is named for — was
+	// never inspected at all.
+	after := readCacheFile(t, path)
+	if strings.Contains(after, cacheKey) {
+		t.Errorf("the credential survived the sweep: %q", after)
 	}
-	if !strings.Contains(readCacheFile(t, path), "later") {
+	if !strings.Contains(after, "later") {
 		t.Error("content appended before the sweep was lost")
+	}
+	if len(got.Edited) != 1 {
+		t.Errorf("Edited = %+v, want exactly one edit", got.Edited)
+	}
+	if len(got.Skipped) != 0 {
+		t.Errorf("Skipped = %+v, want none; the append preceded the sweep, so the "+
+			"live-writer check must not fire — a stale stat comparison would "+
+			"make every already-appended file permanently unsweepable", got.Skipped)
 	}
 }
 

--- a/internal/migrate/apply_test.go
+++ b/internal/migrate/apply_test.go
@@ -228,6 +228,15 @@ func TestDiscoverEnvFilesSkipsOwnBackupFiles(t *testing.T) {
 		t.Fatalf("ApplyEnvFile: %v", err)
 	}
 
+	// ApplyEnvFile's backup goes to the VAULT, under "_backups/<name>.jit-bak-<ts>"
+	// (shellconfig.go) — deliberately, since a plaintext sibling would itself
+	// be an unencrypted copy of the credential. So no ".env.jit-bak-<ts>" ever
+	// appeared in root, and this test — named for exactly that file — never
+	// exercised the jitBackupMarker half of isJitGeneratedEnvArtifact at all;
+	// it passed on the .pointers half alone, which the test above already
+	// covers. Write the artifact by hand so the marker check is observed.
+	writeFile(t, filepath.Join(root, ".env.jit-bak-1"), "A=1\n")
+
 	found, err := DiscoverEnvFiles(root)
 	if err != nil {
 		t.Fatalf("DiscoverEnvFiles: %v", err)

--- a/internal/mount/mount_test.go
+++ b/internal/mount/mount_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -589,9 +590,21 @@ func TestServeCallsOnReaderConnectedBeforeWriting(t *testing.T) {
 		t.Fatalf("CreateFIFO: %v", err)
 	}
 
-	var calls int
-	onReaderConnected := func() { calls++ }
-	content := func() []byte { return []byte("A=1\n") }
+	// A COUNT cannot witness an ordering claim: `calls != 2` holds just as
+	// well with the hook moved below the write, which is precisely the
+	// regression this test exists to catch. Record the sequence instead.
+	// provideContent is the proxy for "about to write" — Serve cannot write a
+	// byte it has not asked for yet — so "connected" preceding "content" in
+	// every cycle is the property, not merely that both happened.
+	var mu sync.Mutex
+	var events []string
+	record := func(what string) {
+		mu.Lock()
+		defer mu.Unlock()
+		events = append(events, what)
+	}
+	onReaderConnected := func() { record("connected") }
+	content := func() []byte { record("content"); return []byte("A=1\n") }
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -608,8 +621,15 @@ func TestServeCallsOnReaderConnectedBeforeWriting(t *testing.T) {
 		t.Fatal("Serve did not exit within 5s of cancellation")
 	}
 
-	if calls != 2 {
-		t.Errorf("onReaderConnected called %d times, want 2 (once per reader cycle)", calls)
+	mu.Lock()
+	got := strings.Join(events, ",")
+	mu.Unlock()
+	const want = "connected,content,connected,content"
+	if got != want {
+		t.Errorf("callback sequence = %q, want %q; onReaderConnected must fire "+
+			"strictly before Serve asks for content, once per reader cycle, or a "+
+			"reader blocked on read() can receive data before the decoy gate has "+
+			"decided what to serve", got, want)
 	}
 }
 

--- a/internal/wrap/plugins_doc_test.go
+++ b/internal/wrap/plugins_doc_test.go
@@ -6,6 +6,7 @@ package wrap
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -58,6 +59,54 @@ func TestPluginsDocListsEveryCatalogTool(t *testing.T) {
 			if _, err := os.Stat(filepath.Join("..", "..", "docs", "wrap", tool+".md")); err == nil {
 				t.Errorf("catalog tool %q must NOT also have a docs/wrap/%s.md — that filename is the exact CLAUDE.md collision docFileOverride exists to avoid", tool, tool)
 			}
+		}
+	}
+}
+
+// docRowTool matches a catalog table row's first cell in docs/wrap/index.md:
+// a backticked tool name linked to its own page, e.g.
+//
+//	| [`gh`](./gh.md) | `GH_TOKEN` | ... |
+//
+// Anchored at the line start so prose elsewhere in the page — which mentions
+// plenty of tool names jit does not wrap — cannot be mistaken for a row.
+var docRowTool = regexp.MustCompile(`(?m)^\| \[` + "`" + `([^` + "`" + `]+)` + "`" + `\]\(\./([^)]+)\.md\)`)
+
+// TestPluginsDocListsNoUncatalogedTool is the direction
+// TestPluginsDocListsEveryCatalogTool's comment claims and does not check.
+// That test iterates CatalogTools(), so it only ever proves catalog ⊆ docs; a
+// docs/wrap/ row for a tool that was REMOVED from the catalog passes it
+// silently, leaving a public page promising `jit wrap <tool>` for a tool the
+// binary answers "unknown tool" to.
+//
+// Also pins each row's link to the stem docFileStem resolves to, so a row can
+// never point at docs/wrap/claude.md — the filename whose mere existence turns
+// a docs page into directory-scoped CLAUDE.md project instructions, per
+// docFileOverride above.
+func TestPluginsDocListsNoUncatalogedTool(t *testing.T) {
+	data, err := os.ReadFile(filepath.Join("..", "..", "docs", "wrap", "index.md"))
+	if err != nil {
+		t.Fatalf("docs/wrap/index.md must exist and list every catalog tool: %v", err)
+	}
+
+	known := make(map[string]bool, len(CatalogTools()))
+	for _, tool := range CatalogTools() {
+		known[tool] = true
+	}
+
+	rows := docRowTool.FindAllStringSubmatch(string(data), -1)
+	if len(rows) == 0 {
+		t.Fatal("no catalog table rows matched in docs/wrap/index.md — the table format changed and this guard is no longer reading it")
+	}
+	for _, row := range rows {
+		tool, stem := row[1], row[2]
+		if !known[tool] {
+			t.Errorf("docs/wrap/index.md lists %q, which is not in the catalog; "+
+				"the page promises `jit wrap %s` for a tool the binary rejects", tool, tool)
+			continue
+		}
+		if want := docFileStem(tool); stem != want {
+			t.Errorf("docs/wrap/index.md links %q to ./%s.md, want ./%s.md", tool, stem, want)
 		}
 	}
 }


### PR DESCRIPTION
First tranche off the 2026-08-06 review handoff. **Tests only — no production code changed.**

This is the prerequisite for the structural work: those refactors are behaviour-preserving, so the suite *is* the net, and the net had holes in the two places it mattered most.

## What was unenforced

**The AEAD interop contract.** `vault.LabeledKeyWrapper` states it outright — "Both wrappers (agent and keychainwrap) MUST bind it identically" — and nothing checked it. The crossing is routine: whether a secret's DEK was wrapped through the agent or through keychainwrap depends only on whether the service was running when it was written, so one vault holds both. Both packages carry their own full copy of `seal`/`open`, each citing the other, and both report a mismatch with the identical text `"unwrap failed (wrong MEK, wrong class, or corrupted data)"` — so a divergence reads as vault corruption, on some secrets and not others.

Driven through the exported wrappers rather than `seal`/`open` (unexported in both), so it covers nonce placement, nonce size and cipher choice too. Deliberately **not** fixed by centralising into `vault.WrapAAD`: `internal/agent` does not import `internal/vault`, and centralising would cover one line of a fully duplicated pair. The new `agent` import is test-only; agent's production imports are unchanged.

**`FIFOHolders`.** The only test of the primitive the Tier 3–4 real-vs-decoy gate reads pointed at a path nothing holds, so `pids` was always nil — a stub `return nil, true` passed it (verified). In production that stub serves decoys to a legitimately granted reader forever. The new test lets a real `cat` hold the read end and opens the write end from the test process, which reproduces the exact condition `FIFOHolders` documents as its reason for excluding the caller.

## The rest

Six assertions that could not fail, and two coverage holes — a doc-drift guard that only checked one direction, an ordering claim asserted with a call count, two tests building their expectation from the production expression under test, an unsatisfiable conjunction, a fixture missing the file its test was named for, two hand-maintained registries whose "every X" tests meant "every X someone remembered to register", and a mid-test `t.Skip` that discarded the negative half of the signature check on exactly the machines where nobody is watching.

## Verification

All 13 assertions are mutation-verified — the plausible wrong implementation applied, and the test confirmed to fail. Each mutation was checked to have actually applied and compiled; one attempt silently didn't apply and its `ok` proved nothing until redone.

Full suite green under `-race`. `gofmt`, `go vet`, pinned `staticcheck` and `gosec` clean, no `go.mod` drift. `FIFOHolders` additionally verified at `-count=10` under `-race`, since `internal/guard` already has an intermittent flake and this guards a security gate.

## Two residual gaps, flagged in the code

- `SkipLive`'s real window sits between jit's read and its rename and is not reproducible deterministically from outside the package. The surrounding contract is pinned instead of adding a flaky test on a path that rewrites credential files.
- `TestVerifyStagedSignature`'s positive half is still machine-dependent. Splitting it stopped the negative half being swallowed, but the durable fix is pipeline-side (**F2**): nothing in CI or `release.yml` compares what goreleaser/quill *produces* against the `codesign` requirement `upgrade.go` *enforces*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4