### PR TITLE
release: verify the signature against the checker, and stop the Team ID being a one-way door (tranche B)

### DIFF
--- a/.github/workflows/authorship-guard.yml
+++ b/.github/workflows/authorship-guard.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       # fetch-depth: 0 so the base..head range below actually has both endpoints.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
@@ -141,15 +141,15 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           # Pin the goreleaser MAJOR, not "latest", so CI's config check and
@@ -158,7 +158,7 @@ jobs:
           args: check
 
       - name: Snapshot build (no publish, no signing)
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           # Pin the goreleaser MAJOR, not "latest", so CI's config check and

--- a/.github/workflows/notarize-spike.yml
+++ b/.github/workflows/notarize-spike.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: spike/notarize-e2e/go.mod
 
@@ -49,9 +49,24 @@ jobs:
             exit 1
           fi
 
-      - name: Install quill (pinned — same signer the release path embeds)
+      # Fetch the pinned release asset and check its digest, rather than piping
+      # an installer script straight into sh. get.anchore.io/quill is an
+      # unpinned, mutable endpoint, and this job then hands the process it
+      # installs both the Developer ID .p12 and the notary .p8 — so whoever can
+      # change that URL's contents can take the signing key. The version was
+      # already pinned; what was not pinned was the code doing the installing.
+      - name: Install quill (pinned by digest — same signer the release path embeds)
+        env:
+          QUILL_VERSION: "0.7.1"
+          QUILL_SHA256: "086cfb3fc69a305d55d9aa5131bed7739d706bbd8bab78c18d011e7260111e96"
         run: |
-          curl -sSfL https://get.anchore.io/quill | sh -s -- -b "$RUNNER_TEMP/bin" v0.7.1
+          set -euo pipefail
+          archive="$RUNNER_TEMP/quill.tar.gz"
+          curl -sSfL -o "$archive" \
+            "https://github.com/anchore/quill/releases/download/v${QUILL_VERSION}/quill_${QUILL_VERSION}_darwin_arm64.tar.gz"
+          echo "${QUILL_SHA256}  ${archive}" | shasum -a 256 --check -
+          mkdir -p "$RUNNER_TEMP/bin"
+          tar -xzf "$archive" -C "$RUNNER_TEMP/bin" quill
           echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
 
       - name: Run the probe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,59 @@ jobs:
           MACOS_NOTARY_ISSUER_ID: ${{ secrets.MACOS_NOTARY_ISSUER_ID }}
           MACOS_NOTARY_KEY_ID: ${{ secrets.MACOS_NOTARY_KEY_ID }}
           MACOS_NOTARY_KEY: ${{ secrets.MACOS_NOTARY_KEY }}
