### PR TITLE
migrate: give ~/.claude.json's findings a fix path

### DIFF
--- a/internal/audit/mcpconfig.go
+++ b/internal/audit/mcpconfig.go
@@ -134,6 +134,18 @@ func scanClaudeDesktopMCPConfig(cfg Config) ([]Finding, error) {
 // mcpServers block, not an MCP config by name. Dogfooding found a real one
 // holding a server with an env block, unscanned.
 func fixedMCPConfigPaths(home string) []string {
+	return FixedMCPConfigPaths(home)
+}
+
+// FixedMCPConfigPaths is the exported form, because this list is a CONTRACT
+// with internal/migrate: every path scanned here produces findings whose only
+// fix path is `jit migrate`, so a path this returns and migrate's discovery
+// does not know about is a finding the user cannot act on. That was
+// ~/.claude.json for a long time — scan reported a CRITICAL/HIGH MCP secret in
+// it, `jit migrate` walked past it, and `jit migrate ~/.claude.json` said
+// there was nothing to do, with zero errors anywhere. migrate now iterates
+// THIS list rather than keeping its own copy of one entry.
+func FixedMCPConfigPaths(home string) []string {
 	return []string{
 		filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
 		filepath.Join(home, ".claude.json"),

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -1518,7 +1518,16 @@ func discoverFileTarget(d *discovered, home, path string) error {
 		}
 		d.pypircFiles = append(d.pypircFiles, filterToTarget(files, path)...)
 		return nil
-	case migrate.ClaudeDesktopConfigPath(home):
+	}
+	// The fixed MCP configs are a LIST (Claude Desktop's file plus
+	// ~/.claude.json), so they're matched against audit's list rather than
+	// being one more case above — a fixed path audit scans but this switch
+	// doesn't know about is a finding `jit migrate <path>` answers "nothing
+	// to do" on, with zero errors anywhere. That was ~/.claude.json.
+	for _, fixed := range audit.FixedMCPConfigPaths(home) {
+		if path != fixed {
+			continue
+		}
 		// Passing path (the config file itself) as the walk root adds nothing
 		// via the walk — its name isn't one of the project mcp.json names —
 		// while includeClaudeDesktop=true is what actually pulls it in; the

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -715,6 +715,14 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 					displayPath(home, mcpPath), sm.ServerName, sm.ProfileName, countWord(len(sm.Variables), "var", "vars"), result.BackupPath)))
 				noteNamespaceMove(out, sm.NamespaceMovedFrom, sm.ProfileName)
 			}
+			// A project block that could not be parsed still holds whatever
+			// `jit scan` flagged. Saying nothing here would report success
+			// over a file that is still partly exposed — the exact
+			// zero-errors dead end the projects support exists to close.
+			for _, dir := range result.SkippedProjects {
+				fmt.Fprintf(out, "  %s project block %s couldn't be parsed and was left unchanged — its servers are NOT migrated; fix the JSON and re-run\n",
+					glyphWarn, dir)
+			}
 		}
 		fmt.Fprintf(out, "  Restart the %s above to pick up the change.\n", pluralWord(n, "MCP host", "MCP hosts"))
 		fmt.Fprintln(out)

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jitpass/jit/internal/audit"
 	"github.com/jitpass/jit/internal/migrate"
 )
 
