### PR TITLE
Give the ownerless contracts an owner, and stop comments describing code that isn't there (tranche E)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,8 +104,9 @@ of it: malformed entries fail `TestCatalogEntriesAreWellFormed`, and an
 undocumented tool fails the wrap-docs drift guard. In the PR, link the
 tool's own docs for where it stores its credential and which env var it
 reads (that's what review checks - see
-[docs/internal/WRAP-PLAN.md](./docs/internal/WRAP-PLAN.md) §3.2 for how the
-shim-vs-native kind is chosen).
+`WRAP-PLAN.md` §3.2 for how the shim-vs-native kind is chosen — that one
+lives in the private planning repo alongside the RFC, so ask in the issue and
+we'll quote the relevant part).
 
 ## Scope
 

--- a/design/output-style.md
+++ b/design/output-style.md
@@ -11,9 +11,15 @@ below `cli`, `audit` and `ui` so all three share it (`internal/cli` imports
 `internal/audit`, so the vocabulary could not live in `cli`).
 `internal/cli/style.go` re-exports it under short local names — `cBold`,
 `cPath`, `cOK`, `cWarn`, `cRisk`, `cWarnBold`, `cPathBold`, `cOKBold`, the
-`glyph*` constants, `flowNames`. Never build a colour or type a glyph literal
-at a call site: `TestPaletteIsCentralised` fails on it, and the point of the
-seam is that a repaint is one edit.
+`glyph*` constants, `flowNames`. Never build a colour at a call site:
+`TestPaletteIsCentralised` and `TestNoHandRolledColors` both fail on it, and
+the point of the seam is that a repaint is one edit.
+
+Typing a glyph literal at a call site is the same mistake, and is currently
+enforced only by convention — no test catches it, and ~100 emitted strings do
+it (mostly `→` and `"  • "`). Treat the rule as binding and the enforcement as
+missing; this paragraph claimed `TestPaletteIsCentralised` covered glyphs, and
+it never has.
 
 ## The whole palette
 

--- a/internal/audit/agentcache.go
+++ b/internal/audit/agentcache.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jitpass/jit/internal/pointerfile"
 )
 
 // AI coding agents keep local copies of the files and text they work on, and