+
+      # The signature the release actually carries, checked by the code that
+      # will judge it — not by the code that wrote it.
+      #
+      # The preflight above proves a signing secret was PRESENT. It cannot
+      # prove the result satisfies `codesign --verify --strict -R`, because
+      # quill writes the signature and Apple's codesign is what
+      # verifyStagedSignature runs against it on every user's machine. Until
+      # now the first machine to ever make that comparison was a user's, after
+      # download — and the failure mode is the worst one this repo has: a
+      # rejected signature traps every installed copy out of `jit upgrade`,
+      # with an error naming the downloaded file rather than the cause.
+      #
+      # Deliberately the binary from the TARBALL, not from dist/'s build
+      # directory: the tarball is the artifact users receive, and it is the
+      # one whose bytes could differ. And deliberately `jit doctor` rather than
+      # a hand-written codesign line — doctor's binarySignature() calls
+      # signatureRequirement(upgradeTeamID), the same function
+      # verifyStagedSignature uses, so this check cannot drift from the client
+      # it is standing in for. A hand-rolled requirement string here would be
+      # a second copy free to disagree with production, which is the whole
+      # class of bug being closed.
+      - name: Verify the released binary satisfies jit upgrade's own requirement
+        run: |
+          set -euo pipefail
+          archive=$(find dist -type f -name 'jitpass_darwin_arm64.tar.gz' | head -1)
+          if [ -z "$archive" ]; then
+            echo "::error::no release tarball found under dist/"
+            exit 1
+          fi
+          workdir=$(mktemp -d)
+          tar -xzf "$archive" -C "$workdir"
+          bin="$workdir/jit"
+          if [ ! -x "$bin" ]; then
+            echo "::error::the release tarball contains no executable jit"
+            exit 1
+          fi
+          # doctor exits non-zero when it finds unrelated problems (no vault
+          # and no profiles on a fresh runner), so its verdict is not the
+          # signal — the tool.signature field is. Capture, then assert.
+          report=$("$bin" doctor --format json 2>/dev/null || true)
+          got=$(printf '%s' "$report" | jq -r '.tool.signature // ""')
+          want="signed CZC6BH93GJ"
+          if [ "$got" != "$want" ]; then
+            echo "::error::the published binary reports signature '$got', want '$want' — jit upgrade would refuse this release on every installed copy. The release stays a DRAFT and is not reachable via /releases/latest."
+            exit 1
+          fi
+          echo "verified: $got"
+
+      # Only now does the release become the one `jit upgrade` can see.
+      # Anything that failed above leaves a draft: invisible to
+      # /releases/latest, and deletable without ever having reached a user.
+      - name: Publish the verified release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,28 @@ jobs:
     # Apple's verdict and cited a `timeout: 30m` that no longer exists.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      # Actions are pinned to full commit SHAs, not tags. A tag is mutable and
+      # repointable by its owner, so `@v4` in THIS job — the one job in the
+      # repo that holds MACOS_SIGN_P12 and the Developer ID private key — is a
+      # standing grant of that key to whoever controls the tag. ci.yml already
+      # pins its three Go tools to exact patch versions for a weaker reason
+      # (reproducible results); the actions themselves floated.
+      #
+      # The trailing comment is the human-readable version. To bump one,
+      # resolve the new tag to its SHA rather than editing the comment.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
+          # The signed build must not restore a build cache written by an
+          # unrelated main-branch run. The release is the one build in the repo
+          # where "where did these object files come from" has a security
+          # answer, and a cache hit makes it unauditable for no real saving on
+          # a job that runs a handful of times a month.
+          cache: false
 
       # Never ship unsigned (CLAUDE.md), enforced BEFORE the build rather than
       # on the user's machine after download.
@@ -67,7 +82,7 @@ jobs:
             exit 1
           fi
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           # Pin the goreleaser MAJOR, not "latest": a future v3 with breaking
@@ -102,12 +117,17 @@ jobs:
       # Deliberately the binary from the TARBALL, not from dist/'s build
       # directory: the tarball is the artifact users receive, and it is the
       # one whose bytes could differ. And deliberately `jit doctor` rather than
-      # a hand-written codesign line — doctor's binarySignature() calls
-      # signatureRequirement(upgradeTeamID), the same function
+      # a hand-written codesign line — doctor's binarySignature() builds its
+      # requirement with signatureRequirement(), the same function
       # verifyStagedSignature uses, so this check cannot drift from the client
       # it is standing in for. A hand-rolled requirement string here would be
       # a second copy free to disagree with production, which is the whole
       # class of bug being closed.
+      #
+      # The expected value names upgradeTeamIDs[0] specifically, not "any
+      # accepted team": during a certificate migration the list also accepts a
+      # successor, and a release accidentally signed with the outgoing identity
+      # must fail here rather than pass as "signed, close enough".
       - name: Verify the released binary satisfies jit upgrade's own requirement
         run: |
           set -euo pipefail

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,14 @@ project_name: jitpass
 
 before:
   hooks:
-    - go mod tidy
+    # download, NOT tidy. `go mod tidy` MUTATES go.mod/go.sum inside the
+    # release build, so the artifact that gets Developer ID signed is built
+    # from a module graph that differs from the reviewed, committed one — and
+    # silently, since nothing reads the result. It was also redundant: ci.yml
+    # already runs `go mod verify && go mod tidy` and fails the build on any
+    # drift, and release.yml gates the publish on that whole pipeline.
+    # `go mod download` pre-fetches the same dependencies and changes nothing.
+    - go mod download
 
 builds:
   # Apple Silicon only, on purpose: we have no Intel hardware to test a

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -84,6 +84,31 @@ release:
   github:
     owner: jitpass
     name: jit
+  # Published as a DRAFT, then undrafted by release.yml only after the
+  # artifact it actually produced has been verified against the very
+  # requirement `jit upgrade` enforces on the user's machine.
+  #
+  # The two halves of the signing story are written by different tools: quill
+  # (Anchore's reimplementation of Apple code signing, via the notarize.macos
+  # path above) PRODUCES the signature, and Apple's own `codesign --verify
+  # --strict -R` CONSUMES it in verifyStagedSignature. Nothing compared them.
+  # The preflight in release.yml proves a secret was PRESENT; it cannot prove
+  # the bytes quill emitted satisfy the requirement, and no test can — the
+  # positive half of TestVerifyStagedSignature validates the requirement's
+  # form against an arbitrary Apple-signed .app BUNDLE and skips outright on
+  # a machine with none, which is the CI case.
+  #
+  # Draft is what makes the check safe rather than merely informative:
+  # /releases/latest EXCLUDES drafts, and `jit upgrade` resolves exactly that
+  # URL. So a release that fails verification is never the one any installed
+  # copy can see, and the fix is to delete a draft rather than to race a bad
+  # binary that is already live.
+  #
+  # Note the interaction with keep-existing below: this governs releases this
+  # workflow CREATES. Re-running against a tag whose release is already
+  # published leaves it published — the gate protects first publication, not
+  # a release someone already undrafted by hand.
+  draft: true
   # keep-existing: when a release for the tag already exists (e.g. re-running
   # the workflow to backfill assets onto a hand-written release), keep its
   # name and notes and just upload the artifacts.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -30,9 +30,16 @@ To verify the download, `checksums.txt` on the
 [release page](https://github.com/jitpass/jit/releases/latest) has the
 SHA-256s: `shasum -a 256 --check checksums.txt --ignore-missing`.
 
-Release binaries are signed with a Developer ID (`Meni Tasa, CZC6BH93GJ`), so
-you can confirm their provenance with
-`codesign -dv --verbose=2 $(command -v jit)`. The `curl` install above is
+Release binaries are signed with a Developer ID (`Meni Tasa, CZC6BH93GJ`). To
+confirm that signature, run `jit doctor` and read its `jit` line: it reports
+`signed CZC6BH93GJ` using the same check `jit upgrade` runs before it will
+install anything, so it cannot disagree with what jit itself enforces.
+
+Note that `codesign -dv` *displays* a signature without validating it — a
+tampered binary still prints the right `Authority` line. If you would rather
+check before running the binary at all, `codesign --verify --strict
+$(command -v jit)` verifies its integrity and prints nothing on success. The
+`curl` install above is
 **quarantine-free**: macOS only sets the quarantine flag on downloads made by a
 browser or other quarantine-aware app, not by `curl`, so the binary runs
 without a Gatekeeper prompt. (Releases are not notarized, so a download made by

--- a/internal/cli/doctorsections.go
+++ b/internal/cli/doctorsections.go
@@ -41,6 +41,13 @@ func runningTool() doctorTool {
 // doesn't satisfy the requirement can never self-upgrade, and the error it
 // gives names the downloaded file rather than the installed one — so the
 // cause is invisible exactly when it matters.
+// Reports WHICH accepted team signed it, not merely that some accepted team
+// did. The distinction matters once upgradeTeamIDs holds a successor during a
+// certificate migration: "signed <current>" and "signed <successor>" are
+// different facts about a binary, and release.yml's post-publish gate asserts
+// on the current one specifically — so a release accidentally signed with the
+// outgoing identity fails that gate instead of passing as "signed, close
+// enough".
 var binarySignature = func() string {
 	exe, err := os.Executable()
 	if err != nil {
@@ -48,12 +55,14 @@ var binarySignature = func() string {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	// #nosec G204 -- fixed system binary; the only variable is our own path
-	if err := exec.CommandContext(ctx, "/usr/bin/codesign",
-		"--verify", "--strict", "-R", signatureRequirement(upgradeTeamID), exe).Run(); err != nil {
-		return "unsigned or not a jit release build"
+	for _, team := range upgradeTeamIDs {
+		// #nosec G204 -- fixed system binary; the only variable is our own path
+		if err := exec.CommandContext(ctx, "/usr/bin/codesign",
+			"--verify", "--strict", "-R", signatureRequirement(team), exe).Run(); err == nil {
+			return "signed " + team
+		}
 	}
-	return "signed " + upgradeTeamID
+	return "unsigned or not a jit release build"
 }
 
 // vaultMasterKeyPresence probes the keychain for this Mac's master encryption

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -661,12 +661,29 @@ func init() {
 	rootCmd.AddCommand(upgradeCmd)
 }
 
-// upgradeTeamID is the Apple Developer Team ID every published jit release is
-// signed with (TECH_STACK.md §5). Hardcoded on purpose, exactly like
-// upgradeRepoOwner/upgradeRepoName above: this command installs jitpass/jit's
-// own releases and nothing else, so the identity it should accept is a
-// constant, not something read from the artifact it is trying to authenticate.
-const upgradeTeamID = "CZC6BH93GJ"
+// upgradeTeamIDs are the Apple Developer Team IDs a published jit release may
+// be signed with (TECH_STACK.md §5), most current first. Hardcoded on purpose,
+// exactly like upgradeRepoOwner/upgradeRepoName above: this command installs
+// jitpass/jit's own releases and nothing else, so the identity it accepts is a
+// constant, not something read from the artifact it is authenticating.
+//
+// A LIST rather than a single constant, because this is the one setting in the
+// repo whose mistake is unrecoverable. The code that rejects a release lives in
+// the ALREADY-INSTALLED binary, so if the certificate is ever re-issued under a
+// different Team ID, every copy in the field rejects every future release
+// forever and no new release can fix it — the fix would have to arrive through
+// the channel it just closed. (The signing identity has already changed once;
+// a stale Z8ADLGGPY6 is still in the keychain.)
+//
+// So a Team ID migration is: add the successor here, ship and let that release
+// propagate, and only THEN switch the signing certificate. Removing the old ID
+// is a separate, later change — once nothing worth upgrading is still running a
+// binary that predates the addition.
+//
+// upgradeTeamIDs[0] is the team releases are CURRENTLY signed with, and is what
+// doctor reports and what release.yml's post-publish gate asserts on; the rest
+// are accepted but not expected.
+var upgradeTeamIDs = []string{"CZC6BH93GJ"}
 
 // verifyStagedSignature refuses to install a binary that isn't a genuine,
 // intact, Developer-ID-signed jit release.
@@ -691,7 +708,8 @@ const upgradeTeamID = "CZC6BH93GJ"
 // deliberately no override flag — a switch that turns off signature checking
 // on a security tool's self-updater is the thing an attacker asks the user to
 // pass.
-// signatureRequirement builds the codesign requirement for a team.
+
+// signatureRequirement builds the codesign requirement for one team.
 //
 // The leading "=" is codesign's marker for an INLINE requirement; without it,
 // -R treats the argument as a path to a requirements FILE and fails with
@@ -700,20 +718,70 @@ const upgradeTeamID = "CZC6BH93GJ"
 // genuine ones, turning `jit upgrade` into a command that can never succeed.
 // Its own function so a test can exercise the exact string production uses,
 // rather than a copy that agrees with itself.
+//
+// The two OID clauses are what make this a DEVELOPER ID requirement rather
+// than merely "Apple-anchored code carrying our OU":
+//
+//	1.2.840.113635.100.6.2.6  Developer ID intermediate CA marker
+//	1.2.840.113635.100.6.1.13 Developer ID Application leaf marker
+//
+// Without them an Apple DEVELOPMENT certificate from the same team satisfies
+// the requirement — which is precisely the wrong-identity-out-of-the-keychain
+// accident this check exists to catch, and produces a binary that is
+// undistributable in the field while looking correct here. Verified both
+// directions against real signatures: a genuine Developer ID application still
+// passes, and Apple-signed non-Developer-ID code (/bin/ls, "Software Signing")
+// passes `anchor apple generic` alone but fails once these clauses are added.
 func signatureRequirement(teamID string) string {
-	return fmt.Sprintf("=anchor apple generic and certificate leaf[subject.OU] = %q", teamID)
+	return fmt.Sprintf("=%s and %s and certificate leaf[subject.OU] = %q",
+		appleAnchor, developerIDMarkers, teamID)
 }
 
+// appleAnchor and developerIDMarkers are the two halves of the requirement
+// that are not about WHICH team signed the binary. Named separately so a test
+// can exercise the markers on their own: against any real binary, the OU
+// clause alone already rejects everything not signed by us, so a requirement
+// tested only as a whole passes identically with the markers present or
+// absent — the markers' contribution is invisible unless it is isolated.
+const (
+	appleAnchor = "anchor apple generic"
+	// The Developer ID marker OIDs: the intermediate CA marker on the chain's
+	// certificate 1, and the Developer ID Application marker on the leaf.
+	// Without both, an Apple DEVELOPMENT certificate from the same team
+	// satisfies the requirement — the wrong-identity-from-the-keychain
+	// accident this check exists to catch, which produces a binary that is
+	// undistributable in the field while looking correct at signing time.
+	developerIDMarkers = "certificate 1[field.1.2.840.113635.100.6.2.6] exists" +
+		" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"
+)
+
+// verifyStagedSignature refuses to install a binary that isn't a genuine,
+// intact, Developer-ID-signed jit release. See the requirement above and the
+// trust-chain note below it.
+//
+// Tries each accepted team in turn rather than building one requirement with
+// an `or` branch: the string handed to codesign is then always the exact shape
+// TestSignatureRequirementFormIsInline pins, and a successor Team ID cannot
+// change the parse of the clause protecting the current one. Two invocations
+// of codesign in the worst case is not a cost worth optimising against that.
 func verifyStagedSignature(ctx context.Context, staged string) error {
-	req := signatureRequirement(upgradeTeamID)
-	cmd := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "-R", req, staged) // #nosec G204 -- fixed system binary; the only variable is jit's own staged temp path
-	output, err := cmd.CombinedOutput()
-	if err == nil {
-		return nil
-	}
-	detail := strings.TrimSpace(string(output))
-	if detail == "" {
-		detail = err.Error()
+	var detail string
+	for _, team := range upgradeTeamIDs {
+		req := signatureRequirement(team)
+		cmd := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "-R", req, staged) // #nosec G204 -- fixed system binary; the only variable is jit's own staged temp path
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		// Report the FIRST team's rejection: upgradeTeamIDs[0] is what
+		// releases are currently signed with, so its failure is the one that
+		// describes what actually went wrong.
+		if detail == "" {
+			detail = strings.TrimSpace(string(output))
+			if detail == "" {
+				detail = err.Error()
+			}
+		}
 	}
 	return fmt.Errorf("the downloaded binary is not a signature-verified jit release (%s); "+
 		"refusing to install it. Download it yourself from %s if you believe this is wrong",

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -376,7 +376,7 @@ func writeTar(t *testing.T, tw *tar.Writer, name, body string) {
 //
 // This asserts the form alone: no codesign, no signed binary, no environment.
 func TestSignatureRequirementFormIsInline(t *testing.T) {
-	req := signatureRequirement(upgradeTeamID)
+	req := signatureRequirement(upgradeTeamIDs[0])
 
 	if !strings.HasPrefix(req, "=") {
 		t.Errorf("signatureRequirement() = %q, which does not start with \"=\" — codesign -R will read it as a file path, "+
@@ -384,13 +384,134 @@ func TestSignatureRequirementFormIsInline(t *testing.T) {
 	}
 	// The team ID has to actually be in there, or the requirement would accept
 	// any Apple-anchored signature — every notarized app on the internet.
-	if !strings.Contains(req, upgradeTeamID) {
-		t.Errorf("signatureRequirement() = %q, which does not name team %s; the requirement would accept any Apple-anchored code", req, upgradeTeamID)
+	if !strings.Contains(req, upgradeTeamIDs[0]) {
+		t.Errorf("signatureRequirement() = %q, which does not name team %s; the requirement would accept any Apple-anchored code", req, upgradeTeamIDs[0])
 	}
 	// And it must be anchored to Apple at all, or it degrades to "signed by
 	// someone claiming this OU".
 	if !strings.Contains(req, "anchor apple") {
 		t.Errorf("signatureRequirement() = %q, which is not anchored to Apple", req)
+	}
+	// The two marker OIDs are what make this a DEVELOPER ID requirement rather
+	// than "any Apple-anchored code carrying our OU". Without them an Apple
+	// Development certificate from the same team satisfies it — the
+	// wrong-identity-from-the-keychain accident the check exists to catch,
+	// which yields a binary undistributable in the field while looking correct
+	// at signing time.
+	for _, oid := range []string{
+		"certificate 1[field.1.2.840.113635.100.6.2.6] exists",     // Developer ID intermediate CA
+		"certificate leaf[field.1.2.840.113635.100.6.1.13] exists", // Developer ID Application leaf
+	} {
+		if !strings.Contains(req, oid) {
+			t.Errorf("signatureRequirement() = %q, missing the Developer ID marker %q; "+
+				"an Apple Development cert from the same team would satisfy it", req, oid)
+		}
+	}
+}
+
+// TestUpgradeTeamIDsHasACurrentTeam guards the ordering contract the rest of
+// the release path leans on: upgradeTeamIDs[0] is the team releases are
+// CURRENTLY signed with — what doctor reports and what release.yml's
+// post-publish gate asserts on — while later entries are accepted but not
+// expected, so a certificate migration can ship a successor-accepting release
+// BEFORE the switch.
+//
+// Emptying the list would make verifyStagedSignature's loop run zero times and
+// fall straight through to its error, turning `jit upgrade` into a command
+// that can never succeed on any binary.
+func TestUpgradeTeamIDsHasACurrentTeam(t *testing.T) {
+	if len(upgradeTeamIDs) == 0 {
+		t.Fatal("upgradeTeamIDs is empty; verifyStagedSignature would reject every release including genuine ones")
+	}
+	for _, team := range upgradeTeamIDs {
+		if team == "" {
+			t.Error("upgradeTeamIDs contains an empty team ID, which would build a requirement matching an absent OU")
+		}
+	}
+}
+
+// TestVerifyStagedSignatureAcceptsASuccessorTeam proves the migration
+// mechanism upgradeTeamIDs exists for: a binary signed by a team that is NOT
+// the current one, but IS on the accepted list, must install.
+//
+// This is the property that makes a certificate re-issue survivable. The code
+// that rejects a release lives in the already-installed binary, so the
+// successor has to be accepted by a version shipped BEFORE the switch — if
+// this path did not work, adding a successor would be a no-op and every
+// installed copy would reject every release signed with the new identity,
+// permanently, with no release able to fix it.
+//
+// Uses whatever Developer ID-signed code the machine has, standing in for a
+// successor-signed jit; the first entry is deliberately a team that matches
+// nothing, so a pass means the loop genuinely reached the second.
+func TestVerifyStagedSignatureAcceptsASuccessorTeam(t *testing.T) {
+	if _, err := os.Stat("/usr/bin/codesign"); err != nil {
+		t.Skip("codesign unavailable")
+	}
+	signed, team := findDeveloperIDSigned(t)
+	if signed == "" {
+		t.Skip("no Developer ID signed binary available to stand in for a successor-signed release")
+	}
+
+	original := upgradeTeamIDs
+	t.Cleanup(func() { upgradeTeamIDs = original })
+
+	upgradeTeamIDs = []string{"NOTOURTEAM", team}
+	if err := verifyStagedSignature(context.Background(), signed); err != nil {
+		t.Errorf("a binary signed by the second accepted team was rejected: %v; "+
+			"adding a successor Team ID would be a no-op and a certificate migration "+
+			"could never ship", err)
+	}
+
+	// And the list must still be a whitelist, not a formality: with neither
+	// entry matching, the same binary has to be refused.
+	upgradeTeamIDs = []string{"NOTOURTEAM", "ALSONOTOURS"}
+	if err := verifyStagedSignature(context.Background(), signed); err == nil {
+		t.Error("a binary signed by NO accepted team passed; the team list is not being enforced")
+	}
+}
+
+// TestDeveloperIDMarkersDiscriminate exercises the marker OIDs ON THEIR OWN,
+// against a signature every macOS machine has. /bin/ls is signed by Apple's
+// own "Software Signing" authority: genuinely Apple-anchored, and NOT a
+// Developer ID.
+//
+// Isolating them is the whole point. Testing the FULL requirement against any
+// real binary proves nothing about the markers, because the OU clause already
+// rejects everything not signed by our team — so such a test passes
+// identically whether the markers are present or absent, which is how a
+// requirement that had silently lost them would still look guarded.
+//
+// Structured as a pair on the same binary: the anchor alone must ACCEPT it
+// (otherwise the rejection below could be caused by anything at all), and the
+// anchor plus markers must REJECT it. That difference is attributable to the
+// markers and nothing else, and it never skips for want of a Developer
+// ID-signed app — unlike both halves of TestVerifyStagedSignature.
+func TestDeveloperIDMarkersDiscriminate(t *testing.T) {
+	const appleSigned = "/bin/ls"
+	if _, err := os.Stat("/usr/bin/codesign"); err != nil {
+		t.Skip("codesign unavailable")
+	}
+	if _, err := os.Stat(appleSigned); err != nil {
+		t.Skip(appleSigned + " unavailable")
+	}
+	ctx := context.Background()
+	verify := func(req string) error {
+		return exec.CommandContext(ctx, "/usr/bin/codesign",
+			"--verify", "--strict", "-R", req, appleSigned).Run()
+	}
+
+	// The control. Without it the assertion below could pass because the
+	// binary is unsigned, missing, or fails for some unrelated reason.
+	if err := verify("=" + appleAnchor); err != nil {
+		t.Skipf("%s does not satisfy a bare Apple anchor on this machine (%v); the comparison below would be meaningless", appleSigned, err)
+	}
+
+	if err := verify("=" + appleAnchor + " and " + developerIDMarkers); err == nil {
+		t.Errorf("%s satisfies the Apple anchor PLUS the Developer ID markers, but it is signed "+
+			"by Apple's Software Signing authority, not a Developer ID. The markers are not "+
+			"discriminating, so an Apple Development certificate from our own team would "+
+			"satisfy signatureRequirement too — the wrong-identity accident it exists to catch", appleSigned)
 	}
 }
 


### PR DESCRIPTION
Second tranche off the 2026-08-06 review handoff: **F2, then F3, in that order** — the ordering is load-bearing, since tightening the requirement without a pipeline-side check against the real artifact is how you brick every installed copy.

Best reviewed commit by commit.

## F2 — nothing compared what the pipeline produces against what the client demands

`grep -rn codesign .github/ scripts/ .goreleaser.yml` returned nothing. **quill** (Anchore's reimplementation of Apple code signing) writes the signature; Apple's own `codesign --verify --strict -R` judges it in `verifyStagedSignature`. The first machine to ever make that comparison was a user's, after download.

The existing preflight proves a signing secret was *present* — a different claim. And no test can close the gap: `TestVerifyStagedSignature`'s positive half validates the requirement's *form* against an arbitrary Apple-signed `.app` **bundle**, never a quill-signed **bare Mach-O**, and skips on a machine with none, which is the CI case.

The release now publishes as a **draft**; release.yml extracts `jit` from the tarball, asserts its own `doctor --format json` reports `tool.signature == "signed CZC6BH93GJ"`, and only then undrafts. `/releases/latest` excludes drafts and `jit upgrade` resolves exactly that URL, so a release that fails verification is never visible to any installed copy.

Deliberately `jit doctor` rather than a hand-written codesign line: `binarySignature()` builds its requirement with the same function `verifyStagedSignature` uses, so the gate cannot drift from the client it stands in for.

**Verified against a real snapshot build:** extraction, the doctor invocation and the jq path all resolve, and the step correctly *fails* on the unsigned snapshot. The positive direction needs the real secret and can only run in CI — which is the gap this closes, not a shortcut around it.

## F3 — the Team ID was a one-way door, and the requirement wasn't a Developer ID requirement

`upgradeTeamID` was a single constant. The code that rejects a release lives in the **already-installed** binary, so a certificate re-issued under a different Team ID means every copy in the field rejects every future release forever — the fix would have to arrive through the channel it just closed. The identity has already changed once (stale `Z8ADLGGPY6` in the keychain). Now a list: add the successor, ship, let it propagate, *then* switch certificates.

Separately the requirement was `anchor apple generic and certificate leaf[subject.OU] = "TEAM"`, which an Apple **Development** certificate from the same team also satisfies — exactly the wrong-identity-from-the-keychain accident the check exists to catch. Both Developer ID marker OIDs added.

**Validated against real signatures before being written into code**, since a requirement that rejects everything turns `jit upgrade` into a command that can never succeed: a genuine Developer ID application still passes, and `/bin/ls` passes the anchor alone but fails once the markers are added.

### One thing worth calling out in review

My first version of the marker test asserted the *full* requirement rejects `/bin/ls`. That was **vacuous** — the OU clause already rejects everything not signed by us, so it passed identically with the markers removed. The markers are now their own constant and the test compares anchor-alone (must accept) against anchor-plus-markers (must reject), so the difference is attributable to the markers and nothing else. It never skips, unlike both halves of the Developer ID coverage.

Mutation-verified: markers replaced with a no-op clause → the marker test; loop restricted to `upgradeTeamIDs[:1]` → the successor test.

## Supply chain and hermeticity

- Actions pinned to commit SHAs across all four workflows. A tag is repointable by its owner, so `@v4` in the job holding `MACOS_SIGN_P12` was a standing grant of the signing key.
- quill installed by pinned asset + SHA-256 instead of piping `get.anchore.io/quill` into `sh`, in the job that then handles the `.p12` and the notary `.p8`. The version was pinned; the installer was not.
- `cache: false` on the signed build, and `go mod tidy` → `go mod download` — tidy mutated `go.mod` inside the release build, so the signed artifact came from a module graph differing from the committed one, silently.
- `install.md` told users to verify with `codesign -dv`, which displays a signature and validates nothing.

## Verification

Full suite green under `-race`; `gofmt`, `go vet`, pinned `staticcheck` and `gosec` clean; every workflow and `.goreleaser.yml` parses; `goreleaser check` passes; full snapshot build succeeds and leaves `go.mod` untouched.

## Known limit, stated in the config

`draft` governs releases this workflow **creates**. Re-running against a tag whose release is already published leaves it published — the gate protects first publication, not a release someone undrafted by hand.

## Still needs you (no agent can see these)

Repo settings: whether the signing secrets are present and non-empty, and whether a `v*` tag ruleset exists. `release.yml` gates a release's *content* on CI but not *who may create the tag*, so today anyone with write access can produce a Developer-ID-signed release from a commit that never saw a PR.

Merges cleanly with #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4