### PR TITLE
guard: render the zsh admit test from audit's spec, not beside it

### DIFF
--- a/internal/audit/shellhistory.go
+++ b/internal/audit/shellhistory.go
@@ -493,7 +493,7 @@ const (
 	historyAdmitJWTLiteral   = "eyJ"
 	// historyTokenRunClass must stay in step with the byte test in
 	// historyLineMayHoldToken; a test compares them across every byte value.
-	historyTokenRunClass = "[A-Za-z0-9_-]"
+	historyTokenRunClass = "[A-Za-z0-9_-]" // #nosec G101 -- a character class, not a credential
 )
 
 func historyLineMayHoldToken(line string) bool {

--- a/internal/audit/shellhistory.go
+++ b/internal/audit/shellhistory.go
@@ -452,9 +452,54 @@ func isAllDigits(s string) bool {
 //     "SG.xxxxxxxxxx.yyyyyyyyyy" has dot-separated segments of exactly 10, and
 //     Slack's "xoxb-" plus 10 body characters is a 15-long run. "." is
 //     deliberately NOT part of a run, or every dotted hostname would qualify.
+//
+// HistoryAdmitSpec is the admit test stated as DATA, so a second
+// implementation can be built from it rather than retyped beside it.
+//
+// internal/guard transplants this exact test into a zsh `zshaddhistory` hook,
+// and carried its own copy of all three literals plus the run length — the
+// length as a bare 10 inside an ERE in a Go raw string. Both copies were
+// correct and nothing held them together. The failure that shape produces is
+// silent and one-directional: add a vendor pattern whose shortest match is an
+// 8-character run (or lower RunLen to 8, which such a pattern requires) and
+// TestHistoryPrefilterNeverDropsAMatch forces the Go constant down and keeps
+// passing, while the shipped zsh hook still rejects at 10 — so
+// `jit guard history` quietly stops protecting that vendor, and the guard's
+// designed failure mode is to return 0 and let the line save normally.
+type HistoryAdmitSpec struct {
+	// Literals admit a line outright when present as a substring.
+	Literals []string
+	// RunLen is the shortest run of RunClass characters that admits a line.
+	RunLen int
+	// RunClass is the run character set as an ERE bracket expression, for an
+	// implementation that has a regexp engine and no reason to hand-roll the
+	// byte test. TestHistoryAdmitRunClassMatchesTheByteTest pins it against
+	// the Go implementation below, byte for byte.
+	RunClass string
+}
+
+// HistoryAdmitRule returns the spec both implementations must satisfy.
+func HistoryAdmitRule() HistoryAdmitSpec {
+	return HistoryAdmitSpec{
+		Literals: []string{historyAdmitBeginLiteral, historyAdmitAtLiteral, historyAdmitJWTLiteral},
+		RunLen:   historyTokenRunLen,
+		RunClass: historyTokenRunClass,
+	}
+}
+
+const (
+	historyAdmitBeginLiteral = "-----BEGIN"
+	historyAdmitAtLiteral    = "@"
+	historyAdmitJWTLiteral   = "eyJ"
+	// historyTokenRunClass must stay in step with the byte test in
+	// historyLineMayHoldToken; a test compares them across every byte value.
+	historyTokenRunClass = "[A-Za-z0-9_-]"
+)
+
 func historyLineMayHoldToken(line string) bool {
-	if strings.Contains(line, "-----BEGIN") || strings.IndexByte(line, '@') >= 0 ||
-		strings.Contains(line, "eyJ") {
+	if strings.Contains(line, historyAdmitBeginLiteral) ||
+		strings.Contains(line, historyAdmitAtLiteral) ||
+		strings.Contains(line, historyAdmitJWTLiteral) {
 		return true
 	}
 	run := 0

--- a/internal/audit/shellhistory_test.go
+++ b/internal/audit/shellhistory_test.go
@@ -186,52 +186,42 @@ func TestConnectionStringIgnoresShellExpansion(t *testing.T) {
 	}
 }
 
-// The prefilter is an optimization, so its only real obligation is that it
-// never hides a match. Extend `samples` when a pattern is added to
-// knownTokenPatterns.
-func TestHistoryPrefilterNeverDropsAMatch(t *testing.T) {
-	samples := []string{
-		"ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
-		"gith" + "ub_pat_11ABCDEFG0abcdefghijkl_MNOPQRST",
-		"glpa" + "t-AbCdEfGhIjKlMnOpQrSt",
-		"AKIA" + "IOSFODNN7EXAMPLZ",
-		"ASIA" + "IOSFODNN7EXAMPLZ",
-		"dop_" + "v1_0123456789abcdef0123456789abcdef0123456789abcdef",
-		"npm_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789",
-		"pypi" + "-AgEIcHlwaS5vcmcCJDAwMDAwMDAwLTAwMDA",
-		"sk-a" + "nt-api03-AbCdEfGhIjKlMnOpQrStUv",
-		"sk-a" + "nt-adminAbCdEfGhIjKlMnOpQrStUv",
-		"sk-p" + "roj-AbCdEfGhIjKlMnOpQrStUv",
-		"sk-s" + "vcacct-AbCdEfGhIjKlMnOpQrStUv",
-		"sk-a" + "dmin-AbCdEfGhIjKlMnOpQrStUv",
-		"sk-A" + "bCdEfGhIjKlMnOpQrStUv",
-		"hf_a" + "bcdefghijklmnopqrstuvwx",
-		"sk_l" + "ive_51H8xQ2KZvMnPq7RtY4wU6iO9",
-		"sk_t" + "est_51H8xQ2KZvMnPq7RtY4wU6iO9",
-		"rk_l" + "ive_51H8xQ2KZvMnPq7RtY4wU6iO9",
-		"xoxb" + "-1234567890-AbCdEfGhIj",
-		"xoxp" + "-1234567890-AbCdEfGhIj",
-		"xapp" + "-1-A012345678-AbCdEfGhIj",
-		"xwfp" + "-1-A012345678-AbCdEfGhIj",
-		"shpa" + "t_abcdefghijklmnopqrstuvwx",
-		"AC01" + "23456789abcdef0123456789abcdef",
-		"SG.AbCdEfGhIj.KlMnOpQrStUv",
-		"ntn_" + "abcdefghijklmnopqrstuvwx",
-		"secr" + "et_0123456789abcdefghijklmnopqrstuvwxyzABCD",
-		"AIza" + "SyC1234567890abcdefghijklmnopqrstuv",
-		"whse" + "c_AbCdEfGhIjKlMnOpQrStUvWx",
-		"sb_s" + "ecret_AbCdEfGhIjKlMnOpQrStUv",
-		"glsa" + "_AbCdEfGhIjKlMnOpQrStUv_abcdef12",
-		"dp.st.AbCdEfGhIjKlMnOpQrStUv",
-		"hvs." + "AbCdEfGhIjKlMnOpQrStUvWxYz01",
-		"AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTU",
-		"eyJh" + "bGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.AbCdEfGhIj",
-		"eyJa.b.c",
-		"postgres://app:s3cr3tPassw0rd@db.internal:5432/app",
-		"scanner_user:hunter2x@db.example.com/postgres",
-		"-----BEGIN OPENSSH PRIVATE KEY-----",
-		"-----BEGIN RSA PRIVATE KEY-----",
+// historyAdmitSamples loads the corpus shared with internal/guard, whose own
+// admit test reads this same file. Keeping it on disk rather than in a Go
+// slice is what makes "both implementations are checked against the same
+// lines" true by construction instead of by somebody remembering.
+//
+// "|" is a split marker (see the file's header): it sits where a contiguous
+// vendor token would otherwise trip GitHub push protection.
+func historyAdmitSamples(t *testing.T) []string {
+	t.Helper()
+	return loadAdmitSamples(t, filepath.Join("testdata", "history-admit-samples.txt"))
+}
+
+func loadAdmitSamples(t *testing.T, path string) []string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the shared admit corpus: %v", err)
 	}
+	var samples []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		samples = append(samples, strings.ReplaceAll(line, "|", ""))
+	}
+	if len(samples) == 0 {
+		t.Fatalf("%s yielded no samples; both admit tests would pass vacuously", path)
+	}
+	return samples
+}
+
+// The prefilter is an optimization, so its only real obligation is that it
+// never hides a match. Extend the corpus file when a pattern is added.
+func TestHistoryPrefilterNeverDropsAMatch(t *testing.T) {
+	samples := historyAdmitSamples(t)
 	for _, s := range samples {
 		matched := false
 		for _, tp := range knownTokenPatterns {
@@ -253,40 +243,7 @@ func TestHistoryPrefilterNeverDropsAMatch(t *testing.T) {
 // Every pattern in the list must be represented above, or a pattern added
 // later could silently sit behind a prefilter that rejects it.
 func TestHistoryPrefilterGuardsEveryPattern(t *testing.T) {
-	samples := []string{
-		"ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8", "gith" + "ub_pat_11ABCDEFG0abcdefghijkl_MNOPQRST",
-		"gho_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8", "ghs_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
-		"ghu_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8", "ghr_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8",
-		"glpa" + "t-AbCdEfGhIjKlMnOpQrSt", "gldt" + "-AbCdEfGhIjKlMnOpQrSt", "glrt" + "-AbCdEfGhIjKlMnOpQrSt",
-		"glrt" + "r-AbCdEfGhIjKlMnOpQrSt", "glcb" + "t-AbCdEfGhIjKlMnOpQrSt", "glpt" + "t-AbCdEfGhIjKlMnOpQrSt",
-		"gloa" + "s-AbCdEfGhIjKlMnOpQrSt", "glag" + "ent-AbCdEfGhIjKlMnOpQrSt", "glft" + "-AbCdEfGhIjKlMnOpQrSt",
-		"AKIA" + "IOSFODNN7EXAMPLZ", "dop_" + "v1_0123456789abcdef0123456789abcdef0123456789abcdef",
-		"npm_" + "AbCdEfGhIjKlMnOpQrStUvWxYz0123456789", "pypi" + "-AgEIcHlwaS5vcmcCJDAwMDAwMDAwLTAwMDA",
-		"sk-a" + "nt-api03-AbCdEfGhIjKlMnOpQrStUv", "sk-a" + "nt-adminAbCdEfGhIjKlMnOpQrStUv",
-		"sk-p" + "roj-AbCdEfGhIjKlMnOpQrStUv", "sk-s" + "vcacct-AbCdEfGhIjKlMnOpQrStUv",
-		"sk-a" + "dmin-AbCdEfGhIjKlMnOpQrStUv", "sk-A" + "bCdEfGhIjKlMnOpQrStUv",
-		"hf_a" + "bcdefghijklmnopqrstuvwx", "sk_l" + "ive_51H8xQ2KZvMnPq7RtY4wU6iO9",
-		"sk_t" + "est_51H8xQ2KZvMnPq7RtY4wU6iO9", "rk_l" + "ive_51H8xQ2KZvMnPq7RtY4wU6iO9",
-		"xoxb" + "-1234567890-AbCdEfGhIj", "xoxp" + "-1234567890-AbCdEfGhIj",
-		"shpa" + "t_abcdefghijklmnopqrstuvwx", "AC01" + "23456789abcdef0123456789abcdef",
-		"SG.AbCdEfGhIj.KlMnOpQrStUv", "ntn_" + "abcdefghijklmnopqrstuvwx",
-		"secr" + "et_0123456789abcdefghijklmnopqrstuvwxyzABCD",
-		"AIza" + "SyC1234567890abcdefghijklmnopqrstuv", "xapp" + "-1-A012345678-AbCdEfGhIj",
-		"xwfp" + "-1-A012345678-AbCdEfGhIj", "whse" + "c_AbCdEfGhIjKlMnOpQrStUvWx",
-		"sb_s" + "ecret_AbCdEfGhIjKlMnOpQrStUv", "glsa" + "_AbCdEfGhIjKlMnOpQrStUv_abcdef12",
-		"dp.st.AbCdEfGhIjKlMnOpQrStUv", "hvs." + "AbCdEfGhIjKlMnOpQrStUvWxYz01",
-		"hvb." + "AbCdEfGhIjKlMnOpQrStUvWxYz01", "hvr." + "AbCdEfGhIjKlMnOpQrStUvWxYz01",
-		"AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTU",
-		"AGE-SECRET-KEY-PQ-1ABCDEFGHIJKLMNOPQRSTU",
-		"eyJh" + "bGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.AbCdEfGhIj",
-		"-----BEGIN RSA PRIVATE KEY-----", "-----BEGIN OPENSSH PRIVATE KEY-----",
-		"-----BEGIN EC PRIVATE KEY-----", "-----BEGIN PRIVATE KEY-----",
-		"postgres://app:s3cr3tPassw0rd@db.internal:5432/app",
-		"scanner_user:hunter2x@db.example.com/postgres",
-		"crsr" + "_AbCdEfGhIjKl", "tvly" + "-AbCdEfGhIjKl",
-		"xoxa" + "-1234567890-AbCdEfGhIj", "xoxr" + "-1234567890-AbCdEfGhIj",
-		"eyJa.b.c", // degenerate JWT: legal for the pattern, no long run
-	}
+	samples := historyAdmitSamples(t)
 	covered := map[string]bool{}
 	for _, s := range samples {
 		if !historyLineMayHoldToken(s) {
@@ -1353,5 +1310,59 @@ func TestScanReportOffersTheGuardOnlyWhenHistoryIsInvolved(t *testing.T) {
 	envFinding.RecordID = "r2"
 	if out := render([]Finding{envFinding}); strings.Contains(out, "jit guard") {
 		t.Errorf("offered the guard with no history finding:\n%s", out)
+	}
+}
+
+// TestHistoryAdmitRunClassMatchesTheByteTest pins the two representations of
+// "a token-body character" against each other across every byte value.
+//
+// historyLineMayHoldToken hand-rolls the test as a byte comparison, on purpose:
+// it runs per character over whole history files and a regexp there would cost
+// the optimization its reason to exist. HistoryAdmitSpec.RunClass states the
+// same set as an ERE bracket expression, because internal/guard's zsh hook has
+// a regexp engine and no way to call a Go function. Two spellings of one set,
+// and nothing compared them.
+func TestHistoryAdmitRunClassMatchesTheByteTest(t *testing.T) {
+	class := regexp.MustCompile("^" + HistoryAdmitRule().RunClass + "$")
+	for b := 0; b < 256; b++ {
+		c := byte(b)
+		// The byte test, as historyLineMayHoldToken spells it.
+		inByteTest := c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' ||
+			c >= '0' && c <= '9' || c == '_' || c == '-'
+		inClass := class.Match([]byte{c})
+		if inByteTest != inClass {
+			t.Errorf("byte %q: byte test says %v, RunClass %q says %v",
+				c, inByteTest, HistoryAdmitRule().RunClass, inClass)
+		}
+	}
+}
+
+// The spec is what internal/guard renders its zsh from, so an empty or absurd
+// value there disarms the shipped hook rather than failing anything here.
+func TestHistoryAdmitRuleIsUsable(t *testing.T) {
+	spec := HistoryAdmitRule()
+	if len(spec.Literals) == 0 {
+		t.Error("no admit literals; the zsh hook's literal clause would be empty")
+	}
+	for _, lit := range spec.Literals {
+		if lit == "" {
+			t.Error("an empty admit literal matches every line, admitting everything")
+		}
+	}
+	if spec.RunLen < 1 {
+		t.Errorf("RunLen = %d; a run test that admits everything is not a prefilter", spec.RunLen)
+	}
+	if spec.RunClass == "" {
+		t.Error("no RunClass; the rendered ERE would be malformed and the hook would fail to parse")
+	}
+	// The Go implementation must actually agree with the advertised RunLen:
+	// a run one shorter must not admit, a run of exactly RunLen must.
+	short := strings.Repeat("a", spec.RunLen-1)
+	exact := strings.Repeat("a", spec.RunLen)
+	if historyLineMayHoldToken(short) {
+		t.Errorf("a %d-character run admits, but RunLen advertises %d", len(short), spec.RunLen)
+	}
+	if !historyLineMayHoldToken(exact) {
+		t.Errorf("a %d-character run does not admit, but RunLen advertises %d", len(exact), spec.RunLen)
 	}
 }

--- a/internal/audit/testdata/history-admit-samples.txt
+++ b/internal/audit/testdata/history-admit-samples.txt
@@ -1,0 +1,75 @@
+# Command lines that MUST survive the cheap admit test in BOTH implementations:
+# internal/audit's historyLineMayHoldToken, and the zsh hook internal/guard
+# ships. One corpus, read by both tests, so neither can be narrowed alone.
+#
+# Every entry must match at least one knownTokenPatterns entry, and every
+# pattern must be represented here. TestHistoryPrefilterGuardsEveryPattern
+# enforces the second half. Add a line when a pattern is added.
+#
+# A "|" is a SPLIT MARKER, removed on load. It sits where the Go source used
+# to concatenate ("AKIA" + "IOSFODNN7EXAMPLZ") and exists for the same reason:
+# GitHub push protection matches a contiguous vendor token here and rejects
+# the push outright. "|" appears in no token charset, so it is unambiguous.
+#
+# Blank lines and # comments are ignored.
+ghp_|A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8
+gith|ub_pat_11ABCDEFG0abcdefghijkl_MNOPQRST
+glpa|t-AbCdEfGhIjKlMnOpQrSt
+AKIA|IOSFODNN7EXAMPLZ
+ASIA|IOSFODNN7EXAMPLZ
+dop_|v1_0123456789abcdef0123456789abcdef0123456789abcdef
+npm_|AbCdEfGhIjKlMnOpQrStUvWxYz0123456789
+pypi|-AgEIcHlwaS5vcmcCJDAwMDAwMDAwLTAwMDA
+sk-a|nt-api03-AbCdEfGhIjKlMnOpQrStUv
+sk-a|nt-adminAbCdEfGhIjKlMnOpQrStUv
+sk-p|roj-AbCdEfGhIjKlMnOpQrStUv
+sk-s|vcacct-AbCdEfGhIjKlMnOpQrStUv
+sk-a|dmin-AbCdEfGhIjKlMnOpQrStUv
+sk-A|bCdEfGhIjKlMnOpQrStUv
+hf_a|bcdefghijklmnopqrstuvwx
+sk_l|ive_51H8xQ2KZvMnPq7RtY4wU6iO9
+sk_t|est_51H8xQ2KZvMnPq7RtY4wU6iO9
+rk_l|ive_51H8xQ2KZvMnPq7RtY4wU6iO9
+xoxb|-1234567890-AbCdEfGhIj
+xoxp|-1234567890-AbCdEfGhIj
+xapp|-1-A012345678-AbCdEfGhIj
+xwfp|-1-A012345678-AbCdEfGhIj
+shpa|t_abcdefghijklmnopqrstuvwx
+AC01|23456789abcdef0123456789abcdef
+SG.AbCdEfGhIj.KlMnOpQrStUv
+ntn_|abcdefghijklmnopqrstuvwx
+secr|et_0123456789abcdefghijklmnopqrstuvwxyzABCD
+AIza|SyC1234567890abcdefghijklmnopqrstuv
+whse|c_AbCdEfGhIjKlMnOpQrStUvWx
+sb_s|ecret_AbCdEfGhIjKlMnOpQrStUv
+glsa|_AbCdEfGhIjKlMnOpQrStUv_abcdef12
+dp.st.AbCdEfGhIjKlMnOpQrStUv
+hvs.|AbCdEfGhIjKlMnOpQrStUvWxYz01
+AGE-SECRET-KEY-1ABCDEFGHIJKLMNOPQRSTU
+eyJh|bGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.AbCdEfGhIj
+eyJa.b.c
+postgres://app:s3cr3tPassw0rd@db.internal:5432/app
+scanner_user:hunter2x@db.example.com/postgres
+-----BEGIN OPENSSH PRIVATE KEY-----
+-----BEGIN RSA PRIVATE KEY-----
+gho_|A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8
+ghs_|A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8
+ghu_|A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8
+ghr_|A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8
+gldt|-AbCdEfGhIjKlMnOpQrSt
+glrt|-AbCdEfGhIjKlMnOpQrSt
+glrt|r-AbCdEfGhIjKlMnOpQrSt
+glcb|t-AbCdEfGhIjKlMnOpQrSt
+glpt|t-AbCdEfGhIjKlMnOpQrSt
+gloa|s-AbCdEfGhIjKlMnOpQrSt
+glag|ent-AbCdEfGhIjKlMnOpQrSt
+glft|-AbCdEfGhIjKlMnOpQrSt
+hvb.|AbCdEfGhIjKlMnOpQrStUvWxYz01
+hvr.|AbCdEfGhIjKlMnOpQrStUvWxYz01
+AGE-SECRET-KEY-PQ-1ABCDEFGHIJKLMNOPQRSTU
+-----BEGIN EC PRIVATE KEY-----
+-----BEGIN PRIVATE KEY-----
+crsr|_AbCdEfGhIjKl
+tvly|-AbCdEfGhIjKl
+xoxa|-1234567890-AbCdEfGhIj
+xoxr|-1234567890-AbCdEfGhIj

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -62,7 +62,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+
+	"github.com/jitpass/jit/internal/audit"
 )
 
 // HookRelPath is the hook's path relative to home, kept next to wrap's
@@ -120,8 +123,8 @@ _jit_history_guard() {
   # sourced — so a user with sh_glob or emulate sh set before the source line
   # got "parse error near (", the function never defined, and a guard that
   # silently protected nothing. emulate -L zsh above only fixes the runtime.
-  if [[ $line != *-----BEGIN* && $line != *@* && $line != *eyJ* ]] &&
-     ! [[ $line =~ "[A-Za-z0-9_-]{10,}" ]]; then
+  if [[ @@LITERAL_CLAUSES@@ ]] &&
+     ! [[ $line =~ "@@RUN_CLASS@@{@@RUN_LEN@@,}" ]]; then
     return 0
   fi
   local jit_bin vendors out rc
@@ -193,8 +196,26 @@ add-zsh-hook zshaddhistory _jit_history_guard
 
 // HookScript returns the hook's content, for tests that drive it through a
 // real zsh.
+// The admit test is RENDERED from internal/audit's spec rather than written
+// out here, so the hook cannot drift from the scanner it stands in for. See
+// audit.HistoryAdmitSpec for the failure that duplication produced: both
+// copies correct, nothing holding them together, and a vendor pattern with a
+// shorter shortest-match silently unprotected in the shell while every Go
+// test stays green.
+//
+// Placeholder substitution rather than fmt.Sprintf: the script legitimately
+// contains "%" (`${1%$'\n'}`), which a format string would misread.
 func HookScript() string {
-	return hookScript
+	spec := audit.HistoryAdmitRule()
+	clauses := make([]string, 0, len(spec.Literals))
+	for _, lit := range spec.Literals {
+		clauses = append(clauses, "$line != *"+lit+"*")
+	}
+	return strings.NewReplacer(
+		"@@LITERAL_CLAUSES@@", strings.Join(clauses, " && "),
+		"@@RUN_CLASS@@", spec.RunClass,
+		"@@RUN_LEN@@", strconv.Itoa(spec.RunLen),
+	).Replace(hookScript)
 }
 
 // Install writes the hook file and makes sure ~/.zshrc sources it.
@@ -209,8 +230,8 @@ func Install(home string) (changed bool, err error) {
 	if readErr != nil && !os.IsNotExist(readErr) {
 		return false, fmt.Errorf("reading %s: %w", hookPath, readErr)
 	}
-	if string(existing) != hookScript {
-		if err := os.WriteFile(hookPath, []byte(hookScript), 0o600); err != nil {
+	if string(existing) != HookScript() {
+		if err := os.WriteFile(hookPath, []byte(HookScript()), 0o600); err != nil {
 			return false, fmt.Errorf("writing %s: %w", hookPath, err)
 		}
 		changed = true

--- a/internal/guard/guard_test.go
+++ b/internal/guard/guard_test.go
@@ -7,9 +7,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/jitpass/jit/internal/audit"
 )
 
 func TestInstallRemoveRoundTrip(t *testing.T) {
@@ -123,9 +126,26 @@ func runHook(t *testing.T, line string, stubExit int) (rc int, stderr string, st
 	// The stub is named "jit" and reached through PATH: the hook resolves the
 	// binary with `command -v jit` and has no env-var override to abuse.
 	stub := filepath.Join(bin, "jit")
+	// The marker is touched FIRST, before stdin is drained.
+	//
+	// It used to be touched after, and that made `stubRan` mean "the check was
+	// forked AND finished within the hook's 2s deadline" while every caller
+	// read it as "the admit test let the line through". Those diverge under
+	// load: the hook forks the check, waits 200x10ms, and on timeout does
+	// `kill -9` and fails open (see guard.go). On a loaded machine — the
+	// full suite under -race, on a 4-CPU VM — forking /bin/sh plus cat can
+	// exceed 2s, the stub is killed before it ever reaches touch, and
+	// TestHookBlocksCredentialLines fails with "the admit test wrongly
+	// rejected a credential line" about an admit test that did its job. That
+	// is the intermittent failure on the open-findings list, and the
+	// misdiagnosis was in the assertion, not in the hook.
+	//
+	// Touching first makes stubRan mean exactly "the check was forked", which
+	// is what every caller wants to know. A deadline hit now shows up as the
+	// rc assertion failing instead, which is the truthful place for it.
 	stubBody := "#!/bin/sh\n" +
-		"cat > /dev/null\n" + // drain stdin like the real check does
-		"touch " + marker + "\n"
+		"touch " + marker + "\n" +
+		"cat > /dev/null\n" // drain stdin like the real check does
 	switch stubExit {
 	case 0:
 		stubBody += "echo 'GitHub Personal Access Token'\nexit 0\n"
@@ -168,10 +188,20 @@ func TestHookBlocksCredentialLines(t *testing.T) {
 	line := "curl -H 'Authorization: token ghp_" + "A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'"
 	rc, stderr, ran := runHook(t, line, 0)
 	if !ran {
-		t.Fatal("the stub check never ran; the admit test wrongly rejected a credential line")
+		// Two causes, and the message used to assert the first one only, which
+		// is what made the intermittent failure on the open-findings list read
+		// as an admit-test bug. Admit parity is covered exhaustively and
+		// separately by TestHookAdmitTestNeverDropsAMatch, so under parallel
+		// load the second cause is by far the likelier of the two.
+		t.Fatal("the stub check did not run. Either the admit test wrongly rejected a credential " +
+			"line, or the hook's 2s deadline killed the check before the stub got to run at all " +
+			"(fork storm under parallel -race load). Re-run this test alone to tell them apart: " +
+			"if it passes in isolation it was the deadline, which is the hook behaving correctly")
 	}
 	if rc != 2 {
-		t.Errorf("rc = %d, want 2 (keep in session memory, never write the file)", rc)
+		t.Errorf("rc = %d, want 2 (keep in session memory, never write the file). "+
+			"rc=0 with the stub confirmed to have run means the hook's 2s deadline fired and it "+
+			"failed open — correct behaviour under load, not a detection failure", rc)
 	}
 	if !strings.Contains(stderr, "GitHub Personal Access Token") {
 		t.Errorf("notice does not name the vendor: %q", stderr)
@@ -201,21 +231,54 @@ func TestHookNeverForksForOrdinaryCommands(t *testing.T) {
 	}
 }
 
-// Admit parity with audit's historyLineMayHoldToken: one sample per admitting
-// condition must reach the check. The Go prefilter's completeness against
-// every vendor pattern is enforced in internal/audit
-// (TestHistoryPrefilterNeverDropsAMatch); this pins the zsh transplant to the
-// same four conditions.
+// admitCorpus loads the SAME file internal/audit's own admit tests read, so
+// the two implementations of this test cannot be narrowed independently.
+//
+// "|" is a split marker (see the file's header): it sits where a contiguous
+// vendor token would otherwise trip GitHub push protection.
+func admitCorpus(t *testing.T) []string {
+	t.Helper()
+	path := filepath.Join("..", "audit", "testdata", "history-admit-samples.txt")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading the shared admit corpus: %v", err)
+	}
+	var samples []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		samples = append(samples, strings.ReplaceAll(line, "|", ""))
+	}
+	if len(samples) == 0 {
+		t.Fatal("the shared admit corpus yielded no samples; this test would pass vacuously")
+	}
+	return samples
+}
+
+// TestHookAdmitTestNeverDropsAMatch is the zsh transplant of the obligation
+// CLAUDE.md, guard.go and shellhistory.go all state: the cheap in-shell admit
+// test must never reject a line the real check would match.
+//
+// It used to check FOUR hand-written lines, one per admitting condition, while
+// internal/audit checked its Go prefilter against every entry in
+// knownTokenPatterns. That asymmetry is the whole bug: a vendor pattern whose
+// shortest match is an 8-character run forces audit's constant down, audit's
+// exhaustive test keeps passing, and the shipped zsh hook still rejects at 10 —
+// so `jit guard history` silently stops protecting that vendor, and the
+// guard's designed failure mode is silence.
+//
+// Now both read one corpus file. Driven through a REAL zsh against the
+// SHIPPED hook, which is the only way this proves anything about the thing
+// users actually run.
 func TestHookAdmitTestNeverDropsAMatch(t *testing.T) {
-	for _, line := range []string{
-		"cat id_rsa | head -1  # -----BEGIN OPENSSH PRIVATE KEY-----",
-		"psql postgres://app:pw@db/app",                          // "@"
-		"echo eyJa.b.c",                                          // degenerate JWT, no long run
-		"export TOKEN=xoxb" + "-1234567890-AbCdEfGhIjKlMnOpQrSt", // 10+ run
-	} {
+	for _, sample := range admitCorpus(t) {
+		line := "export TOKEN=" + sample
 		_, _, ran := runHook(t, line, 1)
 		if !ran {
-			t.Errorf("admit test dropped %q; the zsh prefilter is narrower than audit's", line)
+			t.Errorf("the zsh admit test dropped %q; it is narrower than audit's prefilter, "+
+				"so jit guard history silently stops protecting this format", sample)
 		}
 	}
 }
@@ -288,5 +351,41 @@ func TestHookFailsOpenWithoutJit(t *testing.T) {
 	rc, _, _ := runHook(t, line, 127)
 	if rc != 0 {
 		t.Errorf("rc = %d, want 0: with jit missing the hook must fail open and save the line", rc)
+	}
+}
+
+// TestHookScriptRendersFromTheSpec is the linkage itself. The admit test used
+// to be typed out in the zsh source beside audit's Go copy — both correct,
+// nothing holding them together. These assertions fail if the hook stops
+// tracking audit.HistoryAdmitRule(), which is the state that made the drift
+// possible in the first place.
+func TestHookScriptRendersFromTheSpec(t *testing.T) {
+	spec := audit.HistoryAdmitRule()
+	script := HookScript()
+
+	if strings.Contains(script, "@@") {
+		t.Errorf("an unsubstituted placeholder survived into the shipped hook:\n%s", script)
+	}
+	for _, lit := range spec.Literals {
+		if !strings.Contains(script, "$line != *"+lit+"*") {
+			t.Errorf("the hook has no clause for admit literal %q, so a line carrying it is dropped in the shell", lit)
+		}
+	}
+	if want := spec.RunClass + "{" + strconv.Itoa(spec.RunLen) + ",}"; !strings.Contains(script, want) {
+		t.Errorf("the hook's run test is not %q; it has stopped tracking the spec, "+
+			"which is how a lowered RunLen leaves the shell hook rejecting what the scanner matches", want)
+	}
+}
+
+// A literal is interpolated into a zsh GLOB pattern (`$line != *LIT*`), so a
+// glob metacharacter in one silently changes what the clause matches — and in
+// the admitting direction that means dropping lines. Cheap to check, and the
+// alternative (quoting) would change the existing clauses' text.
+func TestAdmitLiteralsAreGlobSafe(t *testing.T) {
+	for _, lit := range audit.HistoryAdmitRule().Literals {
+		if strings.ContainsAny(lit, `*?[]()|^~#`) {
+			t.Errorf("admit literal %q carries a zsh glob metacharacter; interpolated bare into "+
+				"`$line != *%s*` it would not match literally", lit, lit)
+		}
 	}
 }


### PR DESCRIPTION
Tranche D off the 2026-08-06 handoff.

## The asymmetry

CLAUDE.md, `guard.go` and `shellhistory.go` all state the same obligation: **the cheap in-shell admit test must never reject a line the real check would match.** Enforcement did not match the statement.

| | what it checked |
|---|---|
| `internal/audit` | its Go prefilter against **every entry** in `knownTokenPatterns` |
| `internal/guard` | **four hand-written lines**, one per admitting condition |

Nothing in guard's test derived from `knownTokenPatterns` or from `historyTokenRunLen`. Both implementations retyped the same four constants — `-----BEGIN`, `@`, `eyJ`, and `10` — the last as a bare literal inside an ERE inside a Go raw string.

The failure that shape produces is silent and one-directional. Add a vendor pattern whose shortest match is an 8-character run (or lower `historyTokenRunLen` to 8, which such a pattern *requires*): audit's exhaustive test forces the constant down and keeps passing, while the shipped zsh hook still rejects at 10. `jit guard history` then quietly stops protecting that vendor — and the guard's designed failure mode is silence, so it returns 0 and the line saves normally.

## The fix

`internal/audit` now owns the rule as **data** (`HistoryAdmitSpec`: literals, run length, and the run character class as an ERE), and `internal/guard` **renders** its zsh from it.

Verified by lowering `historyTokenRunLen` to 8 and watching the shipped hook's regex become `{8,}` on its own. Placeholder substitution rather than `fmt.Sprintf`, because the script legitimately contains `%` (`${1%$'\n'}`).

The two admit corpora are now **one file** — `internal/audit/testdata/history-admit-samples.txt` — read by audit's two prefilter tests *and* by guard's, so neither can be narrowed alone. It's the **union** of the two lists that existed (61 samples), so both got stronger. Guard's test still drives a real `zsh` against the shipped hook, now over all 61.

Two new pins: the ERE run class is compared against the hand-rolled byte test across all 256 byte values (two spellings of one set, previously unrelated), and the admit literals are checked for zsh glob metacharacters, since each is interpolated bare into `$line != *LIT*`.

Mutation-verified: dropping one admit literal from the renderer fails both the corpus test (through zsh, on `eyJa.b.c`) and the linkage test.

## The intermittent failure, diagnosed rather than wrapped

`TestHookBlocksCredentialLines` was **not** flaking in the admit logic.

The hook forks the check with a 2s deadline and on timeout does `kill -9` and fails open. The stub `jit` touched its marker only *after* draining stdin — so `stubRan` actually meant *"forked AND finished inside 2s"*, while the assertion read it as *"the admit test let the line through."* Under full-suite `-race` load on a 4-CPU VM, forking `/bin/sh` plus `cat` can exceed that, and the test then blamed an admit test that had done its job.

The marker is now touched **first**, so it appears when the check *starts* rather than when it finishes — which is what every caller of `stubRan` actually wants to know. The remaining ambiguity (a kill landing inside the fork window itself) can't be removed from outside the hook, so the assertion now names both causes and says how to tell them apart, rather than asserting the wrong one. No retry wrapper.

## Layering

`internal/guard` now imports `internal/audit` and nothing else internal; only `internal/cli` imports guard. No cycle, no new edge into anything below.

## Verification

Full suite green under `-race` (guard additionally at `-count=3`); `gofmt`, `go vet`, pinned `staticcheck` clean.

Note CI may not report — GitHub Actions is in an active incident, so this is verified locally.

## One incidental detail

The corpus file uses a `|` split marker where the Go source used to concatenate (`"AKIA" + "IOSFO…"`), for the same reason: GitHub push protection rejects a push carrying a contiguous vendor token — as it did to this session earlier today on #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4