@@ -274,9 +275,12 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 // printMigratePlan can render them in different sections instead of
 // implying both belong in the same section of the plan.
 func splitMCPByScope(home string, mcpConfigs []string) (scoped, fixed []string) {
-	claudePath := migrate.ClaudeDesktopConfigPath(home)
+	fixedPaths := map[string]bool{}
+	for _, p := range audit.FixedMCPConfigPaths(home) {
+		fixedPaths[p] = true
+	}
 	for _, path := range mcpConfigs {
-		if path == claudePath {
+		if fixedPaths[path] {
 			fixed = append(fixed, path)
 		} else {
 			scoped = append(scoped, path)

--- a/internal/migrate/mcpconfig.go
+++ b/internal/migrate/mcpconfig.go
@@ -62,11 +62,9 @@ type MCPConfigMigration struct {
 	Servers    []MCPServerMigration
 }
 
-// ClaudeDesktopConfigPath is exported (alongside AWSCredentialsPath,
-// KubeconfigPath, GlobalNpmrcPath) so internal/cli can tell this one
-// always-checked fixed path apart from a project-scoped mcp.json/.mcp.json
-// finding in the same DiscoverMCPConfigs result — needed to group a
-// migrate plan into "scoped to this run" vs "machine-wide" sections.
+// ClaudeDesktopConfigPath is Claude Desktop's fixed config location. Retained
+// for callers that need THIS one path; scope decisions in internal/cli go
+// through audit.FixedMCPConfigPaths, which also carries ~/.claude.json.
 func ClaudeDesktopConfigPath(home string) string {
 	return filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json")
 }
@@ -75,12 +73,15 @@ func ClaudeDesktopConfigPath(home string) string {
 // project-scoped mcp.json/.mcp.json files under cwd — NOT a home-wide
 // walk, matching DiscoverEnvFiles' own deliberately narrower blast radius
 // for real (non-dry-run) mutation — plus, when includeClaudeDesktop is
-// true, the fixed Claude Desktop path (a single well-known global file
-// that lives under $HOME regardless of which project cwd is, so
-// `jit migrate local` never includes it — only a `home` run does; see
-// internal/cli's runMigrate). Only returns files with at least one server
-// that has something to migrate — a non-empty env block, or an --env-file
-// naming a readable file (hasMigratableCredentials).
+// true, audit.FixedMCPConfigPaths' fixed locations (Claude Desktop's config
+// and ~/.claude.json, files that live under $HOME regardless of which
+// project cwd is, so `jit migrate local` never includes them — only a
+// `home` run does; see internal/cli's runMigrate). This used to claim to
+// mirror audit's discovery while knowing only the Desktop path, which left
+// every ~/.claude.json finding without a fix path. Only returns files with
+// at least one server that has something to migrate — a non-empty env
+// block, or an --env-file naming a readable file
+// (hasMigratableCredentials).
 func DiscoverMCPConfigs(home, cwd string, includeClaudeDesktop bool) ([]string, error) {
 	return discoverMCPConfigFiles(home, cwd, includeClaudeDesktop, hasMigratableCredentials)
 }
@@ -116,9 +117,13 @@ func discoverMCPConfigFiles(home, cwd string, includeClaudeDesktop bool, accept 
 	}
 
 	if includeClaudeDesktop {
-		claudePath := ClaudeDesktopConfigPath(home)
-		if _, err := os.Stat(claudePath); err == nil {
-			check(claudePath)
+		// audit.FixedMCPConfigPaths, not a local copy: every path audit scans
+		// at a fixed location needs a fix path here, or its findings are dead
+		// ends (the ~/.claude.json gap — see that function's comment).
+		for _, fixed := range audit.FixedMCPConfigPaths(home) {
+			if _, err := os.Stat(fixed); err == nil {
+				check(fixed)
+			}
 		}
 	}
 
@@ -170,23 +175,24 @@ func discoverMCPConfigFiles(home, cwd string, includeClaudeDesktop bool, accept 
 // failing, since a plan must still render for a file apply will fail on for
 // its own reasons.
 func MCPEnvFilePreview(path string) []string {
-	_, _, servers, err := loadMCPFile(path)
+	_, blocks, err := loadMCPFile(path)
 	if err != nil {
 		return nil
 	}
-	names := make([]string, 0, len(servers))
-	for name := range servers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
 	var found []string
 	seen := map[string]bool{}
-	for _, name := range names {
-		for _, target := range migratableEnvFiles(path, servers[name]) {
-			if !seen[target] {
-				seen[target] = true
-				found = append(found, target)
+	for _, b := range blocks {
+		names := make([]string, 0, len(b.servers))
+		for name := range b.servers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			for _, target := range migratableEnvFiles(path, b.servers[name]) {
+				if !seen[target] {
+					seen[target] = true
+					found = append(found, target)
+				}
 			}
 		}
 	}
@@ -207,11 +213,11 @@ func MCPEnvFilePreview(path string) []string {
 // write and profile manifest write happens before path itself is
 // rewritten, and path is backed up first.
 func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
-	topLevel, serversKey, servers, err := loadMCPFile(path)
+	topLevel, blocks, err := loadMCPFile(path)
 	if err != nil {
 		return MCPConfigMigration{}, fmt.Errorf("reading %s: %w", path, err)
 	}
-	if serversKey == "" {
+	if len(blocks) == 0 {
 		return MCPConfigMigration{}, fmt.Errorf("%s has no mcpServers/servers block", path)
 	}
 
@@ -224,36 +230,53 @@ func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
 		return MCPConfigMigration{}, fmt.Errorf("resolving global profile root: %w", err)
 	}
 
-	names := make([]string, 0, len(servers))
-	for name := range servers {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	// Every --env-file target is read ONCE, before any of them is rewritten.
-	// Neutralizing inside the per-server loop was a silent corruption when two
-	// servers shared one file: the first vaulted the real values and replaced
-	// the file with a pointer, and the second then parsed that pointer and
-	// stored "jit://vault/mcp-alpha/TOKEN" as its own credential. Reading up
-	// front also moves the unparseable-line hard stop ahead of every mutation.
-	envCache, err := readMCPEnvFiles(path, servers, names)
-	if err != nil {
-		return MCPConfigMigration{}, err
+	// Every --env-file target is read ONCE, across every block, before any of
+	// them is rewritten. Neutralizing inside the per-server loop was a silent
+	// corruption when two servers shared one file: the first vaulted the real
+	// values and replaced the file with a pointer, and the second then parsed
+	// that pointer and stored "jit://vault/mcp-alpha/TOKEN" as its own
+	// credential. Two servers in DIFFERENT blocks sharing one file is the same
+	// hazard, which is why the cache spans blocks rather than being rebuilt
+	// per block. Reading up front also moves the unparseable-line hard stop
+	// ahead of every mutation.
+	envCache := map[string]*mcpEnvFile{}
+	for _, b := range blocks {
+		names := make([]string, 0, len(b.servers))
+		for name := range b.servers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		if err := readMCPEnvFilesInto(envCache, path, b.servers, names); err != nil {
+			return MCPConfigMigration{}, err
+		}
 	}
 
 	result := MCPConfigMigration{FilePath: path}
 	pointers := newEnvFilePointerSet()
-	for _, name := range names {
-		entry := servers[name]
-		if !hasMigratableCredentials(path, entry) {
-			continue
+	for _, b := range blocks {
+		names := make([]string, 0, len(b.servers))
+		for name := range b.servers {
+			names = append(names, name)
 		}
-
-		serverMigration, err := migrateMCPServer(v, home, jitPath, path, name, entry, envCache, pointers)
-		if err != nil {
-			return MCPConfigMigration{}, fmt.Errorf("%s: server %q: %w", path, name, err)
+		sort.Strings(names)
+		// The namespace scope is the BLOCK, not the file: two projects inside
+		// ~/.claude.json routinely define the same server name ("github",
+		// "postgres"), and a file-scoped claim would hand the second one the
+		// first one's namespace — at which point it overwrites the first
+		// project's vault values and nothing anywhere errors. See
+		// mcpSourceScope.
+		scope := mcpSourceScope(path, b.projectDir)
+		for _, name := range names {
+			entry := b.servers[name]
+			if !hasMigratableCredentials(path, entry) {
+				continue
+			}
+			serverMigration, err := migrateMCPServer(v, home, jitPath, path, scope, name, entry, envCache, pointers)
+			if err != nil {
+				return MCPConfigMigration{}, fmt.Errorf("%s: server %q: %w", scope, name, err)
+			}
+			result.Servers = append(result.Servers, serverMigration)
 		}
-		result.Servers = append(result.Servers, serverMigration)
 	}
 	if len(result.Servers) == 0 {
 		return MCPConfigMigration{}, fmt.Errorf("%s has no server with secrets to migrate", path)
@@ -266,11 +289,9 @@ func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
 		return MCPConfigMigration{}, err
 	}
 
-	serversJSON, err := marshalJSONNoEscape(servers, "")
-	if err != nil {
+	if err := storeMCPBlocks(topLevel, blocks); err != nil {
 		return MCPConfigMigration{}, err
 	}
-	topLevel[serversKey] = serversJSON
 
 	// Linked, so `jit migrate undo <config>` brings the absorbed .env files
 	// back in the same run. Restoring the config alone re-adds --env-file
@@ -304,7 +325,7 @@ func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
 // config file being migrated — MCP profile namespaces are claimed per
 // source file (claimMCPNamespace, GAPS.md #56), so a same-named server in
 // a different config can never silently overwrite this one's secrets.
-func migrateMCPServer(v *vault.Vault, globalRoot, jitPath, sourcePath, serverName string, entry mcpServerRaw, envCache map[string]*mcpEnvFile, pointers *envFilePointerSet) (MCPServerMigration, error) {
+func migrateMCPServer(v *vault.Vault, globalRoot, jitPath, sourcePath, sourceScope, serverName string, entry mcpServerRaw, envCache map[string]*mcpEnvFile, pointers *envFilePointerSet) (MCPServerMigration, error) {
 	// Absent, not merely empty: with the widened discovery gate a server can
 	// reach here carrying an --env-file and no env block at all, and
 	// json.Unmarshal(nil, ...) fails with "unexpected end of JSON input".
@@ -336,7 +357,7 @@ func migrateMCPServer(v *vault.Vault, globalRoot, jitPath, sourcePath, serverNam
 		}
 	}
 
-	profileName, profilePath, entries, movedFrom, err := claimMCPNamespace(v, globalRoot, "mcp-"+sanitizeProfileName(serverName), sourcePath, env)
+	profileName, profilePath, entries, movedFrom, err := claimMCPNamespace(v, globalRoot, "mcp-"+sanitizeProfileName(serverName), sourceScope, env)
 	if err != nil {
 		return MCPServerMigration{}, err
 	}
@@ -366,7 +387,7 @@ func migrateMCPServer(v *vault.Vault, globalRoot, jitPath, sourcePath, serverNam
 	// legacy-shaped (unstamped) profile, which the next run treats with the
 	// cautious legacy rules rather than trusting a stamp for content that
 	// never landed.
-	if err := os.WriteFile(profileSourceSidecarPath(profilePath), []byte(sourcePath+"\n"), 0o600); err != nil {
+	if err := os.WriteFile(profileSourceSidecarPath(profilePath), []byte(sourceScope+"\n"), 0o600); err != nil {
 		return MCPServerMigration{}, fmt.Errorf("recording profile source %s: %w", profilePath, err)
 	}
 
@@ -457,6 +478,13 @@ func profileSourceSidecarPath(profilePath string) string {
 //
 // A vault path that exists without being claimed by the candidate's
 // manifest is foreign regardless (claimNamespace's own rule).
+//
+// sourcePath is the block-scoped source (mcpSourceScope) — the config file
+// path, suffixed "#<projectDir>" for a server inside ~/.claude.json's
+// projects map. Scoping the claim to the BLOCK is what lets two projects
+// define the same server name without the second silently overwriting the
+// first's vault values; for a top-level server the scope IS the path, so
+// every sidecar written before project blocks existed still compares equal.
 func claimMCPNamespace(v *vault.Vault, globalRoot, base, sourcePath string, env map[string]string) (name, profilePath string, entries profile.Profile, movedFrom string, err error) {
 	for i := 1; i <= maxNamespaceCandidates; i++ {
 		name = base
@@ -534,12 +562,17 @@ func claimMCPNamespace(v *vault.Vault, globalRoot, base, sourcePath string, env 
 // project stranded that profile and its vault secrets forever (a real E2E
 // finding: `jit status` reported dangling references right after a
 // "removed jit from this project" success).
+// The sidecar may record a block-scoped source ("path#projectDir", written for
+// a server inside ~/.claude.json's projects map — see mcpSourceScope); every
+// caller of THIS function wants the file, so the scope is stripped here. The
+// scoped form is compared only inside claimMCPNamespace, which reads the
+// sidecar raw.
 func ProfileOwnerConfig(profilePath string) string {
 	data, err := os.ReadFile(profileSourceSidecarPath(profilePath)) // #nosec G304 -- a fixed-suffix sibling of jit's own profile manifest
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(string(data))
+	return mcpSourceFile(strings.TrimSpace(string(data)))
 }
 
 // RemoveOwnedProfile deletes a global-store profile manifest together with
@@ -577,14 +610,16 @@ func mcpWrapperProfile(entry mcpServerRaw) string {
 // error: planning must stay tolerant of a config the user deleted or
 // hand-edited since migration.
 func WrappedMCPProfiles(path string) map[string]bool {
-	_, _, servers, err := loadMCPFile(path)
+	_, blocks, err := loadMCPFile(path)
 	if err != nil {
 		return nil
 	}
 	wrapped := map[string]bool{}
-	for _, entry := range servers {
-		if name := mcpWrapperProfile(entry); name != "" {
-			wrapped[name] = true
+	for _, b := range blocks {
+		for _, entry := range b.servers {
+			if name := mcpWrapperProfile(entry); name != "" {
+				wrapped[name] = true
+			}
 		}
 	}
 	return wrapped
@@ -631,18 +666,30 @@ func DiscoverWrappedMCPEntries(home, cwd string, includeClaudeDesktop bool) ([]W
 
 	var entries []WrappedMCPEntry
 	for _, path := range paths {
-		_, _, servers, err := loadMCPFile(path)
+		_, blocks, err := loadMCPFile(path)
 		if err != nil {
 			continue // discovery already tolerated it; don't fail the check on it
 		}
-		names := make([]string, 0, len(servers))
-		for name := range servers {
-			names = append(names, name)
+		var flat []struct {
+			name  string
+			entry mcpServerRaw
 		}
-		sort.Strings(names)
+		for _, b := range blocks {
+			names := make([]string, 0, len(b.servers))
+			for name := range b.servers {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			for _, name := range names {
+				flat = append(flat, struct {
+					name  string
+					entry mcpServerRaw
+				}{name, b.servers[name]})
+			}
+		}
 
-		for _, name := range names {
-			entry := servers[name]
+		for _, it := range flat {
+			name, entry := it.name, it.entry
 			profileName := mcpWrapperProfile(entry)
 			if profileName == "" {
 				continue
@@ -686,23 +733,38 @@ type MCPServerRestore struct {
 // empty result with a nil error means nothing in the file was jit's, and
 // the file wasn't rewritten at all.
 func UnwrapMCPConfig(v *vault.Vault, path string, owned map[string]string) ([]MCPServerRestore, error) {
-	topLevel, serversKey, servers, err := loadMCPFile(path)
+	topLevel, blocks, err := loadMCPFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
-	if serversKey == "" {
+	if len(blocks) == 0 {
 		return nil, nil
 	}
 
-	names := make([]string, 0, len(servers))
-	for name := range servers {
-		names = append(names, name)
+	// Flattened across blocks: `owned` maps profile name -> manifest path, and
+	// a profile name is claimed once per SCOPE (see mcpSourceScope), so a
+	// same-named server in a second project carries a different (bumped)
+	// profile name and cannot be confused with the first's. Mutating an entry
+	// mutates the block's own map, which storeMCPBlocks writes back.
+	type flatEntry struct {
+		name  string
+		entry mcpServerRaw
 	}
-	sort.Strings(names)
+	var flat []flatEntry
+	for _, b := range blocks {
+		names := make([]string, 0, len(b.servers))
+		for name := range b.servers {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			flat = append(flat, flatEntry{name, b.servers[name]})
+		}
+	}
 
 	var restored []MCPServerRestore
-	for _, name := range names {
-		entry := servers[name]
+	for _, it := range flat {
+		name, entry := it.name, it.entry
 		profileName := mcpWrapperProfile(entry)
 		manifestPath, ok := owned[profileName]
 		if profileName == "" || !ok {
@@ -755,11 +817,9 @@ func UnwrapMCPConfig(v *vault.Vault, path string, owned map[string]string) ([]MC
 		return nil, nil
 	}
 
-	serversJSON, err := marshalJSONNoEscape(servers, "")
-	if err != nil {
+	if err := storeMCPBlocks(topLevel, blocks); err != nil {
 		return nil, err
 	}
-	topLevel[serversKey] = serversJSON
 	out, err := marshalJSONNoEscape(topLevel, "  ")
 	if err != nil {
 		return nil, err
@@ -770,37 +830,201 @@ func UnwrapMCPConfig(v *vault.Vault, path string, owned map[string]string) ([]MC
 	return restored, nil
 }
 
-func parseMCPServers(path string) (map[string]mcpServerRaw, error) {
-	_, _, servers, err := loadMCPFile(path)
-	return servers, err
+// parseMCPServers flattens every block's servers into one list, for callers
+// that ask "does anything in this file need attention" without caring which
+// block it sits in (discovery's accept predicates). Same-named servers in
+// different projects are distinct entries, so none is lost to a map collision.
+func parseMCPServers(path string) ([]mcpServerRaw, error) {
+	_, blocks, err := loadMCPFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []mcpServerRaw
+	for _, b := range blocks {
+		for _, entry := range b.servers {
+			out = append(out, entry)
+		}
+	}
+	return out, nil
+}
+
+// mcpProjectsKey is Claude Code's own per-project store in ~/.claude.json: a
+// second set of server definitions keyed by project DIRECTORY, alongside the
+// ordinary top-level block. internal/audit has parsed it since MCP scanning
+// existed (mcpconfig.go's Projects field), which is why `jit scan` reports a
+// credential there — migrate could not, so the finding had no fix path at all.
+const mcpProjectsKey = "projects"
+
+// mcpBlock is one addressable set of server definitions inside a config file:
+// the top-level mcpServers/servers block, or one project's block inside
+// ~/.claude.json's "projects" map.
+//
+// It exists because a config file stopped being "the servers block" the moment
+// ~/.claude.json came into scope. Every read and both rewrites used to assume
+// one flat map, so a project-scoped server was invisible to all of them.
+type mcpBlock struct {
+	// projectDir is "" for the top-level block, or the project directory this
+	// block belongs to. It is also what scopes the profile namespace — see
+	// mcpSourceScope.
+	projectDir string
+	serversKey string // "mcpServers", or "servers" for VS Code's schema
+	servers    map[string]mcpServerRaw
+}
+
+// mcpSourceScope identifies WHICH block a migrated server came from, for
+// namespace claiming and the .source ownership sidecar.
+//
+// This is load-bearing, not cosmetic. claimMCPNamespace bumps mcp-<server> to
+// mcp-<server>-2 only when the sidecar names a DIFFERENT source, and two
+// projects in ~/.claude.json defining the same server name — "github",
+// "postgres", entirely normal — resolve to the same FILE. Without the scope
+// the second migration reuses the first's namespace, sees its own env keys
+// already recorded there, and overwrites the first project's vault values with
+// its own. Silently, and with the first project's credential gone.
+//
+// The scope is deliberately NOT the provenance Origin: that stays the real
+// file path, because Origin is what a human reads in `jit vault list --by
+// origin`.
+func mcpSourceScope(path, projectDir string) string {
+	if projectDir == "" {
+		return path
+	}
+	return path + "#" + projectDir
+}
+
+// mcpSourceFile strips the block scope back to the config file, for callers
+// asking "which file owns this profile" rather than "which block".
+func mcpSourceFile(scope string) string {
+	if i := strings.IndexByte(scope, '#'); i >= 0 {
+		return scope[:i]
+	}
+	return scope
 }
 
 // loadMCPFile decodes path's top level into raw JSON fields (preserving
-// anything besides the servers block untouched) and its "mcpServers" (or
-// "servers", VS Code's schema) block into per-server raw fields.
-func loadMCPFile(path string) (topLevel map[string]json.RawMessage, serversKey string, servers map[string]mcpServerRaw, err error) {
+// anything besides the servers blocks untouched) and every server block it
+// holds: the top-level "mcpServers" (or "servers", VS Code's schema) plus one
+// per entry in "projects".
+//
+// Blocks come back in a stable order — top-level first, then projects sorted
+// by directory — so a rewrite is deterministic and two runs over an unchanged
+// file produce identical bytes.
+func loadMCPFile(path string) (topLevel map[string]json.RawMessage, blocks []mcpBlock, err error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path comes from DiscoverMCPConfigs' own fixed/cwd-scoped walk, never external input
 	if err != nil {
-		return nil, "", nil, err
+		return nil, nil, err
 	}
-
 	if err := json.Unmarshal(data, &topLevel); err != nil {
-		return nil, "", nil, fmt.Errorf("parsing %s: %w", path, err)
+		return nil, nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 
-	serversKey = "mcpServers"
-	raw, ok := topLevel[serversKey]
+	if key, servers, err := decodeServersBlock(topLevel, path, ""); err != nil {
+		return nil, nil, err
+	} else if key != "" {
+		blocks = append(blocks, mcpBlock{serversKey: key, servers: servers})
+	}
+
+	raw, ok := topLevel[mcpProjectsKey]
 	if !ok {
-		serversKey = "servers"
-		raw, ok = topLevel[serversKey]
+		return topLevel, blocks, nil
+	}
+	var projects map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &projects); err != nil {
+		// A malformed projects block must not cost us the top-level one: the
+		// rest of the file is still migratable, and this half is an extension
+		// only one application writes.
+		return topLevel, blocks, nil
+	}
+	dirs := make([]string, 0, len(projects))
+	for dir := range projects {
+		dirs = append(dirs, dir)
+	}
+	sort.Strings(dirs)
+	for _, dir := range dirs {
+		var project map[string]json.RawMessage
+		if err := json.Unmarshal(projects[dir], &project); err != nil {
+			continue
+		}
+		key, servers, err := decodeServersBlock(project, path, dir)
+		if err != nil || key == "" {
+			continue
+		}
+		blocks = append(blocks, mcpBlock{projectDir: dir, serversKey: key, servers: servers})
+	}
+	return topLevel, blocks, nil
+}
+
+// decodeServersBlock pulls the servers map out of one JSON object, trying both
+// spellings the ecosystem uses. Returns key == "" when the object has neither.
+func decodeServersBlock(obj map[string]json.RawMessage, path, projectDir string) (key string, servers map[string]mcpServerRaw, err error) {
+	key = "mcpServers"
+	raw, ok := obj[key]
+	if !ok {
+		key = "servers"
+		raw, ok = obj[key]
 	}
 	if !ok {
-		return topLevel, "", nil, nil
+		return "", nil, nil
 	}
 	if err := json.Unmarshal(raw, &servers); err != nil {
-		return nil, "", nil, fmt.Errorf("parsing %s: %s block: %w", path, serversKey, err)
+		where := path
+		if projectDir != "" {
+			where = mcpSourceScope(path, projectDir)
+		}
+		return "", nil, fmt.Errorf("parsing %s: %s block: %w", where, key, err)
 	}
-	return topLevel, serversKey, servers, nil
+	return key, servers, nil
+}
+
+// storeMCPBlocks writes every block back into topLevel, in place.
+//
+// A project block is written by decoding that project's object into raw fields
+// and replacing ONLY its servers key, so the many other per-project fields
+// ~/.claude.json carries (history, allowedTools, and whatever the application
+// adds next) survive untouched. The "projects" object is re-marshalled only
+// when a project block actually changed, so a file with none comes out with
+// that half byte-identical.
+func storeMCPBlocks(topLevel map[string]json.RawMessage, blocks []mcpBlock) error {
+	var projects map[string]json.RawMessage
+	projectsTouched := false
+	for _, b := range blocks {
+		serversJSON, err := marshalJSONNoEscape(b.servers, "")
+		if err != nil {
+			return err
+		}
+		if b.projectDir == "" {
+			topLevel[b.serversKey] = serversJSON
+			continue
+		}
+		if projects == nil {
+			raw, ok := topLevel[mcpProjectsKey]
+			if !ok {
+				return fmt.Errorf("internal: project block %q with no projects object", b.projectDir)
+			}
+			if err := json.Unmarshal(raw, &projects); err != nil {
+				return fmt.Errorf("re-reading the projects block: %w", err)
+			}
+		}
+		var project map[string]json.RawMessage
+		if err := json.Unmarshal(projects[b.projectDir], &project); err != nil {
+			return fmt.Errorf("re-reading project %s: %w", b.projectDir, err)
+		}
+		project[b.serversKey] = serversJSON
+		projectJSON, err := marshalJSONNoEscape(project, "")
+		if err != nil {
+			return err
+		}
+		projects[b.projectDir] = projectJSON
+		projectsTouched = true
+	}
+	if projectsTouched {
+		projectsJSON, err := marshalJSONNoEscape(projects, "")
+		if err != nil {
+			return err
+		}
+		topLevel[mcpProjectsKey] = projectsJSON
+	}
+	return nil
 }
 
 // hasMigratableCredentials reports whether a server entry has anything
@@ -927,8 +1151,7 @@ type mcpEnvFile struct {
 // It also puts the unparseable-line hard stop ahead of EVERY mutation rather
 // than partway through the server loop, so a config with one bad file leaves
 // nothing half-migrated.
-func readMCPEnvFiles(configPath string, servers map[string]mcpServerRaw, names []string) (map[string]*mcpEnvFile, error) {
-	cache := map[string]*mcpEnvFile{}
+func readMCPEnvFilesInto(cache map[string]*mcpEnvFile, configPath string, servers map[string]mcpServerRaw, names []string) error {
 	for _, name := range names {
 		for _, target := range migratableEnvFiles(configPath, servers[name]) {
 			if _, done := cache[target]; done {
@@ -936,14 +1159,14 @@ func readMCPEnvFiles(configPath string, servers map[string]mcpServerRaw, names [
 			}
 			values, order, unparsed, err := parseEnvFile(target)
 			if err != nil {
-				return nil, fmt.Errorf("parsing %s: %w", target, err)
+				return fmt.Errorf("parsing %s: %w", target, err)
 			}
 			// ApplyEnvFile's hard stop, for its reason: this file is about to
 			// be rewritten, so "I silently dropped what I could not parse"
 			// turns straight into a variable the server loses with nothing
 			// saying why.
 			if len(unparsed) > 0 {
-				return nil, fmt.Errorf(
+				return fmt.Errorf(
 					"%s: %s could not be parsed as KEY=value (%s %s), stopping before touching anything so nothing is silently dropped; fix or comment out %s and re-run",
 					target, countWord(len(unparsed), "line", "lines"),
 					pluralWord(len(unparsed), "line", "lines"), joinLineNumbers(unparsed),
@@ -952,7 +1175,7 @@ func readMCPEnvFiles(configPath string, servers map[string]mcpServerRaw, names [
 			cache[target] = &mcpEnvFile{values: values, order: order}
 		}
 	}
-	return cache, nil
+	return nil
 }
 
 // envFilePointerSet accumulates which vault path each --env-file variable

--- a/internal/migrate/mcpconfig.go
+++ b/internal/migrate/mcpconfig.go
@@ -60,6 +60,12 @@ type MCPConfigMigration struct {
 	FilePath   string
 	BackupPath string
 	Servers    []MCPServerMigration
+	// SkippedProjects names ~/.claude.json project blocks that could not be
+	// parsed and were left untouched — still holding whatever plaintext
+	// `jit scan` flagged. Callers MUST surface these: a silent skip recreates
+	// the finding-with-no-fix-path gap this file's projects support exists to
+	// close, one level down. (Review finding, 2026-08-06.)
+	SkippedProjects []string
 }
 
 // ClaudeDesktopConfigPath is Claude Desktop's fixed config location. Retained
@@ -175,7 +181,7 @@ func discoverMCPConfigFiles(home, cwd string, includeClaudeDesktop bool, accept 
 // failing, since a plan must still render for a file apply will fail on for
 // its own reasons.
 func MCPEnvFilePreview(path string) []string {
-	_, blocks, err := loadMCPFile(path)
+	_, blocks, _, err := loadMCPFile(path)
 	if err != nil {
 		return nil
 	}
@@ -213,7 +219,7 @@ func MCPEnvFilePreview(path string) []string {
 // write and profile manifest write happens before path itself is
 // rewritten, and path is backed up first.
 func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
-	topLevel, blocks, err := loadMCPFile(path)
+	topLevel, blocks, skippedProjects, err := loadMCPFile(path)
 	if err != nil {
 		return MCPConfigMigration{}, fmt.Errorf("reading %s: %w", path, err)
 	}
@@ -251,7 +257,7 @@ func ApplyMCPConfig(v *vault.Vault, path string) (MCPConfigMigration, error) {
 		}
 	}
 
-	result := MCPConfigMigration{FilePath: path}
+	result := MCPConfigMigration{FilePath: path, SkippedProjects: skippedProjects}
 	pointers := newEnvFilePointerSet()
 	for _, b := range blocks {
 		names := make([]string, 0, len(b.servers))
@@ -610,7 +616,7 @@ func mcpWrapperProfile(entry mcpServerRaw) string {
 // error: planning must stay tolerant of a config the user deleted or
 // hand-edited since migration.
 func WrappedMCPProfiles(path string) map[string]bool {
-	_, blocks, err := loadMCPFile(path)
+	_, blocks, _, err := loadMCPFile(path)
 	if err != nil {
 		return nil
 	}
@@ -666,7 +672,7 @@ func DiscoverWrappedMCPEntries(home, cwd string, includeClaudeDesktop bool) ([]W
 
 	var entries []WrappedMCPEntry
 	for _, path := range paths {
-		_, blocks, err := loadMCPFile(path)
+		_, blocks, _, err := loadMCPFile(path)
 		if err != nil {
 			continue // discovery already tolerated it; don't fail the check on it
 		}
@@ -733,7 +739,7 @@ type MCPServerRestore struct {
 // empty result with a nil error means nothing in the file was jit's, and
 // the file wasn't rewritten at all.
 func UnwrapMCPConfig(v *vault.Vault, path string, owned map[string]string) ([]MCPServerRestore, error) {
-	topLevel, blocks, err := loadMCPFile(path)
+	topLevel, blocks, _, err := loadMCPFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
@@ -835,7 +841,7 @@ func UnwrapMCPConfig(v *vault.Vault, path string, owned map[string]string) ([]MC
 // block it sits in (discovery's accept predicates). Same-named servers in
 // different projects are distinct entries, so none is lost to a map collision.
 func parseMCPServers(path string) ([]mcpServerRaw, error) {
-	_, blocks, err := loadMCPFile(path)
+	_, blocks, _, err := loadMCPFile(path)
 	if err != nil {
 		return nil, err
 	}
@@ -909,31 +915,32 @@ func mcpSourceFile(scope string) string {
 // Blocks come back in a stable order — top-level first, then projects sorted
 // by directory — so a rewrite is deterministic and two runs over an unchanged
 // file produce identical bytes.
-func loadMCPFile(path string) (topLevel map[string]json.RawMessage, blocks []mcpBlock, err error) {
+func loadMCPFile(path string) (topLevel map[string]json.RawMessage, blocks []mcpBlock, skipped []string, err error) {
 	data, err := os.ReadFile(path) // #nosec G304 -- path comes from DiscoverMCPConfigs' own fixed/cwd-scoped walk, never external input
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if err := json.Unmarshal(data, &topLevel); err != nil {
-		return nil, nil, fmt.Errorf("parsing %s: %w", path, err)
+		return nil, nil, nil, fmt.Errorf("parsing %s: %w", path, err)
 	}
 
 	if key, servers, err := decodeServersBlock(topLevel, path, ""); err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	} else if key != "" {
 		blocks = append(blocks, mcpBlock{serversKey: key, servers: servers})
 	}
 
 	raw, ok := topLevel[mcpProjectsKey]
 	if !ok {
-		return topLevel, blocks, nil
+		return topLevel, blocks, nil, nil
 	}
 	var projects map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &projects); err != nil {
 		// A malformed projects block must not cost us the top-level one: the
 		// rest of the file is still migratable, and this half is an extension
-		// only one application writes.
-		return topLevel, blocks, nil
+		// only one application writes. But it IS reported as skipped, for the
+		// reason each per-project skip is below.
+		return topLevel, blocks, []string{mcpProjectsKey + " (unparseable)"}, nil
 	}
 	dirs := make([]string, 0, len(projects))
 	for dir := range projects {
@@ -941,17 +948,37 @@ func loadMCPFile(path string) (topLevel map[string]json.RawMessage, blocks []mcp
 	}
 	sort.Strings(dirs)
 	for _, dir := range dirs {
+		// An empty-string key would build a block whose projectDir is "" —
+		// which storeMCPBlocks treats as THE TOP-LEVEL block, so its rewrite
+		// would clobber the real top-level servers while the project's own
+		// plaintext stayed put, and mcpSourceScope would collide with the
+		// top-level namespace scope. No real store has one; a hand-mangled
+		// file must degrade to skipped-and-reported, not to a clobber.
+		// (Review finding, 2026-08-06.)
+		if dir == "" {
+			skipped = append(skipped, `projects[""]`)
+			continue
+		}
 		var project map[string]json.RawMessage
 		if err := json.Unmarshal(projects[dir], &project); err != nil {
+			// A block that fails to parse still holds whatever plaintext
+			// `jit scan` flagged, and silently walking past it recreates the
+			// finding-with-no-fix-path gap one level down. Recorded so the
+			// caller can SAY a block was left behind.
+			skipped = append(skipped, dir)
 			continue
 		}
 		key, servers, err := decodeServersBlock(project, path, dir)
-		if err != nil || key == "" {
+		if err != nil {
+			skipped = append(skipped, dir)
 			continue
+		}
+		if key == "" {
+			continue // a project with no servers block has nothing to migrate — normal, not skipped
 		}
 		blocks = append(blocks, mcpBlock{projectDir: dir, serversKey: key, servers: servers})
 	}
-	return topLevel, blocks, nil
+	return topLevel, blocks, skipped, nil
 }
 
 // decodeServersBlock pulls the servers map out of one JSON object, trying both
@@ -981,9 +1008,12 @@ func decodeServersBlock(obj map[string]json.RawMessage, path, projectDir string)
 // A project block is written by decoding that project's object into raw fields
 // and replacing ONLY its servers key, so the many other per-project fields
 // ~/.claude.json carries (history, allowedTools, and whatever the application
-// adds next) survive untouched. The "projects" object is re-marshalled only
-// when a project block actually changed, so a file with none comes out with
-// that half byte-identical.
+// adds next) survive untouched. The "projects" object is re-marshalled
+// whenever the file holds any project block — every value passes through
+// RawMessage unchanged, but key ORDER is not preserved (Go maps marshal
+// alphabetically). Accepted: JSON object order carries no meaning, and the
+// owning application rewrites this file constantly itself. A file with no
+// project blocks comes out with that half byte-identical.
 func storeMCPBlocks(topLevel map[string]json.RawMessage, blocks []mcpBlock) error {
 	var projects map[string]json.RawMessage
 	projectsTouched := false

--- a/internal/migrate/mcpconfig_test.go
+++ b/internal/migrate/mcpconfig_test.go
@@ -662,7 +662,7 @@ func TestApplyMCPConfigMigratesEnvFileServer(t *testing.T) {
 
 	// The flag goes with the file: leaving it would point uv at the pointer
 	// file and set every credential to a literal "jit://vault/..." string.
-	_, blocks, err := loadMCPFile(path)
+	_, blocks, _, err := loadMCPFile(path)
 	if err != nil {
 		t.Fatalf("loadMCPFile: %v", err)
 	}
@@ -1153,5 +1153,75 @@ func TestUnwrapMCPConfigRestoresClaudeCodeProjects(t *testing.T) {
 	}
 	if string(top["numStartups"]) != "42" {
 		t.Errorf("numStartups = %s after round trip, want 42", top["numStartups"])
+	}
+}
+
+// TestClaudeCodeStoreDegradesSafelyOnMangledProjects pins the two review
+// findings on the projects support (2026-08-06): an empty-string project key
+// must not alias the TOP-LEVEL block (its rewrite would clobber real
+// top-level servers while the project's own plaintext stayed put), and an
+// unparseable project block must be REPORTED, not silently walked past —
+// silence recreates the finding-with-no-fix-path gap one level down.
+func TestClaudeCodeStoreDegradesSafelyOnMangledProjects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	writeFile(t, path, `{
+	  "mcpServers": {"top": {"command": "node", "args": ["t.js"], "env": {"TOP_TOKEN": "top-secret-1"}}},
+	  "projects": {
+	    "": {"mcpServers": {"evil": {"command": "node", "env": {"X": "clobber-me"}}}},
+	    "/Users/x/broken": {"mcpServers": "not an object"},
+	    "/Users/x/fine": {"mcpServers": {"ok": {"command": "node", "env": {"K": "fine-secret"}}}}
+	  }
+	}`)
+	v := newTestVault(t)
+
+	result, err := ApplyMCPConfig(v, path)
+	if err != nil {
+		t.Fatalf("ApplyMCPConfig: %v", err)
+	}
+
+	// Both mangled blocks are reported, in a stable order.
+	if len(result.SkippedProjects) != 2 {
+		t.Fatalf("SkippedProjects = %v, want the empty-key and broken blocks", result.SkippedProjects)
+	}
+
+	// The real blocks migrated: the top-level server and the healthy project.
+	migrated := map[string]bool{}
+	for _, sm := range result.Servers {
+		migrated[sm.ServerName] = true
+	}
+	if !migrated["top"] || !migrated["ok"] || len(migrated) != 2 {
+		t.Errorf("migrated %v, want exactly top and ok", migrated)
+	}
+
+	data, _ := os.ReadFile(path)
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("rewritten file: %v", err)
+	}
+	// The top-level block was rewritten to launch through jit — NOT replaced
+	// by the empty-key project's servers, which is what projectDir=="" used
+	// to do to it.
+	var topServers map[string]mcpServerRaw
+	if err := json.Unmarshal(top["mcpServers"], &topServers); err != nil {
+		t.Fatal(err)
+	}
+	if _, clobbered := topServers["evil"]; clobbered {
+		t.Error(`the projects[""] block clobbered the top-level servers`)
+	}
+	if p := mcpWrapperProfile(topServers["top"]); p == "" {
+		t.Error("the real top-level server was not migrated")
+	}
+	// The mangled blocks' own bytes are untouched.
+	var projects map[string]json.RawMessage
+	if err := json.Unmarshal(top["projects"], &projects); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(projects[""]), "clobber-me") {
+		t.Error(`projects[""] was modified; a skipped block must be left byte-exact`)
+	}
+	if !strings.Contains(string(projects["/Users/x/broken"]), "not an object") {
+		t.Error("the unparseable block was modified")
 	}
 }

--- a/internal/migrate/mcpconfig_test.go
+++ b/internal/migrate/mcpconfig_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 	"testing"
 
@@ -661,10 +662,14 @@ func TestApplyMCPConfigMigratesEnvFileServer(t *testing.T) {
 
 	// The flag goes with the file: leaving it would point uv at the pointer
 	// file and set every credential to a literal "jit://vault/..." string.
-	_, _, servers, err := loadMCPFile(path)
+	_, blocks, err := loadMCPFile(path)
 	if err != nil {
 		t.Fatalf("loadMCPFile: %v", err)
 	}
+	if len(blocks) != 1 {
+		t.Fatalf("blocks = %d, want 1", len(blocks))
+	}
+	servers := blocks[0].servers
 	var args []string
 	if err := json.Unmarshal(servers["okta"]["args"], &args); err != nil {
 		t.Fatalf("args: %v", err)
@@ -922,5 +927,231 @@ func TestApplyMCPConfigUnparsedEnvFileLeavesEverythingUntouched(t *testing.T) {
 	}
 	if _, err := v.Get("mcp-alpha/GOOD_TOKEN"); err == nil {
 		t.Error("a secret was vaulted before the run failed on another server")
+	}
+}
+
+// claudeCodeStoreFixture is the shape of a real ~/.claude.json: application
+// state (numprompts, history) around a top-level mcpServers block AND a
+// projects map keying a second set of server definitions by project directory
+// — each project carrying its own non-MCP state that a rewrite must not touch.
+// Both projects deliberately define a server named "github": that is the
+// collision that used to overwrite vault values (see the overwrite test).
+const claudeCodeStoreFixture = `{
+  "numStartups": 42,
+  "mcpServers": {
+    "jira": {"command": "node", "args": ["jira.js"], "env": {"JIRA_TOKEN": "jira-secret-1"}}
+  },
+  "projects": {
+    "/Users/x/proj-a": {
+      "allowedTools": ["Bash"],
+      "history": ["do the thing"],
+      "mcpServers": {
+        "github": {"command": "node", "args": ["gh.js"], "env": {"GITHUB_TOKEN": "gh-secret-a"}}
+      }
+    },
+    "/Users/x/proj-b": {
+      "allowedTools": [],
+      "mcpServers": {
+        "github": {"command": "node", "args": ["gh.js"], "env": {"GITHUB_TOKEN": "gh-secret-b"}}
+      }
+    }
+  }
+}`
+
+// TestApplyMCPConfigMigratesClaudeCodeProjects is the fix-path half of the
+// ~/.claude.json gap: audit has scanned this file's projects map since MCP
+// scanning existed, so its findings were real — and migrate's rewriter only
+// knew the top-level block, so `jit migrate ~/.claude.json` either said
+// "nothing to do" or, wired naively, would have rewritten only part of a file
+// holding live credentials.
+func TestApplyMCPConfigMigratesClaudeCodeProjects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	writeFile(t, path, claudeCodeStoreFixture)
+	v := newTestVault(t)
+
+	result, err := ApplyMCPConfig(v, path)
+	if err != nil {
+		t.Fatalf("ApplyMCPConfig: %v", err)
+	}
+	if len(result.Servers) != 3 {
+		t.Fatalf("migrated %d servers, want 3 (top-level jira + one github per project): %+v", len(result.Servers), result.Servers)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(data)
+
+	// Every credential is out of the file...
+	for _, secret := range []string{"jira-secret-1", "gh-secret-a", "gh-secret-b"} {
+		if strings.Contains(body, secret) {
+			t.Errorf("credential %q still in the rewritten file", secret)
+		}
+	}
+	// ...while the application state around the blocks survives, top-level and
+	// per-project alike. This is the "teach the rewriter Projects first"
+	// pitfall: a rewriter that round-trips only the servers key would drop
+	// numStartups/allowedTools/history and corrupt Claude Code's own store.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("rewritten file is not valid JSON: %v", err)
+	}
+	if string(top["numStartups"]) != "42" {
+		t.Errorf("numStartups = %s, want 42 (top-level state must survive)", top["numStartups"])
+	}
+	var projects map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(top["projects"], &projects); err != nil {
+		t.Fatalf("projects block: %v", err)
+	}
+	if got := string(projects["/Users/x/proj-a"]["history"]); !strings.Contains(got, "do the thing") {
+		t.Errorf("proj-a history = %s; per-project state must survive a rewrite", got)
+	}
+	if got := string(projects["/Users/x/proj-b"]["allowedTools"]); got != "[]" {
+		t.Errorf("proj-b allowedTools = %s, want []", got)
+	}
+	// And each project's server now launches through jit.
+	for _, dir := range []string{"/Users/x/proj-a", "/Users/x/proj-b"} {
+		var servers map[string]mcpServerRaw
+		if err := json.Unmarshal(projects[dir]["mcpServers"], &servers); err != nil {
+			t.Fatalf("%s mcpServers: %v", dir, err)
+		}
+		if p := mcpWrapperProfile(servers["github"]); p == "" {
+			t.Errorf("%s's github server was not rewritten to launch through jit", dir)
+		}
+	}
+}
+
+// TestClaudeCodeProjectsSameServerNameKeepsBothCredentials pins the overwrite
+// hazard scoping exists for. The namespace base is "mcp-"+server, and
+// claimMCPNamespace bumps to -2 only when the .source sidecar names a
+// DIFFERENT source. Two projects in one ~/.claude.json defining the same
+// server name resolve to the same FILE — so before block scoping, the second
+// project reused the first's namespace, saw its own env key already recorded
+// there, and OVERWROTE the first project's vault value. Silently: the file
+// rewrite succeeded, and the first project's server now resolved the second's
+// credential.
+func TestClaudeCodeProjectsSameServerNameKeepsBothCredentials(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	writeFile(t, path, claudeCodeStoreFixture)
+	v := newTestVault(t)
+
+	if _, err := ApplyMCPConfig(v, path); err != nil {
+		t.Fatalf("ApplyMCPConfig: %v", err)
+	}
+
+	// BOTH secrets must be in the vault, under distinct namespaces.
+	var found []string
+	for _, ns := range []string{"mcp-github", "mcp-github-2"} {
+		got, err := v.Get(ns + "/GITHUB_TOKEN")
+		if err != nil {
+			continue
+		}
+		found = append(found, string(got))
+	}
+	sort.Strings(found)
+	if len(found) != 2 || found[0] != "gh-secret-a" || found[1] != "gh-secret-b" {
+		t.Fatalf("vault holds %v, want both gh-secret-a and gh-secret-b under distinct namespaces; "+
+			"a shared namespace means the second project overwrote the first's credential", found)
+	}
+
+	// And each project's rewritten entry names the namespace holding ITS value.
+	data, _ := os.ReadFile(path)
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatal(err)
+	}
+	var projects map[string]map[string]json.RawMessage
+	if err := json.Unmarshal(top["projects"], &projects); err != nil {
+		t.Fatal(err)
+	}
+	profiles := map[string]string{}
+	for dir := range projects {
+		var servers map[string]mcpServerRaw
+		if err := json.Unmarshal(projects[dir]["mcpServers"], &servers); err != nil {
+			t.Fatal(err)
+		}
+		profiles[dir] = mcpWrapperProfile(servers["github"])
+	}
+	if profiles["/Users/x/proj-a"] == profiles["/Users/x/proj-b"] {
+		t.Errorf("both projects launch through profile %q; they must be distinct or they resolve one credential", profiles["/Users/x/proj-a"])
+	}
+	for dir, prof := range profiles {
+		wantSecret := "gh-secret-a"
+		if dir == "/Users/x/proj-b" {
+			wantSecret = "gh-secret-b"
+		}
+		got, err := v.Get(prof + "/GITHUB_TOKEN")
+		if err != nil {
+			t.Errorf("%s's profile %q resolves nothing: %v", dir, prof, err)
+			continue
+		}
+		if string(got) != wantSecret {
+			t.Errorf("%s resolves %q, want %q — the projects swapped or shared credentials", dir, got, wantSecret)
+		}
+	}
+}
+
+// TestUnwrapMCPConfigRestoresClaudeCodeProjects closes the loop the handoff
+// insisted on: migrating ~/.claude.json is only safe if undo/remove
+// understands project blocks too, or the migration is un-undoable — worse
+// than the dead end it replaces.
+func TestUnwrapMCPConfigRestoresClaudeCodeProjects(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	path := filepath.Join(home, ".claude.json")
+	writeFile(t, path, claudeCodeStoreFixture)
+	v := newTestVault(t)
+
+	if _, err := ApplyMCPConfig(v, path); err != nil {
+		t.Fatalf("ApplyMCPConfig: %v", err)
+	}
+
+	// remove's real flow: every profile whose sidecar names this config.
+	owned := map[string]string{}
+	globalRoot, err := profile.GlobalRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"mcp-jira", "mcp-github", "mcp-github-2"} {
+		p, err := profile.Path(globalRoot, name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ProfileOwnerConfig(p) != path {
+			t.Fatalf("profile %s's owner = %q, want %q (ProfileOwnerConfig must strip the block scope)", name, ProfileOwnerConfig(p), path)
+		}
+		owned[name] = p
+	}
+
+	restored, err := UnwrapMCPConfig(v, path, owned)
+	if err != nil {
+		t.Fatalf("UnwrapMCPConfig: %v", err)
+	}
+	if len(restored) != 3 {
+		t.Fatalf("restored %d servers, want 3: %+v", len(restored), restored)
+	}
+
+	data, _ := os.ReadFile(path)
+	body := string(data)
+	for _, secret := range []string{"jira-secret-1", "gh-secret-a", "gh-secret-b"} {
+		if !strings.Contains(body, secret) {
+			t.Errorf("credential %q not restored to the file", secret)
+		}
+	}
+	if strings.Contains(body, "--profile") {
+		t.Error("a jit wrapper survived the unwrap")
+	}
+	// Application state still intact after the round trip.
+	var top map[string]json.RawMessage
+	if err := json.Unmarshal(data, &top); err != nil {
+		t.Fatalf("restored file is not valid JSON: %v", err)
+	}
+	if string(top["numStartups"]) != "42" {
+		t.Errorf("numStartups = %s after round trip, want 42", top["numStartups"])
 	}
 }


### PR DESCRIPTION
The last big item from tranche C of the 2026-08-06 handoff — the user-visible dead end.

## The dead end

`jit scan` has reported credentials inside `~/.claude.json` since MCP scanning existed: audit probes it as a fixed path and parses the `projects` map only that file carries. migrate knew none of this — `DiscoverMCPConfigs` *claimed* to "mirror audit's own file discovery" while knowing only the Claude Desktop path. Demonstrated with real binaries against the same fixture:

```
main:         Nothing to migrate: none of the path(s) you named contain plaintext secrets jit can move.
this branch:  [MCP config] 1 · ~/.claude.json · 1 change planned
```

Zero errors either way — which is what made it a credibility problem: the user re-scans into the same finding and concludes migrate is broken.

## Built in the order the handoff insisted on

**Rewriter first, discovery last.** `loadMCPFile` now returns addressable *blocks* — top-level plus one per `projects` entry — and `storeMCPBlocks` writes a project block back by decoding that project's object and replacing only its servers key, so the application state `~/.claude.json` keeps alongside (`numStartups`, `allowedTools`, `history`) survives. All seven callers moved, including **both** write paths — undo/remove had to learn the shape too, or migrating the file becomes un-undoable, which is worse than the dead end it replaces.

## A hazard the handoff didn't mention

The namespace base is `mcp-<server>`, and `claimMCPNamespace` bumps to `-2` only when the `.source` sidecar names a *different* source. Two projects inside one `~/.claude.json` defining the same server name — `github`, `postgres`, entirely normal — resolve to the same **file**, so a file-scoped claim hands the second project the first's namespace, and it **silently overwrites the first project's vault values**.

The claim scope is now the *block* (`path`, or `path#projectDir`), reusing the existing bump machinery rather than inventing a naming scheme. For a top-level server the scope *is* the path, so every pre-existing sidecar still compares equal — no migration of migrations. `ProfileOwnerConfig` strips the scope at the boundary (all its callers want the file); provenance `Origin` stays the real path (it's what a human reads in `jit vault list --by origin`).

Discovery is wired through a new `audit.FixedMCPConfigPaths` — the list is a contract, so migrate, the cli switch and the plan-scope split all iterate audit's list instead of keeping copies.

## Verification

Three new tests against a realistic `~/.claude.json` fixture whose two projects deliberately share a server name: the migration, the both-credentials-survive property, and the full unwrap round trip (state intact, every credential restored, no wrapper left).

Mutation-verified:
- claim scoped to the file (the pre-fix behaviour) → the overwrite test fails with *"vault holds [gh-secret-b], want both"*
- project object rebuilt instead of edited → the state-preservation assertions fail (history and allowedTools gone)

Full suite green under `-race`; `gofmt`, `go vet`, pinned `staticcheck` clean; `docs-gen` no drift.

The env-file cache deliberately spans blocks: two servers in *different* projects sharing one `--env-file` is the same double-neutralize hazard the existing cache already guards within a block.

Note CI may not report — GitHub Actions incident permitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4