@@ -256,7 +258,7 @@ func eligibleNeedle(v string) bool {
 // pointerValuePrefix is what a migrated file holds where the credential was.
 // Duplicated from internal/migrate rather than imported: this package is the
 // read-only scanner and must not depend on the package that writes.
-const pointerValuePrefix = "jit://vault/"
+const pointerValuePrefix = pointerfile.ValuePrefix
 
 // crossReferenceAgentCaches searches every present AI agent cache for verbatim
 // copies of the credentials findings already confirmed, and returns one

--- a/internal/audit/credfile.go
+++ b/internal/audit/credfile.go
@@ -19,6 +19,8 @@ import (
 	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/jitpass/jit/internal/pointerfile"
 )
 
 // ScanCredentialFiles implements RFC.md §4 category 3: known credential
@@ -1165,7 +1167,7 @@ func scanClissoConfig(cfg Config) ([]Finding, error) {
 	var findings []Finding
 	for _, name := range slices.Sorted(maps.Keys(cc.Providers)) {
 		p := cc.Providers[name]
-		if p.ClientSecret == "" || strings.HasPrefix(p.ClientSecret, "jit://vault/") {
+		if p.ClientSecret == "" || pointerfile.IsValue(p.ClientSecret) {
 			continue // absent, or already a pointer at the vaulted secret
 		}
 		f := cfg.ValueFinding(ValueFindingParams{

--- a/internal/audit/credfile.go
+++ b/internal/audit/credfile.go
@@ -264,7 +264,7 @@ func scanGlobalNpmrc(cfg Config) ([]Finding, error) {
 }
 
 // classifyProjectNpmrc is the credential category's discovery half: a .npmrc
-// can live in any project, so it's found by the shared walk (task #22) rather
+// can live in any project, so it's found by the shared walk rather
 // than by only checking cwd.
 //
 // It deliberately does NOT skip the global ~/.npmrc that scanGlobalNpmrc also

--- a/internal/audit/doc.go
+++ b/internal/audit/doc.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
 
 // Package audit implements the read-only risk scanner (RFC.md §4, jit scan).
-// The jit migrate guided fix path (task #7) is a separate command, not a
+// The jit migrate guided fix path is a separate command, not a
 // flag on audit, so this package's Scan stays read-only in every mode; it
 // reuses Scan's results rather than living inside this package.
 package audit

--- a/internal/audit/envfile.go
+++ b/internal/audit/envfile.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/wrap"
 )
 
@@ -50,7 +51,7 @@ func isEnvTemplateFile(name string) bool {
 // .env secret — confirmed as the same underlying pattern bug that made
 // `jit migrate` re-discover and destroy its own `.pointers` files on a
 // second run (a real, reported incident — GAPS.md #30).
-const jitPointerFileSuffix = ".pointers"
+const jitPointerFileSuffix = pointerfile.CompanionSuffix
 
 func isJitPointerFile(name string) bool {
 	return strings.HasSuffix(name, jitPointerFileSuffix)
@@ -60,7 +61,7 @@ func isJitPointerFile(name string) bool {
 // same name (small independent copy, matching this package's convention of
 // not importing internal/migrate). It's the start of a jit pointer file's
 // first line.
-const pointerFileHeaderPrefix = "# jit pointer file"
+const pointerFileHeaderPrefix = pointerfile.Header
 
 // isJitPointerContent recognizes a jit pointer file by CONTENT, not name —
 // the case isJitPointerFile's suffix check misses: a backup-suffixed .env

--- a/internal/audit/privatekey.go
+++ b/internal/audit/privatekey.go
@@ -31,7 +31,7 @@ var privateKeyPEMHeaders = []string{
 
 // commonDumpDirs are non-~/.ssh locations checked for stray private keys.
 // Deliberately narrow (not a full home-directory walk) — the scan-breadth
-// decision made before task #5 started (ROADMAP.md) — since RFC.md §4
+// decision made before the private-key scanner was written — since RFC.md §4
 // category 5 is scoped to "keys outside expected directories," and these
 // are where real-world review showed stray keys actually accumulate.
 var commonDumpDirs = []string{"Desktop", "Downloads"}

--- a/internal/audit/redact_test.go
+++ b/internal/audit/redact_test.go
@@ -3,7 +3,11 @@
 
 package audit
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jitpass/jit/internal/auditlog"
+)
 
 func TestMaskValue(t *testing.T) {
 	cases := []struct {
@@ -50,5 +54,24 @@ func TestIsAlreadyMasked(t *testing.T) {
 		if got != c.want {
 			t.Errorf("IsAlreadyMasked(%q) = %v, want %v", c.input, got, c.want)
 		}
+	}
+}
+
+// TestJitsOwnRedactionMarkIsRecognised links two lists that describe the same
+// thing from opposite ends and were connected only by both spelling
+// "<redacted>" by hand.
+//
+// commonMaskedPlaceholders is a list of markers FOREIGN tools leave behind, so
+// it is deliberately not built from auditlog.RedactToken — the overlap is a
+// coincidence, not a contract, and coupling them would make jit's own log
+// format govern what it recognises in other people's files. What IS a
+// contract: jit must never re-flag a value it masked itself. If the audit
+// log's placeholder ever changes, `jit scan` would start reporting jit's own
+// redaction marks as exposed secrets, and this is what notices.
+func TestJitsOwnRedactionMarkIsRecognised(t *testing.T) {
+	if !IsAlreadyMasked(auditlog.RedactToken) {
+		t.Errorf("jit's own redaction placeholder %q is not recognised as masked; "+
+			"jit scan would report its own audit-log redactions as exposed secrets",
+			auditlog.RedactToken)
 	}
 }

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -30,25 +30,7 @@ const (
 // color for something the reader can run) and drops the backticks — the
 // audit-package twin of internal/cli's hlCmds, for the same reason as the
 // glyphs above. When color is off the spans pass through as clean text.
-func highlightCmds(s string) string {
-	cmd := style.Path
-	var b strings.Builder
-	for {
-		i := strings.IndexByte(s, '`')
-		if i < 0 {
-			b.WriteString(s)
-			return b.String()
-		}
-		j := strings.IndexByte(s[i+1:], '`')
-		if j < 0 {
-			b.WriteString(s)
-			return b.String()
-		}
-		b.WriteString(s[:i])
-		b.WriteString(cmd.Sprint(s[i+1 : i+1+j]))
-		s = s[i+1+j+1:]
-	}
-}
+func highlightCmds(s string) string { return style.HighlightCommands(s) }
 
 // findingTypeLabels are human-readable section headers, in AllFindingTypes
 // order, matching docs/audit/example-report.md's preview format. Keys are

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -550,12 +550,14 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 	countW := len(fmt.Sprintf("%d", summary.TotalFindings))
 	for _, ft := range AllFindingTypes {
 		n := summary.FindingsByCategory[ft]
+		// A nothing-found row used to be dimmed here, so the categories that
+		// DO have findings were what the eye landed on. The faint attribute
+		// was removed on 2026-08-06 (TestNoFaintText now fails the build if it
+		// returns), which left an `n == 0` arm byte-identical to default and a
+		// comment describing styling that no longer happens. Zero rows are
+		// plain, like every other unremarkable row; the itemized sections
+		// below still skip empty categories entirely.
 		switch {
-		case n == 0:
-			// Dim the nothing-found rows so the categories that DO have
-			// findings are what the eye lands on — the itemized sections
-			// below already skip empty categories entirely.
-			fmt.Fprintf(w, "  %-22s %*d\n", findingTypeLabels[ft], countW, n)
 		case n >= heavyCategoryCount:
 			fmt.Fprintf(w, "  %-22s ", findingTypeLabels[ft])
 			_, _ = style.Bold.Fprintf(w, "%*d\n", countW, n)

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -204,10 +204,15 @@ func (l *Logger) Trim() {
 	}
 }
 
-// redactToken is the fixed placeholder a masked secret becomes. Fixed (not
+// RedactToken is the fixed placeholder a masked secret becomes. Fixed (not
 // length-preserving stars) so the log never leaks even the length of what was
 // masked.
-const redactToken = "<redacted>"
+//
+// Exported because internal/cli masks one more argument this package cannot
+// see (the trailing value of a `jit vault set`-shaped command, auditrecord.go)
+// and was retyping the literal to do it. Two producers of one placeholder, and
+// a divergence puts a real value in the log looking like a mask.
+const RedactToken = "<redacted>"
 
 // secretPrefixes are the well-known "this is unambiguously a live credential"
 // leaders. A token starting with one is masked whole regardless of length or
@@ -307,7 +312,7 @@ func looksSecret(arg string) bool {
 func RedactText(s string) string {
 	return tokenAlphabet.ReplaceAllStringFunc(s, func(tok string) string {
 		if looksSecretToken(tok) {
-			return redactToken
+			return RedactToken
 		}
 		return tok
 	})
@@ -360,13 +365,13 @@ func redactArg(a string) string {
 			// base64 credential just because it contains '/' or '+', the way
 			// the path-shy looksSecret does for a bare argument.
 			if looksSecretToken(val) {
-				return name + "=" + redactToken
+				return name + "=" + RedactToken
 			}
 			return a
 		}
 	}
 	if looksSecret(a) {
-		return redactToken
+		return RedactToken
 	}
 	return a
 }

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -103,12 +103,12 @@ func TestRedactMasksSecretLookingTokens(t *testing.T) {
 		{
 			name: "known prefix, bare",
 			in:   []string{"vault", "set", "stripe/live", "sk_FAKEfixture_notARealKeyXYZ0123"},
-			want: []string{"vault", "set", "stripe/live", redactToken},
+			want: []string{"vault", "set", "stripe/live", RedactToken},
 		},
 		{
 			name: "flag=value with secret value",
 			in:   []string{"--token=ghp_16charsAtLeastxxxxxxxxxxxxxxxxxx"},
-			want: []string{"--token=" + redactToken},
+			want: []string{"--token=" + RedactToken},
 		},
 		{
 			name: "vault label and flags survive",
@@ -123,14 +123,14 @@ func TestRedactMasksSecretLookingTokens(t *testing.T) {
 		{
 			name: "high-entropy opaque token masked",
 			in:   []string{"AKIAIOSFODNN7EXAMPLE"},
-			want: []string{redactToken},
+			want: []string{RedactToken},
 		},
 		{
 			// A bare base64 token ending in '=' padding must not be misread as
 			// KEY=VALUE (name=the token, value="=") and slip through unmasked.
 			name: "padded base64 bare is masked, not misread as KEY=VALUE",
 			in:   []string{"SGVsbG9Xb3JsZERlYWRiZWVmMDAxMjM0NQ=="},
-			want: []string{redactToken},
+			want: []string{RedactToken},
 		},
 		{
 			// A base64 credential containing '/' must be masked when it is a
@@ -138,12 +138,12 @@ func TestRedactMasksSecretLookingTokens(t *testing.T) {
 			// through as if the '/' made it a file path.
 			name: "flag value base64 containing slash is masked",
 			in:   []string{"--token=aB3xKq9ZmQpLrStUvWxYz012+ab/cdEF"},
-			want: []string{"--token=" + redactToken},
+			want: []string{"--token=" + RedactToken},
 		},
 		{
 			name: "env value base64 containing slash is masked",
 			in:   []string{"AWS_SECRET=aB3xKq9ZmQpLrStUvWxYz012+ab/cdEF"},
-			want: []string{"AWS_SECRET=" + redactToken},
+			want: []string{"AWS_SECRET=" + RedactToken},
 		},
 		{
 			// The path-safety the '/' masking must not cost: an absolute path
@@ -162,7 +162,7 @@ func TestRedactMasksSecretLookingTokens(t *testing.T) {
 			// masked: the value split, not the name's shape, decides.
 			name: "long key name still masks a prefixed value",
 			in:   []string{"MY_VERY_LONG_ENVIRONMENT_VARIABLE_NAME_XYZ=ghp_16charsAtLeastxxxxxxxxxxxxxxxxxx"},
-			want: []string{"MY_VERY_LONG_ENVIRONMENT_VARIABLE_NAME_XYZ=" + redactToken},
+			want: []string{"MY_VERY_LONG_ENVIRONMENT_VARIABLE_NAME_XYZ=" + RedactToken},
 		},
 		{
 			// A legible key=value whose value is not a secret is left intact —
@@ -212,7 +212,7 @@ func TestRedactTextMasksPunctuationWrappedSecrets(t *testing.T) {
 		if strings.Contains(got, secret) {
 			t.Errorf("RedactText(%q) leaked the secret: %q", in, got)
 		}
-		if !strings.Contains(got, redactToken) {
+		if !strings.Contains(got, RedactToken) {
 			t.Errorf("RedactText(%q) did not insert the mask: %q", in, got)
 		}
 	}

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -196,12 +196,12 @@ func parseAuditTime(s string) (time.Time, error) {
 		}
 		return time.Now().Add(-d), nil
 	}
-	for _, layout := range []string{"2006-01-02 15:04:05", "2006-01-02 15:04", "2006-01-02", time.RFC3339} {
+	for _, layout := range []string{auditTimeLayout, "2006-01-02 15:04", "2006-01-02", time.RFC3339} {
 		if t, err := time.ParseInLocation(layout, s, time.Local); err == nil {
 			return t, nil
 		}
 	}
-	return time.Time{}, fmt.Errorf("not a duration (like 2h, 90m, 3d) or a date (like 2006-01-02 or \"2006-01-02 15:04:05\")")
+	return time.Time{}, fmt.Errorf("not a duration (like 2h, 90m, 3d) or a date (like 2006-01-02 or %q)", auditTimeLayout)
 }
 
 // parseFlexDuration extends time.ParseDuration with day and week suffixes,

--- a/internal/cli/auditrecord.go
+++ b/internal/cli/auditrecord.go
@@ -207,7 +207,7 @@ func sanitizeInvocationArgs(cmdPath string, rawArgs, positionals []string, parse
 		if strings.HasPrefix(args[i], "-") {
 			continue
 		}
-		args[i] = "<redacted>"
+		args[i] = auditlog.RedactToken
 		break
 	}
 	return args

--- a/internal/cli/clissocapture.go
+++ b/internal/cli/clissocapture.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/vault"
 )
 
@@ -411,7 +412,7 @@ func serveClissoConfig(openV vaultOpener) (fifo string, serving bool, cleanup fu
 		return "", false, nil, err
 	}
 	// Cheap gate before any vault (and unlock prompt) involvement.
-	if !bytes.Contains(data, []byte("jit://vault/")) {
+	if !bytes.Contains(data, []byte(pointerfile.ValuePrefix)) {
 		return "", false, nil, nil
 	}
 	v, err := openV()

--- a/internal/cli/logstamp.go
+++ b/internal/cli/logstamp.go
@@ -42,7 +42,7 @@ func (s *stampedWriter) Write(p []byte) (int, error) {
 	rest := p
 	for len(rest) > 0 {
 		if !s.midline {
-			buf.WriteString(time.Now().Format("2006-01-02 15:04:05 "))
+			buf.WriteString(time.Now().Format(auditTimeLayout + " "))
 			s.midline = true
 		}
 		i := bytes.IndexByte(rest, '\n')

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -451,7 +451,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 		// plaintext cache files as new needles, mid-sweep. A _backups/ entry
 		// is never a credential the user typed; it is jit's copy of a whole
 		// file, and its last path segment is a timestamp, not a variable name.
-		if strings.HasPrefix(secretPath, "_backups/") {
+		if vault.IsBackupPath(secretPath) {
 			return
 		}
 		val := string(value)

--- a/internal/cli/migrateremove.go
+++ b/internal/cli/migrateremove.go
@@ -683,7 +683,7 @@ func buildLooseFileRemovalPlan(root, home, file string, rv *vault.Vault) (looseF
 			return plan, fmt.Errorf("listing vault for origin match: %w", err)
 		}
 		for _, p := range paths {
-			if strings.HasPrefix(p, "_backups/") {
+			if vault.IsBackupPath(p) {
 				continue
 			}
 			info, err := rv.Info(p)
@@ -947,7 +947,7 @@ func buildProjectRemovalPlan(root, home, cwd string, rv *vault.Vault) (projectRe
 		for _, p := range paths {
 			// _backups/ entries are raw file snapshots handled by their own
 			// records below, never project secrets — skip them.
-			if deleteSet[p] || strings.HasPrefix(p, "_backups/") {
+			if deleteSet[p] || vault.IsBackupPath(p) {
 				continue
 			}
 			info, err := rv.Info(p)

--- a/internal/cli/outputstyle_test.go
+++ b/internal/cli/outputstyle_test.go
@@ -43,12 +43,16 @@ func TestNoUnroutedCommandBackticks(t *testing.T) {
 			if !strings.Contains(line, "`") || !printCall.MatchString(line) {
 				continue
 			}
-			if strings.Contains(line, "hlCmds") {
+			// hlCmds in internal/cli, highlightCmds in internal/audit; both
+			// now delegate to style.HighlightCommands.
+			if strings.Contains(line, "hlCmds") || strings.Contains(line, "highlightCmds") ||
+				strings.Contains(line, "HighlightCommands") {
 				continue
 			}
-			t.Errorf("%s:%d writes a `backticked` command without hlCmds, so it renders "+
-				"literal and uncolored. Wrap the message: hlCmds(fmt.Sprintf(...)).\n    %s",
-				filepath.Base(file), i+1, strings.TrimSpace(line))
+			t.Errorf("%s:%d writes a `backticked` command without routing it through the "+
+				"command highlighter, so it renders literal and uncolored. Wrap the message "+
+				"(hlCmds in internal/cli, highlightCmds in internal/audit).\n    %s",
+				filepath.ToSlash(file), i+1, strings.TrimSpace(line))
 		}
 	}
 }
@@ -240,23 +244,44 @@ func TestDoctorsRenderNoLiteralBackticks(t *testing.T) {
 	}
 }
 
-// styleCheckedFiles lists this package's own non-test sources, minus
-// style.go — which is where the palette is allowed to be built, and the one
-// file both checks above exist to protect.
+// styleCheckedFiles lists the non-test sources the two checks above police,
+// across EVERY package that prints to the terminal — not just this one.
+//
+// It used to be os.ReadDir("."), i.e. internal/cli alone, while
+// TestPaletteIsCentralised and TestNoFaintText correctly walk "..". So rule 5
+// of design/output-style.md — "cyan is the only colour a command ever takes,
+// on every surface" — went unenforced in audit, migrate, ui and wrap,
+// including the scan report, which is the largest user-facing surface jit has.
+//
+// internal/cli/style.go and internal/style are where the palette is allowed to
+// be built, and are the files these checks exist to protect.
 func styleCheckedFiles(t *testing.T) []string {
 	t.Helper()
-	entries, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatalf("reading package dir: %v", err)
-	}
 	var files []string
-	for _, e := range entries {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") ||
-			strings.HasSuffix(name, "_test.go") || name == "style.go" {
-			continue
+	err := filepath.WalkDir("..", func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
 		}
-		files = append(files, name)
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		// The palette's own definitions, and cli's re-export of them.
+		if name == "style.go" {
+			return nil
+		}
+		// markdown.go writes a MARKDOWN report to a file, not styled output to
+		// a terminal. Its backticks are markdown's own code-span syntax and
+		// must render literally; routing them through the highlighter would
+		// strip them and colour a document nobody views in a terminal.
+		if name == "markdown.go" {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
 	}
 	if len(files) == 0 {
 		t.Fatal("no source files found to check — the guard would pass vacuously")

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -90,24 +90,7 @@ func wrapBody(w io.Writer, used int, cont, body string) {
 // removed and the line reads as clean plain text. Use it on directive lines
 // ("run `jit x` to …"), not on every incidental mention, so cyan stays a
 // signal rather than noise.
-func hlCmds(s string) string {
-	var b strings.Builder
-	for {
-		i := strings.IndexByte(s, '`')
-		if i < 0 {
-			b.WriteString(s)
-			return b.String()
-		}
-		j := strings.IndexByte(s[i+1:], '`')
-		if j < 0 {
-			b.WriteString(s)
-			return b.String()
-		}
-		b.WriteString(s[:i])
-		b.WriteString(cPath.Sprint(s[i+1 : i+1+j]))
-		s = s[i+1+j+1:]
-	}
-}
+func hlCmds(s string) string { return style.HighlightCommands(s) }
 
 // maxFlowWidth caps how wide flowNames lays out, and maxFlowCols how many
 // columns, regardless of how wide the terminal is. Flowing to the full width

--- a/internal/cli/undo.go
+++ b/internal/cli/undo.go
@@ -53,7 +53,7 @@ var migrateUndoCmd = &cobra.Command{
 		"To see every restorable file first, run `jit migrate undo <dir> --dry-run`\n" +
 		"(e.g. your $HOME). Backups made by jit builds before this command existed\n" +
 		"aren't in its index, restore those by hand: `jit vault list` (look under\n" +
-		"_backups/) + `jit vault get <path>`.",
+		vault.BackupPathPrefix + ") + `jit vault get <path>`.",
 	Example: "  jit migrate undo ~/proj/.env    # restore one migrated file\n" +
 		"  jit migrate undo ~/proj         # restore everything migrated under a project\n" +
 		"  jit migrate undo ~/proj --dry-run",
@@ -122,7 +122,7 @@ func runMigrateUndo(cmd *cobra.Command, args []string) error {
 	// read as "that one file" rather than "nothing to restore anywhere."
 	all := migrate.LatestBackups(recs)
 	if len(all) == 0 {
-		fmt.Fprintln(out, hlCmds("No jit-written backups are recorded, nothing to restore. (Backups made by builds before `jit migrate undo` existed aren't indexed; see `jit vault list` under _backups/ for those.)"))
+		fmt.Fprintln(out, hlCmds("No jit-written backups are recorded, nothing to restore. (Backups made by builds before `jit migrate undo` existed aren't indexed; see `jit vault list` under "+vault.BackupPathPrefix+" for those.)"))
 		return nil
 	}
 	// args is non-empty (the command requires a path) and all is non-empty,
@@ -264,7 +264,7 @@ func nudgeLooseRemainders(out io.Writer, v *vault.Vault, home string, recs []mig
 	}
 	remaining := map[string]bool{}
 	for _, p := range paths {
-		if strings.HasPrefix(p, "_backups/") {
+		if vault.IsBackupPath(p) {
 			continue
 		}
 		info, err := v.Info(p)

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -1062,7 +1062,7 @@ var vaultHistoryCmd = &cobra.Command{
 		}
 		for _, hv := range versions {
 			when := time.Unix(0, hv.ArchiveStamp)
-			line := fmt.Sprintf("archived %s ago (%s)", humanAgo(time.Since(when)), when.Format("2006-01-02 15:04:05"))
+			line := fmt.Sprintf("archived %s ago (%s)", humanAgo(time.Since(when)), when.Format(auditTimeLayout))
 			if hv.UpdatedUnix > 0 {
 				line += fmt.Sprintf(", value from %s", time.Unix(hv.UpdatedUnix, 0).Format("2006-01-02"))
 			}

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -117,7 +117,7 @@ type vaultGetResult struct {
 func splitBackupPaths(paths []string) (secrets, backups []string) {
 	secrets, backups = []string{}, []string{}
 	for _, p := range paths {
-		if strings.HasPrefix(p, "_backups/") {
+		if vault.IsBackupPath(p) {
 			backups = append(backups, p)
 			continue
 		}
@@ -1379,7 +1379,7 @@ var vaultCleanCmd = &cobra.Command{
 		}
 		backups := 0
 		for _, p := range paths {
-			if strings.HasPrefix(p, "_backups/") {
+			if vault.IsBackupPath(p) {
 				backups++
 			}
 		}
@@ -1428,7 +1428,7 @@ var vaultPruneYes bool
 var vaultPruneCmd = &cobra.Command{
 	Use:   "prune",
 	Short: "Delete stale encrypted file backups, keeping each file's newest",
-	Long: "jit migrate backs a file up into the vault (under _backups/...) every time\n" +
+	Long: "jit migrate backs a file up into the vault (under " + vault.BackupPathPrefix + "...) every time\n" +
 		"it rewrites one, and `jit migrate undo` snapshots the pre-undo state too, so\n" +
 		"repeated migrate/undo cycles accumulate backups indefinitely, nothing\n" +
 		"expires them automatically, on purpose (a recovery snapshot silently aging\n" +
@@ -2130,7 +2130,7 @@ func init() {
 	vaultRmCmd.Flags().BoolVarP(&vaultRmForce, "force", "f", false, "synonym for --yes")
 	_ = vaultRmCmd.Flags().MarkHidden("force")
 	vaultListCmd.Flags().StringVar(&vaultListFormat, "format", "text", `output format: "text" (default) or "json"`)
-	vaultListCmd.Flags().BoolVar(&vaultListAll, "all", false, "also list jit migrate's encrypted file backups (_backups/...)")
+	vaultListCmd.Flags().BoolVar(&vaultListAll, "all", false, "also list jit migrate's encrypted file backups ("+vault.BackupPathPrefix+"...)")
 	vaultListCmd.Flags().BoolVarP(&vaultListLong, "long", "l", false, "show each secret's class and last-updated age (terminal output only)")
 	vaultListCmd.Flags().StringVar(&vaultListBy, "by", "path", `group secrets by: "path" (default), "origin" (source file), or "group" (import batch)`)
 	vaultExportCmd.Flags().BoolVar(&vaultExportStdin, "stdin", false, "read the passphrase from stdin instead of prompting (no confirmation double-entry)")

--- a/internal/inject/doc.go
+++ b/internal/inject/doc.go
@@ -5,5 +5,4 @@
 // (internal/vault) into plaintext environment variable values, shared by
 // jit run (RFC.md Pillar III Tier 1, process-overwrite injection) and
 // jit export (materializing a profile into the current shell session).
-// See task #9.
 package inject

--- a/internal/keychainwrap/keychainwrap.go
+++ b/internal/keychainwrap/keychainwrap.go
@@ -286,11 +286,6 @@ func (w *Wrapper) RequireUserPresence(reason string) error {
 	return nil
 }
 
-// deleteMEK removes the stored MEK for this Wrapper's service/account.
-// Test-only cleanup helper — normal CLI operation never deletes the MEK
-// (that would orphan every existing secret), and it's a method (not a
-// free function keyed on the shared production constants) precisely so a
-// test can only ever delete the identifier its own Wrapper was built with.
 // DeleteMEK permanently removes this wrapper's keychain-stored MEK — the
 // key protecting every secret in the vault. Exactly one caller exists on
 // purpose: `jit vault delete`, behind its own explicit confirmation.
@@ -304,6 +299,11 @@ func (w *Wrapper) DeleteMEK() error {
 	return w.deleteMEK()
 }
 
+// deleteMEK removes the stored MEK for this Wrapper's service/account.
+// Test-only cleanup helper — normal CLI operation never deletes the MEK
+// (that would orphan every existing secret), and it's a method (not a
+// free function keyed on the shared production constants) precisely so a
+// test can only ever delete the identifier its own Wrapper was built with.
 func (w *Wrapper) deleteMEK() error {
 	cService := C.CString(w.service)
 	defer C.free(unsafe.Pointer(cService))

--- a/internal/migrate/agentcache.go
+++ b/internal/migrate/agentcache.go
@@ -413,7 +413,7 @@ func CollectVaultSecrets(v *vault.Vault) ([]AgentCacheSecret, error) {
 	}
 	var out []AgentCacheSecret
 	for _, p := range paths {
-		if strings.HasPrefix(p, "_backups/") || strings.HasPrefix(p, "_history/") {
+		if vault.IsReservedPath(p) {
 			continue
 		}
 		val, err := v.Get(p)

--- a/internal/migrate/apply.go
+++ b/internal/migrate/apply.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jitpass/jit/internal/audit"
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/profile"
 	"github.com/jitpass/jit/internal/vault"
 )
@@ -85,7 +86,7 @@ func IsEnvBackupOnlySuffix(name string) bool {
 // Must be checked before envTemplateSuffixes — these are jit's own
 // artifacts, not user-authored templates, and folding them into that
 // map would misdescribe why they're skipped.
-const jitPointerFileSuffix = ".pointers"
+const jitPointerFileSuffix = pointerfile.CompanionSuffix
 const jitBackupMarker = ".jit-bak-"
 
 func isJitGeneratedEnvArtifact(name string) bool {

--- a/internal/migrate/clissoconfig.go
+++ b/internal/migrate/clissoconfig.go
@@ -12,6 +12,7 @@ import (
 
 	"gopkg.in/yaml.v3"
 
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/vault"
 )
 
@@ -50,7 +51,7 @@ func ClissoVaultPath(provider string) string {
 	return "wrap-clisso/" + provider + "-client-secret"
 }
 
-const clissoPointerPrefix = "jit://vault/"
+const clissoPointerPrefix = pointerfile.ValuePrefix
 
 // ClissoConfigMigration reports what ApplyClissoConfig moved.
 type ClissoConfigMigration struct {

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -27,7 +27,7 @@
 //   - .env files (apply.go/unmount.go), scoped to the chosen root (cwd for
 //     jit migrate local, $HOME for jit migrate home), converted into a
 //     profile + vault secrets + a live-mounted pipe (RFC.md Pillar III
-//     Tier 3, task #10) that jit unmount can reverse. A git-safe,
+//     Tier 3) that jit unmount can reverse. A git-safe,
 //     IDE-peekable <file>.pointers companion (pointerfile.go, GAPS.md #26)
 //     is written alongside it — see that file's own doc comment for why,
 //     including the just-in-time interception scheme that was considered

--- a/internal/migrate/pointerfile.go
+++ b/internal/migrate/pointerfile.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/profile"
 )
 
@@ -18,7 +19,7 @@ import (
 // WritePointerFile/ReplaceWithPointerFile write and the content-based
 // detection LooksLikePointerContent uses derive from this one constant, so
 // they can never drift.
-const pointerFileHeaderPrefix = "# jit pointer file"
+const pointerFileHeaderPrefix = pointerfile.Header
 
 // PointerFilePath returns the git-safe, human-readable companion file
 // jit migrate writes alongside a live-mounted .env/.npmrc at mountPath
@@ -27,7 +28,7 @@ const pointerFileHeaderPrefix = "# jit pointer file"
 // mount itself has (GAPS.md #6). Safe to commit to git for the same
 // reason a profile manifest is: it holds vault paths, never values.
 func PointerFilePath(mountPath string) string {
-	return mountPath + ".pointers"
+	return pointerfile.CompanionPath(mountPath)
 }
 
 // WritePointerFile writes a plain, regular file at PointerFilePath(mountPath)
@@ -114,7 +115,7 @@ func pointerFileContent(vars profile.Profile, order []string) []byte {
 	b.WriteString("# Real values reach a tool through `jit run` (the live mount serves them\n")
 	b.WriteString("# to that run), or `jit export`/`jit vault get`, never from this file. Safe to commit.\n")
 	for _, name := range names {
-		fmt.Fprintf(&b, "%s=jit://vault/%s\n", name, vars[name])
+		fmt.Fprintf(&b, "%s=%s\n", name, pointerfile.Value(vars[name]))
 	}
 	return []byte(b.String())
 }

--- a/internal/migrate/remove.go
+++ b/internal/migrate/remove.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/pointerfile"
 	"github.com/jitpass/jit/internal/vault"
 )
 
@@ -28,10 +29,10 @@ import (
 
 // pointerFileHeader is the first line WritePointerFile/ReplaceWithPointerFile
 // emit — IsPointerFile's detection anchor. Keep the two in sync.
-const pointerFileHeader = "# jit pointer file"
+const pointerFileHeader = pointerfile.Header
 
 // pointerValuePrefix is the value scheme every pointer line uses.
-const pointerValuePrefix = "jit://vault/"
+const pointerValuePrefix = pointerfile.ValuePrefix
 
 // IsPointerFile reports whether path is a regular file jit itself wrote in
 // the pointer format (never a live mount's FIFO — those are checked by

--- a/internal/migrate/renameadvisory.go
+++ b/internal/migrate/renameadvisory.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/jitpass/jit/internal/pointerfile"
 )
 
 // pointerVaultPrefix is the token every pointer-file line puts before a
 // secret's vault path (pointerfile.go writes "VAR=jit://vault/<ns>/<VAR>").
 // The namespace is the single path segment right after it.
-const pointerVaultPrefix = "jit://vault/"
+const pointerVaultPrefix = pointerfile.ValuePrefix
 
 // DetectRenamedRootProject reports whether the project at root was migrated
 // under a different folder name than root's current basename — the common
@@ -50,8 +52,8 @@ func DetectRenamedRootProject(root string) (oldName, newName string, ok bool) {
 			continue
 		}
 		name := e.Name()
-		envName := strings.TrimSuffix(name, ".pointers")
-		if envName == name { // no .pointers suffix
+		envName, isCompanion := pointerfile.TrimCompanionSuffix(name)
+		if !isCompanion {
 			continue
 		}
 		if !envFileNamePattern.MatchString(envName) {

--- a/internal/migrate/shellconfig.go
+++ b/internal/migrate/shellconfig.go
@@ -397,5 +397,5 @@ func storeSecretBackup(v *vault.Vault, path string, data []byte, snapshot bool, 
 // what a given backup belongs to.
 func backupVaultPath(absPath string, unixTS int64) string {
 	safe := vaultPathUnsafeChars.ReplaceAllString(strings.TrimPrefix(absPath, string(filepath.Separator)), "_")
-	return fmt.Sprintf("_backups/%s.jit-bak-%d", safe, unixTS)
+	return fmt.Sprintf("%s%s.jit-bak-%d", vault.BackupPathPrefix, safe, unixTS)
 }

--- a/internal/pointerfile/pointerfile.go
+++ b/internal/pointerfile/pointerfile.go
@@ -1,0 +1,80 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+// Package pointerfile owns the on-disk format `jit migrate` leaves in place
+// of a credential: the header that marks a file as jit's own, the `jit://`
+// value that names a vault path instead of holding a secret, and the suffix
+// of the git-safe companion written beside a live mount.
+//
+// It exists because the format had three components and thirteen spellings,
+// in four packages, with no owner. internal/migrate WRITES it, internal/audit
+// READS it to avoid re-reporting an already-migrated file as an exposed
+// secret, internal/cli and internal/mount both test for it — and each declared
+// its own const, under three different names for the same string
+// (pointerFileHeader / pointerFileHeaderPrefix, pointerValuePrefix /
+// pointerVaultPrefix / clissoPointerPrefix), plus four inline literals.
+//
+// The failure that shape produces is documented in both packages' comments as
+// a real incident (GAPS.md #30). Change the header wording in the writer and
+// audit stops recognising its own output, so `jit scan` reports every
+// already-migrated file as an exposed secret — the re-discovery incident where
+// a second `jit migrate local` run parsed a `.pointers` companion's
+// `KEY=jit://vault/...` lines as if they were real credentials and converted
+// the git-safe companion itself into a live mount.
+//
+// Deliberately a leaf: no imports beyond the standard library, so it can sit
+// below internal/audit, internal/migrate, internal/cli and internal/mount
+// without adding an edge between any of them — the same shape internal/style
+// has for the output vocabulary.
+package pointerfile
+
+import "strings"
+
+const (
+	// Header is the first line of a file jit rewrote in place. Matched as a
+	// PREFIX: the written header continues with guidance for whoever opens
+	// the file, and only this much is the marker.
+	Header = "# jit pointer file"
+
+	// ValuePrefix introduces a vault path where a credential used to be, in
+	// `KEY=jit://vault/<path>` form. Its whole job is to be recognisable:
+	// anything reading a config must be able to tell "this is a reference"
+	// from "this is a secret", and a value that fails that test gets stored
+	// in the vault a second time as though it were a credential.
+	ValuePrefix = "jit://vault/"
+
+	// CompanionSuffix names the git-safe file written ALONGSIDE a live mount
+	// (`.env` -> `.env.pointers`), listing which vault path each variable
+	// resolves to. Committable and IDE-peekable, holding no secret.
+	CompanionSuffix = ".pointers"
+)
+
+// Value renders vaultPath as a pointer value.
+func Value(vaultPath string) string { return ValuePrefix + vaultPath }
+
+// IsValue reports whether s is a pointer rather than a real credential.
+func IsValue(s string) bool { return strings.HasPrefix(s, ValuePrefix) }
+
+// VaultPath returns the vault path a pointer value names, and whether s was a
+// pointer at all. Callers that only need the yes/no want IsValue.
+func VaultPath(s string) (string, bool) {
+	rest, ok := strings.CutPrefix(s, ValuePrefix)
+	return rest, ok
+}
+
+// HasHeader reports whether content begins with the pointer-file marker.
+func HasHeader(content []byte) bool {
+	return strings.HasPrefix(string(content), Header)
+}
+
+// CompanionPath returns the companion file written beside path.
+func CompanionPath(path string) string { return path + CompanionSuffix }
+
+// TrimCompanionSuffix returns the file a companion belongs to, and whether
+// name was a companion at all.
+func TrimCompanionSuffix(name string) (string, bool) {
+	return strings.CutSuffix(name, CompanionSuffix)
+}
+
+// IsCompanion reports whether name is one of jit's `.pointers` companions.
+func IsCompanion(name string) bool { return strings.HasSuffix(name, CompanionSuffix) }

--- a/internal/pointerfile/pointerfile_test.go
+++ b/internal/pointerfile/pointerfile_test.go
@@ -1,0 +1,107 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package pointerfile
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestValueRoundTrip(t *testing.T) {
+	const vaultPath = "mcp-alpha/TOKEN"
+	v := Value(vaultPath)
+	if !IsValue(v) {
+		t.Fatalf("Value(%q) = %q, which IsValue rejects; a reader would treat jit's own pointer as a credential and vault it a second time", vaultPath, v)
+	}
+	got, ok := VaultPath(v)
+	if !ok || got != vaultPath {
+		t.Errorf("VaultPath(%q) = (%q, %v), want (%q, true)", v, got, ok, vaultPath)
+	}
+	// A real credential must NOT read as a pointer, or migrate would skip it.
+	for _, notPointer := range []string{
+		"", "sk-ant-api03-realvalue", "https://vault/example", "jit://other/thing",
+	} {
+		if IsValue(notPointer) {
+			t.Errorf("IsValue(%q) = true; a real credential read as a pointer is silently left in place", notPointer)
+		}
+	}
+}
+
+func TestCompanionRoundTrip(t *testing.T) {
+	const env = "/proj/.env.local"
+	c := CompanionPath(env)
+	if !IsCompanion(c) {
+		t.Fatalf("CompanionPath(%q) = %q, which IsCompanion rejects", env, c)
+	}
+	got, ok := TrimCompanionSuffix(c)
+	if !ok || got != env {
+		t.Errorf("TrimCompanionSuffix(%q) = (%q, %v), want (%q, true)", c, got, ok, env)
+	}
+	if _, ok := TrimCompanionSuffix("/proj/.env"); ok {
+		t.Error("a plain .env reported as a companion; migrate would skip a real file")
+	}
+}
+
+func TestHasHeader(t *testing.T) {
+	if !HasHeader([]byte(Header + " — do not edit\nKEY=" + Value("ns/KEY") + "\n")) {
+		t.Error("a file jit wrote is not recognised by its own header check")
+	}
+	if HasHeader([]byte("# some other file\n")) {
+		t.Error("an unrelated comment read as jit's header")
+	}
+	if HasHeader(nil) {
+		t.Error("empty content read as a pointer file")
+	}
+}
+
+// TestNoRawFormatSpellingsOutsideThisPackage is the guard that gives the format
+// an owner rather than thirteen copies.
+//
+// Both packages' comments record the same real incident (GAPS.md #30): change
+// the header wording in the writer and audit stops recognising jit's own
+// output, so `jit scan` reports every already-migrated file as an exposed
+// secret — and a second `jit migrate` run parses a `.pointers` companion's
+// KEY=jit://vault/... lines as though they were real credentials.
+//
+// Test files are exempt on purpose, for the reason vault's namespace guard
+// gives: a fixture should carry the literal, so both sides of an assertion
+// cannot move together.
+func TestNoRawFormatSpellingsOutsideThisPackage(t *testing.T) {
+	spellings := []string{Header, ValuePrefix, CompanionSuffix}
+	var offenders []string
+	err := filepath.WalkDir("..", func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(path, "_test.go") || strings.Contains(filepath.ToSlash(path), "/pointerfile/") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- walking jit's own source tree
+		if readErr != nil {
+			return nil
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			code := line
+			if idx := strings.Index(code, "//"); idx >= 0 {
+				code = code[:idx] // prose describes the format freely
+			}
+			for _, sp := range spellings {
+				if strings.Contains(code, `"`+sp) || strings.Contains(code, sp+`"`) {
+					offenders = append(offenders, filepath.ToSlash(path)+":"+strconv.Itoa(i+1)+" ("+sp+")")
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("pointer-file format spelled out in code rather than using this package:\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/profile/doc.go
+++ b/internal/profile/doc.go
@@ -6,7 +6,7 @@
 // variable names to vault secret paths, decoupled from the vault tree
 // itself. jit doctor (internal/cli/doctor.go) is the first consumer —
 // it loads profiles from this package and checks each referenced path
-// actually exists in the vault. See task #8.
+// actually exists in the vault.
 //
 // Load(root, name) also falls back to GlobalRoot() (os.UserHomeDir()) when
 // a profile isn't found relative to root — for secrets not tied to one

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -27,7 +27,11 @@
 // design/output-style.md. Keep the two in step.
 package style
 
-import "github.com/fatih/color"
+import (
+	"strings"
+
+	"github.com/fatih/color"
+)
 
 // The palette: six inks and one attribute, and nothing else. No blue, no
 // magenta, no backgrounds, no 256-color or truecolor.
@@ -152,3 +156,37 @@ const (
 // by "GlyphDone <text>" when it settles. Plain, so a transient frame never
 // competes with the report it precedes.
 var SpinnerFrames = []rune{'⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'}
+
+// HighlightCommands renders `backtick`-delimited command spans in Path (cyan,
+// the house colour for something the reader can type or open) and drops the
+// backticks. When colour is off — piped output, TERM=dumb, tests — Path.Sprint
+// returns the text unchanged, so the backticks are simply removed and the line
+// reads as clean plain text.
+//
+// Use it on directive lines ("run `jit x` to …"), not on every incidental
+// mention, so cyan stays a signal rather than noise.
+//
+// It lives here because it existed TWICE, character for character apart from
+// the name of the colour variable: internal/cli's hlCmds and internal/audit's
+// highlightCmds, the latter's own comment calling itself "the audit-package
+// twin". Both packages already import this one, which owns Path — so the
+// duplication bought nothing, and design/output-style.md's "always via hlCmds"
+// could not be true while there were two of them.
+func HighlightCommands(s string) string {
+	var b strings.Builder
+	for {
+		i := strings.IndexByte(s, '`')
+		if i < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		j := strings.IndexByte(s[i+1:], '`')
+		if j < 0 {
+			b.WriteString(s)
+			return b.String()
+		}
+		b.WriteString(s[:i])
+		b.WriteString(Path.Sprint(s[i+1 : i+1+j]))
+		s = s[i+1+j+1:]
+	}
+}

--- a/internal/vault/crypto.go
+++ b/internal/vault/crypto.go
@@ -80,7 +80,7 @@ func open(key, sealed, aad []byte) ([]byte, error) {
 // once it's no longer needed. Not a guarantee against a GC-moved copy or a
 // swapped page; real in-memory hardening (mlock, memguard) is out of scope
 // for this first cut of the vault — see spike/memguard/ for the validated
-// mechanism this can grow into once jit-agent (task #9) exists.
+// mechanism this can grow into now that internal/agent exists.
 func wipe(b []byte) {
 	for i := range b {
 		b[i] = 0

--- a/internal/vault/doc.go
+++ b/internal/vault/doc.go
@@ -6,6 +6,5 @@
 // random AES-256-GCM Data Encryption Key, itself wrapped by whatever
 // KeyWrapper the caller provides. This package has no opinion on how the
 // wrapping key is protected — see internal/keychainwrap for Phase 1's
-// interim implementation and its real guarantee level (RFC.md B9). See
-// task #6.
+// interim implementation and its real guarantee level (RFC.md B9).
 package vault

--- a/internal/vault/history.go
+++ b/internal/vault/history.go
@@ -38,7 +38,7 @@ import (
 const (
 	// historyDirName lives directly under vault/ alongside the secrets it
 	// shadows and _backups/.
-	historyDirName = "_history"
+	historyDirName = HistoryNamespace
 	// HistoryKeep bounds versions kept per secret. Five covers "the last
 	// few rotations" without ever letting a set-in-a-loop script grow the
 	// vault without bound.
@@ -68,7 +68,7 @@ func (v *Vault) historyDir(path string) string {
 // _backups/ entries are deliberately never archived: they're already the
 // safety copy of something else, and history-of-backups is pure bloat.
 func (v *Vault) archiveVersion(path string, data []byte, stamp int64) error {
-	if strings.HasPrefix(path, "_backups/") {
+	if IsBackupPath(path) {
 		return nil
 	}
 	dest := filepath.Join(v.historyDir(path), fmt.Sprintf("%d.enc", stamp))

--- a/internal/vault/namespace.go
+++ b/internal/vault/namespace.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import "strings"
+
+// Reserved namespaces: vault paths jit writes for its OWN bookkeeping, rather
+// than secrets a user asked it to keep. Both are excluded from the surfaces
+// that mean "your secrets" — List's headline count, export, completion — and a
+// caller that forgets to exclude one shows migrate's undo snapshots to a user
+// asking what is in their vault.
+//
+// These exist because the prefixes were string literals at ten call sites
+// across internal/cli, internal/migrate and this package, and the OWNING
+// package did not name them either: vault's own archiveVersion tested
+// `strings.HasPrefix(path, "_backups/")` with the same literal every borrower
+// used. A namespace whose spelling lives in ten places is not a contract, it
+// is ten copies of one, and the failure on renaming it is silent in the worst
+// direction — a missed site stops excluding, so backup copies of credentials
+// start appearing wherever that site feeds.
+//
+// sanitizeSecretPath admits no path that could collide with these accidentally
+// (see path.go): a real profile namespace cannot begin with an underscore.
+const (
+	// BackupNamespace holds `jit migrate`'s undo snapshots — the encrypted
+	// copy of a file as it was before migrate rewrote it.
+	BackupNamespace = "_backups"
+	// HistoryNamespace holds superseded versions of a secret, shadowing the
+	// live path (history.go).
+	HistoryNamespace = "_history"
+
+	// BackupPathPrefix and HistoryPathPrefix are the namespaces as a vault
+	// path prefix, i.e. with the separator, for HasPrefix-style tests.
+	BackupPathPrefix  = BackupNamespace + "/"
+	HistoryPathPrefix = HistoryNamespace + "/"
+)
+
+// IsBackupPath reports whether p is one of `jit migrate undo`'s snapshots
+// rather than a secret.
+func IsBackupPath(p string) bool { return strings.HasPrefix(p, BackupPathPrefix) }
+
+// IsHistoryPath reports whether p is an archived previous version rather than
+// a live secret.
+func IsHistoryPath(p string) bool { return strings.HasPrefix(p, HistoryPathPrefix) }
+
+// IsReservedPath reports whether p lives in any namespace jit owns for its own
+// bookkeeping. The test a caller listing "the user's secrets" wants, so that
+// adding a third namespace later is one edit here rather than a hunt for every
+// site that happened to check two.
+func IsReservedPath(p string) bool { return IsBackupPath(p) || IsHistoryPath(p) }

--- a/internal/vault/namespace_test.go
+++ b/internal/vault/namespace_test.go
@@ -1,0 +1,94 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestReservedNamespaceClassification(t *testing.T) {
+	cases := []struct {
+		path            string
+		backup, history bool
+	}{
+		{"_backups/Users_x_app_.env.jit-bak-1", true, false},
+		{"_history/stripe/live-key/1234.enc", false, true},
+		{"stripe/live-key", false, false},
+		// Neither prefix may match a path that merely CONTAINS the name, or a
+		// user's own "backups/…" group would vanish from their vault listing.
+		{"backups/thing", false, false},
+		{"app/_backups/thing", false, false},
+		{"_backupsomething/thing", false, false},
+		{"", false, false},
+	}
+	for _, c := range cases {
+		if got := IsBackupPath(c.path); got != c.backup {
+			t.Errorf("IsBackupPath(%q) = %v, want %v", c.path, got, c.backup)
+		}
+		if got := IsHistoryPath(c.path); got != c.history {
+			t.Errorf("IsHistoryPath(%q) = %v, want %v", c.path, got, c.history)
+		}
+		if got, want := IsReservedPath(c.path), c.backup || c.history; got != want {
+			t.Errorf("IsReservedPath(%q) = %v, want %v", c.path, got, want)
+		}
+	}
+}
+
+// TestNoRawReservedPrefixOutsideThisFile is the guard that gives the namespaces
+// an owner rather than ten copies.
+//
+// Both prefixes were string literals at ten call sites across internal/cli,
+// internal/migrate and this package — and vault itself, the owner, used the
+// same bare literal every borrower did. Renaming one fails silently in the
+// worst direction: a missed site stops EXCLUDING, so `jit migrate`'s encrypted
+// backup copies of credentials start appearing wherever that site feeds.
+//
+// Walks the whole tree, not just this package: the borrowers are the point.
+func TestNoRawReservedPrefixOutsideThisFile(t *testing.T) {
+	root := ".."
+	var offenders []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Test files are exempt ON PURPOSE. A fixture path SHOULD be the
+		// literal "_backups/…": building it from the constant under test makes
+		// both sides of the comparison move together, which is how an
+		// assertion stops being able to fail. Same reasoning that took
+		// shortVersion() out of internal/cli's status expectations.
+		if strings.HasSuffix(path, "_test.go") || filepath.Base(path) == "namespace.go" {
+			return nil
+		}
+		data, readErr := os.ReadFile(path) // #nosec G304 -- walking jit's own source tree
+		if readErr != nil {
+			return nil
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			code := line
+			if idx := strings.Index(code, "//"); idx >= 0 {
+				code = code[:idx] // prose may name the namespace freely
+			}
+			// Any occurrence in code, not just a quote-adjacent one: the
+			// namespace also appears mid-string in help text, and help that
+			// names a directory the vault no longer uses is the same drift
+			// with a user on the other end of it.
+			if strings.Contains(code, BackupPathPrefix) || strings.Contains(code, HistoryPathPrefix) {
+				offenders = append(offenders, filepath.ToSlash(path)+":"+strconv.Itoa(i+1))
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+	if len(offenders) > 0 {
+		t.Errorf("reserved namespace spelled out in code rather than using vault's constants:\n  %s\n"+
+			"use BackupPathPrefix/HistoryPathPrefix or IsBackupPath/IsHistoryPath/IsReservedPath",
+			strings.Join(offenders, "\n  "))
+	}
+}

--- a/internal/vault/path.go
+++ b/internal/vault/path.go
@@ -43,27 +43,6 @@ func invalidPath(format string, a ...any) error {
 	return &invalidPathError{msg: fmt.Sprintf(format, a...)}
 }
 
-// sanitizeSecretPath validates a user-supplied secret path and returns the
-// absolute file path it maps to under vaultDir. Rejecting anything outside
-// secretPathPattern up front, then re-checking the resulting path still
-// falls under vaultDir after filepath.Clean, is deliberate defense in
-// depth: the regexp should already make traversal impossible, but a
-// filesystem path derived from user input is exactly the kind of place a
-// single missed edge case turns into a real path-traversal bug.
-//
-// Beyond traversal, the path must map to its file WITHOUT normalization:
-// a v2 payload's AAD is bound to the path exactly as given (envelopeAAD),
-// so any input the filesystem resolves to a different name than the AAD
-// records decrypts never — and fails with the "corrupted/tampered" error,
-// the one message that makes a user fear a healthy vault is gone. Two
-// real cases are rejected here for exactly that reason: "." segments
-// (collapsed by filepath.Join, so "a/./b" stored at a/b.enc with an AAD
-// of "a/./b") and letter-case variants of an existing entry (the default
-// macOS filesystem is case-insensitive, so "stripe/dev-key" opens
-// Dev-Key.enc while the AAD says otherwise — see rejectCaseVariant).
-//
-// Every rejection here wraps ErrInvalidPath, so a caller can tell a bad path
-// from a bad store.
 // ValidatePath reports whether path is a legal secret path, using only the
 // checks that need nothing from the filesystem: shape, traversal segments,
 // and the reserved history namespace.
@@ -104,6 +83,27 @@ func ValidatePath(path string) error {
 	return nil
 }
 
+// sanitizeSecretPath validates a user-supplied secret path and returns the
+// absolute file path it maps to under vaultDir. Rejecting anything outside
+// secretPathPattern up front, then re-checking the resulting path still
+// falls under vaultDir after filepath.Clean, is deliberate defense in
+// depth: the regexp should already make traversal impossible, but a
+// filesystem path derived from user input is exactly the kind of place a
+// single missed edge case turns into a real path-traversal bug.
+//
+// Beyond traversal, the path must map to its file WITHOUT normalization:
+// a v2 payload's AAD is bound to the path exactly as given (envelopeAAD),
+// so any input the filesystem resolves to a different name than the AAD
+// records decrypts never — and fails with the "corrupted/tampered" error,
+// the one message that makes a user fear a healthy vault is gone. Two
+// real cases are rejected here for exactly that reason: "." segments
+// (collapsed by filepath.Join, so "a/./b" stored at a/b.enc with an AAD
+// of "a/./b") and letter-case variants of an existing entry (the default
+// macOS filesystem is case-insensitive, so "stripe/dev-key" opens
+// Dev-Key.enc while the AAD says otherwise — see rejectCaseVariant).
+//
+// Every rejection here wraps ErrInvalidPath, so a caller can tell a bad path
+// from a bad store.
 func sanitizeSecretPath(vaultDir, path string) (string, error) {
 	if err := ValidatePath(path); err != nil {
 		return "", err


### PR DESCRIPTION
Tranche E off the 2026-08-06 handoff. Five commits, best reviewed one at a time.

## Contracts that had no owner

**`"_backups/"` and `"_history/"`** were string literals at ten call sites across `internal/cli`, `internal/migrate` and `internal/vault` — and the *owning* package used the same bare literal every borrower did (`archiveVersion` tested `strings.HasPrefix(path, "_backups/")` by hand). Every one of those sites **excludes** the namespace, so a missed site on a rename stops excluding, and `jit migrate`'s encrypted backup copies of credentials start appearing wherever it feeds.

Now `vault.BackupNamespace`/`HistoryNamespace` + `IsBackupPath`/`IsHistoryPath`/`IsReservedPath`. This also caught the **write** site the reader-side survey missed (`backupVaultPath` builds the prefix with `Sprintf`, so it doesn't look like a prefix test).

**The pointer-file format** had three components and thirteen spellings in four packages, under three different names for the same string. Both packages' comments record the same real incident (GAPS.md #30) as the consequence. Now `internal/pointerfile`, a leaf with no internal imports, sitting below audit/migrate/cli/mount like `internal/style` does for the palette.

**`auditTimeLayout`** was bypassed by three sites including its own `--since` parser and error message. **`auditlog.redactToken`** was unexported, so `internal/cli` retyped `"<redacted>"` to mask the one argument auditlog can't see.

**`hlCmds` existed twice** — character for character apart from the colour variable's name, the audit copy's own comment calling it "the audit-package twin". Now `style.HighlightCommands`, with both local names kept as delegates.

## A guard that only looked at one package

`TestNoUnroutedCommandBackticks` and `TestNoHandRolledColors` iterated `os.ReadDir(".")` — `internal/cli` only — while the other two style guards correctly walk `..`. So rule 5 was unenforced in audit, migrate, ui and wrap, **including the scan report**, the largest user-facing surface jit has.

Widening it found **no violations**, which is worth stating plainly. What it did find was `internal/audit/markdown.go` — a **false positive**: that file writes a markdown report to disk, so its backticks are markdown's own code-span syntax and must render literally. Excluded by name with the reason recorded.

## Comments describing code that isn't there

- `go doc ValidatePath` opened with *"sanitizeSecretPath validates…"* — a 20-line block with no blank line before the next one, promising three things `ValidatePath` doesn't do. `jit vault rm` pre-validates with it.
- `DeleteMEK` documented itself as both *"Test-only cleanup helper"* and *"Never call this from a test"*, from the same merged-comment bug. `jit vault delete` is a production caller.
- **Nine** references to `task #N` cited a tracker that has never existed here (`git log --all -- TASKS.md` is empty). The handoff listed two.
- `CONTRIBUTING.md` had a clickable relative link to `docs/internal/WRAP-PLAN.md`, which isn't in the repo — a 404 on the one pointer explaining how the shim-vs-native kind is chosen. Now cited the way `RFC.md`/`GAPS.md` already are in that same file.
- `report.go` had a "Dim the nothing-found rows" comment outliving the faint removal, above an `n == 0` arm byte-identical to `default`.

## One claim I did NOT act on as written

`design/output-style.md` said *"Never build a colour or type a glyph literal at a call site: `TestPaletteIsCentralised` fails on it."* The glyph half has never been true. I measured the real scale — **~100 sites in 18 files** (41 `→`, 49 `•`, plus `✓└●✗─`) — and that is its own piece of work with ~100 user-visible output substitutions, not a tail-end sweep. So the doc now states what is actually enforced and marks the glyph half as convention-with-missing-enforcement, rather than continuing to assert a guard that doesn't exist. Scoped as a follow-up with the measurements recorded.

## Two corrections to the handoff

- It said `style.GlyphBullet` and `style.GlyphBranch` are "referenced from no production code at all". **`GlyphBranch` is used**, at `internal/audit/triage.go:1088`. Only `GlyphBullet` is unreferenced.
- It counted `"_backups/"` at 8 raw sites; there are **13**.

## Verification

Every mechanical change is mutation-verified — reintroduce a raw literal and the guard names the line; rename `BackupNamespace` and only *test fixtures* fail, never production (the intended split, since fixtures must carry literals or both sides of an assertion move together); change `pointerfile.Header` and reader and writer now move together where previously the writer moved alone and nothing failed.

Two mutations needed a second attempt and are called out in the commits: one added `color.New` without its import, so nothing compiled and the "pass" proved nothing.

Full suite green under `-race`; `gofmt`, `go vet`, pinned `staticcheck` clean; `docs-gen` shows no drift. Help-text and report output verified byte-identical where strings moved behind constants.

Merges cleanly with #25, #26, #27 and #28.

Note CI may not report — GitHub Actions is in an active incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4