### PR TITLE
style: enforce the glyph rule; audit: the scan header stops lying about scope

### DIFF
--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -450,6 +450,14 @@ type ScanSummary struct {
 	// Unfiltered records that Config.Unfiltered was set for this run, so a
 	// stored report says which view it is. See Config.Unfiltered.
 	Unfiltered bool `json:"unfiltered"`
+	// Targets are the paths a targeted `jit scan <path>...` was pointed at,
+	// empty for the machine-wide scan. Carried so the report header can say
+	// what was actually scanned: it used to print "~/" regardless, so
+	// `jit scan token.txt` opened by claiming a whole-home scan had happened —
+	// wrong in both directions (overstating what was checked, understating
+	// where the findings came from). Additive, so no schema bump (the same
+	// rule doctorSchemaVersion states).
+	Targets []string `json:"targets,omitempty"`
 	// The coverage ledger, in DISTINCT secrets (not findings; see
 	// SchemaVersion 0.12.0 note): how many secrets exist on this machine as
 	// far as jit can tell (protected + counted exposed), how many are already

--- a/internal/audit/mcpconfig.go
+++ b/internal/audit/mcpconfig.go
@@ -25,6 +25,13 @@ var mcpConfigFileNames = map[string]bool{
 	"claude_desktop_config.json": true,
 }
 
+// IsMCPConfigFileName reports whether name is one of the filenames the MCP
+// scanner recognizes. Exported for the same reason FixedMCPConfigPaths is:
+// internal/migrate's discovery must recognize exactly the set audit scans, or
+// a finding has no fix path — and migrate kept a hand-mirrored copy of this
+// map behind a comment saying so, which is a contract by reminder.
+func IsMCPConfigFileName(name string) bool { return mcpConfigFileNames[name] }
+
 // mcpConfigFile covers both "mcpServers" (Claude Desktop, Cursor) and
 // "servers" (VS Code's MCP schema) top-level keys, since this is a
 // fast-moving ecosystem and tools haven't converged on one key name.

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -864,7 +864,7 @@ func writeRenderItemText(w io.Writer, item renderItem, home string, cols columns
 		// Same "• " marker as a file path: both kinds of header anchor a
 		// block, and a category mixing marked files with unmarked collapsed
 		// headers read as if only some blocks were "real".
-		fmt.Fprintf(w, "  • %s", collapsedHeader(item))
+		fmt.Fprintf(w, "  "+style.GlyphBullet+" %s", collapsedHeader(item))
 		writeItemTags(w, false, unfiltered)
 		fmt.Fprint(w, "\n\n")
 		cols.writeFindingRow(w, item.rep, false)
@@ -893,7 +893,7 @@ func writeRenderItemText(w io.Writer, item renderItem, home string, cols columns
 	// edge to edge.
 	archived := LooksArchived(item.rep.FilePath)
 	avail := termtext.Width() - 4 - itemTagsWidth(archived, unfiltered)
-	fmt.Fprintf(w, "  • %s", termtext.TruncHead(displayFilePath(home, item.rep.FilePath), avail))
+	fmt.Fprintf(w, "  "+style.GlyphBullet+" %s", termtext.TruncHead(displayFilePath(home, item.rep.FilePath), avail))
 	writeItemTags(w, archived, unfiltered)
 	fmt.Fprint(w, "\n\n")
 	for _, f := range item.findings {
@@ -957,7 +957,7 @@ func (c columns) writeFindingRow(w io.Writer, f Finding, showLine bool) {
 	fmt.Fprintln(w)
 
 	if ev := displayEvidence(f); ev != "" {
-		fmt.Fprintf(w, "%s└ ", indent)
+		fmt.Fprintf(w, "%s"+style.GlyphBranch+" ", indent)
 		termtext.Wrap(w, c.reasonIndent()+2, indent+"  ", highlightCmds(ev))
 	}
 	c.writeUnfilteredNote(w, f, indent)
@@ -970,6 +970,6 @@ func (c columns) writeUnfilteredNote(w io.Writer, f Finding, indent string) {
 	if !f.UnfilteredOnly || f.UnfilteredReason == "" {
 		return
 	}
-	fmt.Fprintf(w, "%s└ ", indent)
+	fmt.Fprintf(w, "%s"+style.GlyphBranch+" ", indent)
 	termtext.Wrap(w, c.reasonIndent()+2, indent+"  ", "shown by --unfiltered: "+sanitizeDisplay(f.UnfilteredReason))
 }

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -474,10 +474,7 @@ func WriteHumanReport(w io.Writer, findings []Finding, summary ScanSummary, home
 	if host == "" {
 		host = "unknown"
 	}
-	where := "~/"
-	if home == "" {
-		where = "scan targets"
-	}
+	where := scanScopeLabel(summary, home)
 	sizeNote := ""
 	if summary.FilesScanned > 0 {
 		// Inflected and digit-grouped, the same composition the triage header
@@ -704,6 +701,35 @@ func anyUnfilteredOnly(findings []Finding) bool {
 		}
 	}
 	return false
+}
+
+// scanScopeLabel names what this scan actually looked at. "~/" is the
+// machine-wide scan's truthful label; a targeted run names its targets — it
+// used to print "~/" for those too, so `jit scan token.txt` opened by claiming
+// a whole-home scan had happened. Two targets are listed outright; more
+// truncate to a count, per the house rule (truncate variable content rather
+// than wrap the header).
+func scanScopeLabel(summary ScanSummary, home string) string {
+	if len(summary.Targets) == 0 {
+		if home == "" {
+			return "scan targets"
+		}
+		return "~/"
+	}
+	shown := summary.Targets
+	more := 0
+	if len(shown) > 2 {
+		shown, more = shown[:2], len(shown)-2
+	}
+	parts := make([]string, 0, len(shown))
+	for _, t := range shown {
+		parts = append(parts, displayFilePath(home, t))
+	}
+	label := strings.Join(parts, ", ")
+	if more > 0 {
+		label += fmt.Sprintf(" +%d more", more)
+	}
+	return label
 }
 
 // heavyCategoryCount is where a summary-table count gets bold: a

--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -498,3 +498,30 @@ func TestBuildRenderItemsSortsLiveBeforeArchived(t *testing.T) {
 			items[0].rep.FilePath)
 	}
 }
+
+// TestScanScopeLabelNamesTheTargets is the regression test for the header
+// claiming "~/" regardless of what was scanned: `jit scan token.txt` opened
+// with "jit scan  ~/", overstating what was checked and understating where
+// the findings came from — on the first line of the report.
+func TestScanScopeLabelNamesTheTargets(t *testing.T) {
+	home := "/Users/x"
+	cases := []struct {
+		name    string
+		targets []string
+		want    string
+	}{
+		{"machine-wide", nil, "~/"},
+		{"one file", []string{"/Users/x/proj/.env"}, "~/proj/.env"},
+		{"two files", []string{"/Users/x/a", "/Users/x/b"}, "~/a, ~/b"},
+		{"many files truncate", []string{"/Users/x/a", "/Users/x/b", "/Users/x/c", "/Users/x/d"}, "~/a, ~/b +2 more"},
+		{"outside home stays absolute", []string{"/srv/app/.env"}, "/srv/app/.env"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := scanScopeLabel(ScanSummary{Targets: c.targets}, home)
+			if got != c.want {
+				t.Errorf("scanScopeLabel(%v) = %q, want %q", c.targets, got, c.want)
+			}
+		})
+	}
+}

--- a/internal/audit/target.go
+++ b/internal/audit/target.go
@@ -83,6 +83,7 @@ func TargetedScan(cfg Config, targets []string) ([]Finding, ScanSummary, error) 
 	annotateRemedies(all, cfg.HomeDir)
 
 	summary := buildScanSummary(cfg, all, countProtectedMounts(cfg.MountRegistryPath), time.Since(start))
+	summary.Targets = targets
 	summary.DegradedScanners = degraded
 	coverage := ComputeCoverage(cfg.HomeDir, cfg.MountRegistryPath, all)
 	summary.SecretsTotal = coverage.Total()

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -196,7 +196,7 @@ func WriteTriageReport(w io.Writer, findings []Finding, summary ScanSummary, hom
 			header += fmt.Sprintf(" — %s", countWord(len(migratable), "file", "files"))
 		} else {
 			header += fmt.Sprintf(" — %s in %s, ", countWord(cov.Migratable, "secret", "secrets"), countWord(len(migratable), "file", "files")) +
-				greenBold.Sprintf("%d%% → %d%%", pct, after)
+				greenBold.Sprintf("%d%% "+style.GlyphAction+" %d%%", pct, after)
 		}
 		termtext.Wrap(w, 2, "  ", header)
 		fmt.Fprint(w, triageNoteIndent)
@@ -242,7 +242,7 @@ func WriteTriageReport(w io.Writer, findings []Finding, summary ScanSummary, hom
 		termtext.Wrap(w, 2, "  ",
 			red.Sprint("only you can protect these")+
 				fmt.Sprintf(" — %s, ", countWord(cov.manualRemainder(), "secret", "secrets"))+
-				yellowBold.Sprintf("%d%% → 100%%", after))
+				yellowBold.Sprintf("%d%% "+style.GlyphAction+" 100%%", after))
 		for _, ag := range actions {
 			fmt.Fprintln(w)
 			fmt.Fprint(w, "    ")

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1154,11 +1154,11 @@ func printSessionProvenance(w io.Writer, st agent.Status) {
 		if cause == "" {
 			cause = "unknown cause"
 		}
-		fmt.Fprintf(w, "  • %s, %s\n", sessionWhen("locked", l.UnixTime), cause)
+		fmt.Fprintf(w, "  "+glyphBullet+" %s, %s\n", sessionWhen("locked", l.UnixTime), cause)
 	}
 
 	u := st.LastUnlock
-	line := fmt.Sprintf("  • %s", sessionWhen("unlocked", u.UnixTime))
+	line := fmt.Sprintf("  "+glyphBullet+" %s", sessionWhen("unlocked", u.UnixTime))
 	if u.LaunchedBy != "" {
 		// The half that answers "why now" — and the half nobody could get at
 		// before, since a process's parent is gone from every log jit keeps.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -342,7 +342,7 @@ func renderDoctorText(out io.Writer, outcome checkOutcome, problems, warnings []
 		for _, r := range outcome.OKRefs {
 			_, _ = cOK.Fprintf(out, "  %s ", glyphOK)
 			wrapBody(out, findingIndent, body,
-				fmt.Sprintf("%s: %s → %s", profileRef(checkFinding{Profile: r.Profile, Scope: r.Scope}), r.Variable, r.Path))
+				fmt.Sprintf("%s: %s "+glyphAction+" %s", profileRef(checkFinding{Profile: r.Profile, Scope: r.Scope}), r.Variable, r.Path))
 		}
 		for _, c := range outcome.OKChecks {
 			_, _ = cOK.Fprintf(out, "  %s ", glyphOK)
@@ -564,16 +564,16 @@ func formatFinding(f checkFinding) string {
 	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit, kindMCP:
 		return shortHome(f.Detail)
 	case kindMissing:
-		return fmt.Sprintf("%s: %s → %s, not in the vault", profileRef(f), f.Variable, f.Path)
+		return fmt.Sprintf("%s: %s "+glyphAction+" %s, not in the vault", profileRef(f), f.Variable, f.Path)
 	case kindCorrupt:
-		return fmt.Sprintf("%s: %s → %s: %s", profileRef(f), f.Variable, f.Path, shortHome(f.Detail))
+		return fmt.Sprintf("%s: %s "+glyphAction+" %s: %s", profileRef(f), f.Variable, f.Path, shortHome(f.Detail))
 	case kindBadPath:
-		return fmt.Sprintf("%s: %s → %s", profileRef(f), f.Variable, shortHome(f.Detail))
+		return fmt.Sprintf("%s: %s "+glyphAction+" %s", profileRef(f), f.Variable, shortHome(f.Detail))
 	case kindVaultError:
 		if f.Profile == "" {
 			return shortHome(f.Detail)
 		}
-		return fmt.Sprintf("%s: %s → %s: %s", profileRef(f), f.Variable, f.Path, shortHome(f.Detail))
+		return fmt.Sprintf("%s: %s "+glyphAction+" %s: %s", profileRef(f), f.Variable, f.Path, shortHome(f.Detail))
 	case kindOrphan:
 		return fmt.Sprintf("%s — %s", f.Path, f.Detail)
 	case kindShadowed:

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -533,7 +533,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			// pointer file), and nothing to reveal.
 			if !result.Mounted {
 				summary.backupOnlyFiles++
-				fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`, replaced with a safe pointer file (never mounted; nothing reads a backup file live)\n",
+				fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, replaced with a safe pointer file (never mounted; nothing reads a backup file live)\n",
 					displayPath(home, envPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 				noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 				continue
@@ -544,7 +544,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(result.EnvPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`\n", displayPath(home, envPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n", displayPath(home, envPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 		}
 		fmt.Fprintln(out)
@@ -569,7 +569,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 				if err := summary.writePointerFile(path, result.ProfilePath); err != nil {
 					return false, fmt.Errorf("jit migrate: %w", err)
 				}
-				fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`, live mount (real value to `jit run` grants, a decoy otherwise)\n",
+				fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, live mount (real value to `jit run` grants, a decoy otherwise)\n",
 					displayPath(home, path), result.ProfileName, countWord(len(result.Variables), "secret", "secrets"), result.BackupPath)))
 				noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 				continue
@@ -582,7 +582,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
 			summary.backupOnlyFiles++
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`, replaced with a safe pointer file (retrieve with `jit vault get %s/%s`)\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, replaced with a safe pointer file (retrieve with `jit vault get %s/%s`)\n",
 				displayPath(home, path), result.ProfileName, countWord(len(result.Variables), "secret", "secrets"), result.BackupPath, result.ProfileName, result.Variables[0])))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 		}
@@ -608,7 +608,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			for i, b := range result.Backups {
 				backups[i] = fmt.Sprintf("`jit vault get %s`", b)
 			}
-			fmt.Fprintf(out, "  • %s (%s) -> profile %q (%s); %s: %s\n",
+			fmt.Fprintf(out, "  "+glyphBullet+" %s (%s) -> profile %q (%s); %s: %s\n",
 				displayPath(home, dir), countWord(len(result.Files), "file", "files"), result.ProfileName,
 				countWord(len(result.Variables), "var", "vars"), pluralWord(len(result.Backups), "backup", "backups"), strings.Join(backups, ", "))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
@@ -640,7 +640,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(path, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`, live mount (real manifest to `jit run` grants, rejectable decoys otherwise)\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, live mount (real manifest to `jit run` grants, rejectable decoys otherwise)\n",
 				displayPath(home, path), result.ProfileName, countWord(len(result.Variables), "secret", "secrets"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			if result.ConvertedStringData {
@@ -660,7 +660,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`, open a new shell (or `source %s`)\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, open a new shell (or `source %s`)\n",
 				displayPath(home, shellPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath, displayPath(home, shellPath))))
 		}
 		fmt.Fprintln(out)
@@ -675,7 +675,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s, %s redacted in place); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s, %s redacted in place); backup: `jit vault get %s`\n",
 				displayPath(home, path), result.ProfileName, countWord(len(result.Variables), "secret", "secrets"),
 				countWord(result.Occurrences, "occurrence", "occurrences"), result.BackupPath)))
 			// A file can hold both. Never let a successful token redaction
@@ -711,7 +711,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
 			for _, sm := range result.Servers {
-				fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s server %q -> profile %q (%s); backup: `jit vault get %s`\n",
+				fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s server %q -> profile %q (%s); backup: `jit vault get %s`\n",
 					displayPath(home, mcpPath), sm.ServerName, sm.ProfileName, countWord(len(sm.Variables), "var", "vars"), result.BackupPath)))
 				noteNamespaceMove(out, sm.NamespaceMovedFrom, sm.ProfileName)
 			}
@@ -732,7 +732,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if result.ConfigBackup != "" {
 				backups += fmt.Sprintf(", `jit vault get %s`", result.ConfigBackup)
 			}
-			fmt.Fprintf(out, "  • %q -> vault profile %q (%s); backups: %s\n",
+			fmt.Fprintf(out, "  "+glyphBullet+" %q -> vault profile %q (%s); backups: %s\n",
 				awsProfile, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), backups)
 		}
 		fmt.Fprintln(out)
@@ -746,7 +746,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %q (%s) -> vault profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %q (%s) -> vault profile %q (%s); backup: `jit vault get %s`\n",
 				k8sUser, result.AuthType, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), result.Backup)))
 		}
 		fmt.Fprintln(out)
@@ -764,7 +764,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if result.RCBackup != "" {
 				backups += fmt.Sprintf(", `jit vault get %s`", result.RCBackup)
 			}
-			fmt.Fprintf(out, "  • %q -> vault profile %q (%s); backups: %s\n",
+			fmt.Fprintf(out, "  "+glyphBullet+" %q -> vault profile %q (%s); backups: %s\n",
 				tfHost, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), backups)
 		}
 		fmt.Fprintln(out)
@@ -780,7 +780,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
 			claimedDefaultStore = claimedDefaultStore || result.ClaimedDefaultStore
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %q -> vault profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %q -> vault profile %q (%s); backup: `jit vault get %s`\n",
 				dockerRegistry, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), result.ConfigBackup)))
 		}
 		if claimedDefaultStore {
@@ -817,7 +817,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			// a credential silently left behind is how a user ends up believing
 			// they are protected when they are not.
 			if errors.Is(err, migrate.ErrGitMultipleAccounts) {
-				fmt.Fprintf(out, "  • %q SKIPPED — %v\n", gitHost, err)
+				fmt.Fprintf(out, "  "+glyphBullet+" %q SKIPPED — %v\n", gitHost, err)
 				fmt.Fprintln(out, "    Its credentials are untouched and still work. Vault them by hand with"+
 					" `jit vault set` if you want them protected before multi-account support lands.")
 				continue
@@ -830,7 +830,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if result.ConfigBackup != "" {
 				backupNote += fmt.Sprintf(", `jit vault get %s`", result.ConfigBackup)
 			}
-			fmt.Fprintf(out, "  • %q -> vault profile %q (%s); backups: %s\n",
+			fmt.Fprintf(out, "  "+glyphBullet+" %q -> vault profile %q (%s); backups: %s\n",
 				gitHost, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), backupNote)
 		}
 		if replacedStore {
@@ -868,7 +868,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(adcPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s (%s) -> profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s (%s) -> profile %q (%s); backup: `jit vault get %s`\n",
 				displayPath(home, adcPath), result.CredType, result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			// A machine-global mount: usage is explicit `jit run --with` intent
@@ -896,7 +896,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(keyPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q; backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q; backup: `jit vault get %s`\n",
 				displayPath(home, keyPath), result.ProfileName, result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			// Two consumption paths, user's pick: the live mount serves the
@@ -931,7 +931,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(npmrcPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n",
 				displayPath(home, npmrcPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			if npmrcPath == migrate.GlobalNpmrcPath(home) {
@@ -960,7 +960,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(netrcPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n",
 				displayPath(home, netrcPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			// ~/.netrc is a machine-wide mount, same as the global ~/.npmrc:
@@ -987,7 +987,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			if err := summary.writePointerFile(pypircPath, result.ProfilePath); err != nil {
 				return false, fmt.Errorf("jit migrate: %w", err)
 			}
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("  • %s -> profile %q (%s); backup: `jit vault get %s`\n",
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n",
 				displayPath(home, pypircPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
 			// ~/.pypirc is a machine-wide mount, same as ~/.netrc and the
@@ -1273,7 +1273,7 @@ func runMigrateAll(cmd *cobra.Command) error {
 	if applied && !migrateDryRun && d.total() > 0 && summary.SecretsTotal > 0 {
 		before := summary.SecretsProtected * 100 / summary.SecretsTotal
 		after := (summary.SecretsProtected + summary.SecretsMigratable) * 100 / summary.SecretsTotal
-		fmt.Fprint(out, hlCmds(fmt.Sprintf("\ncoverage: %d%% → up to %d%% — run `jit scan` to see the new number\n", before, after)))
+		fmt.Fprint(out, hlCmds(fmt.Sprintf("\ncoverage: %d%% "+glyphAction+" up to %d%% — run `jit scan` to see the new number\n", before, after)))
 	}
 	return nil
 }

--- a/internal/cli/migratecaches.go
+++ b/internal/cli/migratecaches.go
@@ -195,7 +195,7 @@ func renderAgentSkips(w io.Writer, c migrate.AgentCacheCleanup) {
 		}
 		fmt.Fprintf(w, "    %-14s %s\n", agent, s.Reason)
 	}
-	fmt.Fprintln(w, "    → delete those files yourself, or re-run after any live session ends")
+	fmt.Fprintln(w, "    "+glyphAction+" delete those files yourself, or re-run after any live session ends")
 }
 
 // editsByAgentArea buckets edits as agent -> area -> count.

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -90,7 +90,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 		}
 		_, _ = cBold.Fprintf(w, "Project files you named\n\n")
 		printMigratePlanCategoryAnnotated(w,
-			pluralWord(len(d.envFiles), ".env file", ".env files")+" → EVERY variable moves to the vault (ordinary config too, so the file still works); the file keeps working as a live, auto-updating mount",
+			pluralWord(len(d.envFiles), ".env file", ".env files")+" "+glyphAction+" EVERY variable moves to the vault (ordinary config too, so the file still works); the file keeps working as a live, auto-updating mount",
 			shorten(d.envFiles),
 			func(item string) string {
 				if migrate.IsEnvBackupOnlySuffix(filepath.Base(item)) {
@@ -109,14 +109,14 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 				return fmt.Sprintf("%s, %d secret-shaped", countWord(total, "variable", "variables"), shaped)
 			})
 		printMigratePlanCategory(w,
-			pluralWord(len(d.tfvarsFiles), "Terraform tfvars file", "Terraform tfvars files")+" → secret values move to the vault; terraform reads them back as TF_VAR_ environment variables when run through jit",
+			pluralWord(len(d.tfvarsFiles), "Terraform tfvars file", "Terraform tfvars files")+" "+glyphAction+" secret values move to the vault; terraform reads them back as TF_VAR_ environment variables when run through jit",
 			shorten(d.tfvarsFiles))
 		k8sOriginal := make(map[string]string, len(d.k8sManifests))
 		for _, p := range d.k8sManifests {
 			k8sOriginal[displayPath(home, p)] = p
 		}
 		printMigratePlanCategoryAnnotated(w,
-			pluralWord(len(d.k8sManifests), "Kubernetes Secret manifest", "Kubernetes Secret manifests")+" → secret values move to the vault; the manifest stays at its path as a live mount: `jit run -- kubectl apply` gets real values, anything else gets decoys kubectl rejects",
+			pluralWord(len(d.k8sManifests), "Kubernetes Secret manifest", "Kubernetes Secret manifests")+" "+glyphAction+" secret values move to the vault; the manifest stays at its path as a live mount: `jit run -- kubectl apply` gets real values, anything else gets decoys kubectl rejects",
 			shorten(d.k8sManifests),
 			func(item string) string {
 				secrets, converts, ok := migrate.K8sManifestPreview(k8sOriginal[item])
@@ -130,7 +130,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 				return note
 			})
 		printMigratePlanCategoryAnnotated(w,
-			pluralWord(len(mcpScoped), "MCP config", "MCP configs")+" → secrets move to the vault; injected automatically when the server launches",
+			pluralWord(len(mcpScoped), "MCP config", "MCP configs")+" "+glyphAction+" secrets move to the vault; injected automatically when the server launches",
 			shorten(mcpScoped), func(item string) string {
 				// The user named a config file; this names the OTHER file on
 				// disk the run will rewrite into a pointer. Without it the
@@ -146,12 +146,12 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 				return "also rewrites " + strings.Join(short, ", ")
 			})
 		printMigratePlanCategory(w,
-			pluralWord(len(npmrcScoped), "npmrc file", "npmrc files")+" → secrets move to the vault; the file keeps working via a live, auto-updating mount",
+			pluralWord(len(npmrcScoped), "npmrc file", "npmrc files")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount",
 			shorten(npmrcScoped))
 		looseName := pluralWord(len(d.looseSecretFiles), "loose secret file", "loose secret files")
-		looseHeadline := looseName + " → the whole file is a bare token; it moves to the vault and the file is replaced with a git-safe pointer (retrieve with `jit vault get`)"
+		looseHeadline := looseName + " " + glyphAction + " the whole file is a bare token; it moves to the vault and the file is replaced with a git-safe pointer (retrieve with `jit vault get`)"
 		if migrateMount {
-			looseHeadline = looseName + " → the " + pluralWord(len(d.looseSecretFiles), "secret moves", "secrets move") + " to the vault; the file stays live at its path as a mount (real value to `jit run` grants, a decoy otherwise), non-secret content preserved"
+			looseHeadline = looseName + " " + glyphAction + " the " + pluralWord(len(d.looseSecretFiles), "secret moves", "secrets move") + " to the vault; the file stays live at its path as a mount (real value to `jit run` grants, a decoy otherwise), non-secret content preserved"
 		}
 		printMigratePlanCategory(w, looseHeadline, shorten(d.looseSecretFiles))
 	}
@@ -163,14 +163,14 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 		_, _ = fmt.Fprintln(w, "Machine-wide config files you named")
 		fmt.Fprintln(w)
 		printMigratePlanCategory(w,
-			pluralWord(len(d.shellConfigs), "shell config", "shell configs")+" → secrets move to the vault; loaded back automatically when your shell starts",
+			pluralWord(len(d.shellConfigs), "shell config", "shell configs")+" "+glyphAction+" secrets move to the vault; loaded back automatically when your shell starts",
 			shorten(d.shellConfigs))
 		historyOriginal := make(map[string]string, len(d.historyFiles))
 		for _, p := range d.historyFiles {
 			historyOriginal[displayPath(home, p)] = p
 		}
 		printMigratePlanCategoryAnnotated(w,
-			pluralWord(len(d.historyFiles), "shell history file", "shell history files")+" → recorded credentials move to the vault, every occurrence is redacted in place; your commands stay, the secrets don't (rotation still recommended)",
+			pluralWord(len(d.historyFiles), "shell history file", "shell history files")+" "+glyphAction+" recorded credentials move to the vault, every occurrence is redacted in place; your commands stay, the secrets don't (rotation still recommended)",
 			shorten(d.historyFiles),
 			func(item string) string {
 				secrets, occ, err := migrate.PreviewShellHistory(historyOriginal[item])
@@ -183,7 +183,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 				return fmt.Sprintf("%s across %s", countWord(secrets, "secret", "secrets"), countWord(occ, "occurrence", "occurrences"))
 			})
 		printMigratePlanCategoryAnnotated(w,
-			pluralWord(len(mcpFixed), "MCP config", "MCP configs")+" → secrets move to the vault; injected automatically when the server launches",
+			pluralWord(len(mcpFixed), "MCP config", "MCP configs")+" "+glyphAction+" secrets move to the vault; injected automatically when the server launches",
 			shorten(mcpFixed), func(item string) string {
 				// The user named a config file; this names the OTHER file on
 				// disk the run will rewrite into a pointer. Without it the
@@ -201,34 +201,34 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 		// AWS/kubeconfig/Terraform/Docker items are profile/user/host/
 		// registry NAMES, not paths — nothing to shorten.
 		printMigratePlanCategory(w,
-			pluralWord(len(d.awsProfiles), "AWS profile", "AWS profiles")+" in ~/.aws/credentials → secrets move to the vault; fetched automatically when the AWS CLI/SDK needs them",
+			pluralWord(len(d.awsProfiles), "AWS profile", "AWS profiles")+" in ~/.aws/credentials "+glyphAction+" secrets move to the vault; fetched automatically when the AWS CLI/SDK needs them",
 			d.awsProfiles)
 		printMigratePlanCategory(w,
-			pluralWord(len(d.k8sUsers), "kubeconfig user", "kubeconfig users")+" in ~/.kube/config → secrets move to the vault; fetched automatically whenever kubectl runs",
+			pluralWord(len(d.k8sUsers), "kubeconfig user", "kubeconfig users")+" in ~/.kube/config "+glyphAction+" secrets move to the vault; fetched automatically whenever kubectl runs",
 			d.k8sUsers)
 		printMigratePlanCategory(w,
-			pluralWord(len(d.terraformHosts), "Terraform Cloud host", "Terraform Cloud hosts")+" in ~/.terraform.d/credentials.tfrc.json → tokens move to the vault; fetched automatically whenever terraform runs",
+			pluralWord(len(d.terraformHosts), "Terraform Cloud host", "Terraform Cloud hosts")+" in ~/.terraform.d/credentials.tfrc.json "+glyphAction+" tokens move to the vault; fetched automatically whenever terraform runs",
 			d.terraformHosts)
 		printMigratePlanCategory(w,
-			pluralWord(len(d.dockerRegistries), "Docker registry credential", "Docker registry credentials")+" in ~/.docker/config.json → credentials move to the vault; fetched automatically whenever docker needs them (docker login/logout keep working)",
+			pluralWord(len(d.dockerRegistries), "Docker registry credential", "Docker registry credentials")+" in ~/.docker/config.json "+glyphAction+" credentials move to the vault; fetched automatically whenever docker needs them (docker login/logout keep working)",
 			d.dockerRegistries)
 		printMigratePlanCategory(w,
-			pluralWord(len(d.gitHosts), "git HTTPS host", "git HTTPS hosts")+" in ~/.git-credentials → credentials move to the vault; fetched automatically whenever git pushes/fetches over HTTPS (credential.helper set to jit)",
+			pluralWord(len(d.gitHosts), "git HTTPS host", "git HTTPS hosts")+" in ~/.git-credentials "+glyphAction+" credentials move to the vault; fetched automatically whenever git pushes/fetches over HTTPS (credential.helper set to jit)",
 			d.gitHosts)
 		printMigratePlanCategory(w,
-			"GCP application-default credentials → secrets move to the vault; the file keeps working via a live, auto-updating mount",
+			"GCP application-default credentials "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount",
 			shorten(d.gcpADCFiles))
 		printMigratePlanCategory(w,
-			pluralWord(len(d.sopsAgeFiles), "SOPS age key file", "SOPS age key files")+" → the "+pluralWord(len(d.sopsAgeFiles), "key moves", "keys move")+" to the vault; sops/kluctl keep working via a live, auto-updating mount (or sops's own SOPS_AGE_KEY_CMD hook)",
+			pluralWord(len(d.sopsAgeFiles), "SOPS age key file", "SOPS age key files")+" "+glyphAction+" the "+pluralWord(len(d.sopsAgeFiles), "key moves", "keys move")+" to the vault; sops/kluctl keep working via a live, auto-updating mount (or sops's own SOPS_AGE_KEY_CMD hook)",
 			shorten(d.sopsAgeFiles))
 		printMigratePlanCategory(w,
-			pluralWord(len(npmrcFixed), "npmrc file", "npmrc files")+" → secrets move to the vault; the file keeps working via a live, auto-updating mount",
+			pluralWord(len(npmrcFixed), "npmrc file", "npmrc files")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount",
 			shorten(npmrcFixed))
 		printMigratePlanCategory(w,
-			pluralWord(len(d.netrcFiles), "~/.netrc password", "~/.netrc passwords")+" → secrets move to the vault; the file keeps working via a live, auto-updating mount (login/machine lines untouched)",
+			pluralWord(len(d.netrcFiles), "~/.netrc password", "~/.netrc passwords")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount (login/machine lines untouched)",
 			shorten(d.netrcFiles))
 		printMigratePlanCategory(w,
-			pluralWord(len(d.pypircFiles), "~/.pypirc credential", "~/.pypirc credentials")+" → secrets move to the vault; the file keeps working via a live, auto-updating mount (repository/username lines untouched)",
+			pluralWord(len(d.pypircFiles), "~/.pypirc credential", "~/.pypirc credentials")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount (repository/username lines untouched)",
 			shorten(d.pypircFiles))
 
 		// --only filters by CATEGORY, not by this scoped/machine-wide
@@ -319,8 +319,8 @@ func printMigratePlanCategory(w io.Writer, headline string, items []string) {
 // Split, the name anchors the bracketed header and the outcome drops to its
 // own line, matching how scan renders a [Category] over its detail.
 func splitHeadline(headline string) (name, outcome string) {
-	if i := strings.Index(headline, " → "); i >= 0 {
-		return headline[:i], headline[i+len(" → "):]
+	if i := strings.Index(headline, " "+glyphAction+" "); i >= 0 {
+		return headline[:i], headline[i+len(" "+glyphAction+" "):]
 	}
 	return headline, ""
 }
@@ -346,7 +346,7 @@ func printMigratePlanCategoryAnnotated(w io.Writer, headline string, items []str
 	fmt.Fprintf(w, "[%s]", name)
 	_, _ = fmt.Fprintf(w, " %d\n", len(items))
 	if outcome != "" {
-		_, _ = fmt.Fprintf(w, "  → %s\n", outcome)
+		_, _ = fmt.Fprintf(w, "  "+glyphAction+" %s\n", outcome)
 	}
 	for _, item := range items {
 		note := ""
@@ -354,9 +354,9 @@ func printMigratePlanCategoryAnnotated(w io.Writer, headline string, items []str
 			note = annotate(item)
 		}
 		if note != "" {
-			fmt.Fprintf(w, "  • %s (%s)\n", item, note)
+			fmt.Fprintf(w, "  "+glyphBullet+" %s (%s)\n", item, note)
 		} else {
-			fmt.Fprintf(w, "  • %s\n", item)
+			fmt.Fprintf(w, "  "+glyphBullet+" %s\n", item)
 		}
 	}
 	fmt.Fprintln(w)

--- a/internal/cli/migrateremove.go
+++ b/internal/cli/migrateremove.go
@@ -798,36 +798,36 @@ func printLooseFileRemovalPlan(out interface{ Write([]byte) (int, error) }, home
 	switch {
 	case plan.isMount:
 		printMigrateResultCategory(out, "Live mount -> plain file again (current vault values)", 1)
-		fmt.Fprintf(out, "  • %s\n\n", displayPath(home, plan.file))
+		fmt.Fprintf(out, "  "+glyphBullet+" %s\n\n", displayPath(home, plan.file))
 	case plan.isPointer:
 		printMigrateResultCategory(out, "Pointer file -> plain file again (pre-migration backup)", 1)
-		fmt.Fprintf(out, "  • %s\n\n", displayPath(home, plan.file))
+		fmt.Fprintf(out, "  "+glyphBullet+" %s\n\n", displayPath(home, plan.file))
 	}
 	if n := len(plan.profilePaths); n > 0 {
 		printMigrateResultCategory(out, pluralWord(n, "Profile + its", "Profiles + their")+" vault secrets deleted", n)
 		for _, p := range plan.profilePaths {
-			fmt.Fprintf(out, "  • %s\n", displayPath(home, p))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", displayPath(home, p))
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.deletePaths); n > 0 {
 		printMigrateResultCategory(out, "Vault secrets deleted", n)
 		for _, p := range plan.deletePaths {
-			fmt.Fprintf(out, "  • %s\n", p)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", p)
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.keptShared); n > 0 {
 		printMigrateResultCategory(out, "Vault secrets KEPT (another profile still references them)", n)
 		for _, p := range plan.keptShared {
-			fmt.Fprintf(out, "  • %s\n", p)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", p)
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.backups); n > 0 {
 		printMigrateResultCategory(out, "Encrypted file backups deleted", n)
 		for _, rec := range plan.backups {
-			fmt.Fprintf(out, "  • %s\n", rec.VaultPath)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", rec.VaultPath)
 		}
 		fmt.Fprintln(out)
 	}
@@ -1143,14 +1143,14 @@ func printProjectRemovalPlan(out interface{ Write([]byte) (int, error) }, home s
 	if n := len(plan.mounts); n > 0 {
 		printMigrateResultCategory(out, "Live mounts -> plain files again (current vault values)", n)
 		for _, e := range plan.mounts {
-			fmt.Fprintf(out, "  • %s\n", displayPath(home, e.MountPath))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", displayPath(home, e.MountPath))
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.inPlace); n > 0 {
 		printMigrateResultCategory(out, "Pointer files -> plain files again (current vault values)", n)
 		for _, p := range plan.inPlace {
-			fmt.Fprintf(out, "  • %s\n", displayPath(home, p))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", displayPath(home, p))
 		}
 		fmt.Fprintln(out)
 	}
@@ -1160,7 +1160,7 @@ func printProjectRemovalPlan(out interface{ Write([]byte) (int, error) }, home s
 		// run `jit vault set` on one of these since migrating.
 		printMigrateResultCategory(out, "Rewritten files -> restored from their pre-migration backup", n)
 		for _, rec := range plan.rewritten {
-			fmt.Fprintf(out, "  • %s\n", displayPath(home, rec.OriginalPath))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", displayPath(home, rec.OriginalPath))
 		}
 		fmt.Fprintln(out)
 	}
@@ -1177,35 +1177,35 @@ func printProjectRemovalPlan(out interface{ Write([]byte) (int, error) }, home s
 				names = append(names, name)
 			}
 			sort.Strings(names)
-			fmt.Fprintf(out, "  • %s (profile %s)\n", displayPath(home, cfg), strings.Join(names, ", "))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s (profile %s)\n", displayPath(home, cfg), strings.Join(names, ", "))
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.profileInfos); n > 0 {
 		printMigrateResultCategory(out, "Profiles + their vault secrets deleted", n)
 		for _, info := range plan.profileInfos {
-			fmt.Fprintf(out, "  • %q (%s)\n", info.Name, displayPath(home, info.Path))
+			fmt.Fprintf(out, "  "+glyphBullet+" %q (%s)\n", info.Name, displayPath(home, info.Path))
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.orphanSecrets); n > 0 {
 		printMigrateResultCategory(out, "Orphaned vault secrets deleted (no profile; matched by origin in this project)", n)
 		for _, p := range plan.orphanSecrets {
-			fmt.Fprintf(out, "  • %s\n", p)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", p)
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.keptShared); n > 0 {
 		printMigrateResultCategory(out, "Vault secrets KEPT (another profile still references them)", n)
 		for _, p := range plan.keptShared {
-			fmt.Fprintf(out, "  • %s\n", p)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", p)
 		}
 		fmt.Fprintln(out)
 	}
 	if n := len(plan.backups); n > 0 {
 		printMigrateResultCategory(out, "Encrypted file backups deleted (jit migrate undo loses these)", n)
 		for _, rec := range plan.backups {
-			fmt.Fprintf(out, "  • %s\n", rec.VaultPath)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s\n", rec.VaultPath)
 		}
 		fmt.Fprintln(out)
 	}

--- a/internal/cli/migratesummary.go
+++ b/internal/cli/migratesummary.go
@@ -128,7 +128,7 @@ func (s *migrateSummary) print(w io.Writer) {
 			countWord(len(s.gitHistoryFiles), "file", "files"),
 			pluralWord(len(s.gitHistoryFiles), "has", "have")))
 		for _, f := range s.gitHistoryFiles {
-			fmt.Fprintf(w, "  • %s\n", f)
+			fmt.Fprintf(w, "  "+glyphBullet+" %s\n", f)
 		}
 		fmt.Fprintln(w, hlCmds("  Any value ever committed is still recoverable via `git log -p`/`git blame` for the life of"))
 		fmt.Fprintln(w, "  the repository, and by anyone who already has a clone or fork. To actually remove it,")

--- a/internal/cli/outputstyle_test.go
+++ b/internal/cli/outputstyle_test.go
@@ -5,6 +5,8 @@ package cli
 
 import (
 	"bytes"
+	"go/scanner"
+	"go/token"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -271,4 +273,69 @@ func readLines(t *testing.T, path string) []string {
 		t.Fatalf("reading %s: %v", path, err)
 	}
 	return strings.Split(string(data), "\n")
+}
+
+// glyphLiterals are the house glyphs (internal/style) that must reach output
+// through their constants, never typed at a call site. GlyphMark ("!") is
+// absent deliberately: it is ordinary punctuation, and a check for it would
+// flag every exclamation mark in every message.
+var glyphLiterals = []string{"●", "○", "✗", "✓", "→", "•", "└", "─", "🔐", "▰", "▱"}
+
+// TestNoGlyphLiterals is the enforcement design/output-style.md rule 5 claimed
+// and never had: it said TestPaletteIsCentralised fails on a glyph literal at
+// a call site, while that test checks color.New( only — and ~100 emitted
+// strings typed glyphs directly when this was written (41 arrows, 49 bullets,
+// the rest scattered across 18 files). Like the colour checks, the point of
+// the seam is that a vocabulary change happens in exactly one place.
+//
+// String literals only, via the real Go tokenizer: a glyph in a COMMENT is
+// prose describing the output and entirely fine. Walks every package (the
+// scan report lives in internal/audit), with three exemptions: test files
+// (fixtures should carry the literal, or expectation and production move
+// together), style.go files (the definitions and cli's re-exports), and
+// markdown.go (a markdown document written to disk, not terminal output).
+func TestNoGlyphLiterals(t *testing.T) {
+	var checked int
+	err := filepath.WalkDir("..", func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") ||
+			name == "style.go" || name == "markdown.go" {
+			return nil
+		}
+		src, readErr := os.ReadFile(path) // #nosec G304 -- jit's own source tree
+		if readErr != nil {
+			return nil
+		}
+		checked++
+		fset := token.NewFileSet()
+		tf := fset.AddFile(path, fset.Base(), len(src))
+		var sc scanner.Scanner
+		sc.Init(tf, src, nil, 0)
+		for {
+			pos, tok, lit := sc.Scan()
+			if tok == token.EOF {
+				break
+			}
+			if tok != token.STRING {
+				continue
+			}
+			for _, g := range glyphLiterals {
+				if strings.Contains(lit, g) {
+					t.Errorf("%s:%d types the glyph %q in a string literal; use the style.Glyph* "+
+						"constant (or internal/cli's glyph* re-export) so a vocabulary change stays one edit.\n    %s",
+						filepath.ToSlash(path), fset.Position(pos).Line, g, lit)
+				}
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the tree: %v", err)
+	}
+	if checked == 0 {
+		t.Fatal("no source files checked — the guard would pass vacuously")
+	}
 }

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -116,7 +116,7 @@ var scanCmd = &cobra.Command{
 		"stores (~/.aws, ~/.ssh, …); symlinks are not followed.\n\n" +
 		"Exposure score\n\n" +
 		"jit reports a 0-100 exposure score next to the categorical risk level " +
-		"(the report's `✗ CRITICAL — exposure 85/100` banner). It is computed " +
+		"(the report's `" + glyphRisk + " CRITICAL — exposure 85/100` banner). It is computed " +
 		"entirely locally and deterministically:\n\n" +
 		"  1. Sum a severity-weighted load over all findings: critical 30, high " +
 		"15, medium 6, low 2, info 0. (info is detection-only, not an at-rest " +

--- a/internal/cli/style.go
+++ b/internal/cli/style.go
@@ -43,6 +43,8 @@ const (
 	glyphRisk   = style.GlyphRisk
 	glyphDone   = style.GlyphDone
 	glyphAction = style.GlyphAction
+	glyphBullet = style.GlyphBullet
+	glyphBranch = style.GlyphBranch
 	glyphMark   = style.GlyphMark
 	glyphRule   = style.GlyphRule
 	glyphLock   = style.GlyphLock

--- a/internal/cli/undo.go
+++ b/internal/cli/undo.go
@@ -153,10 +153,10 @@ func runMigrateUndo(cmd *cobra.Command, args []string) error {
 			note = ", live mount: stops being served, unregistered"
 		}
 		if rec.RemoveOnRestore {
-			fmt.Fprintf(out, "  • %s (created by migration, will be removed)%s\n", displayPath(home, rec.OriginalPath), note)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s (created by migration, will be removed)%s\n", displayPath(home, rec.OriginalPath), note)
 			continue
 		}
-		fmt.Fprintf(out, "  • %s (backed up %s ago)%s\n", displayPath(home, rec.OriginalPath), humanAgo(time.Since(time.Unix(rec.UnixTS, 0))), note)
+		fmt.Fprintf(out, "  "+glyphBullet+" %s (backed up %s ago)%s\n", displayPath(home, rec.OriginalPath), humanAgo(time.Since(time.Unix(rec.UnixTS, 0))), note)
 	}
 	fmt.Fprintln(out)
 	warn := cWarn
@@ -334,7 +334,7 @@ func runRestores(out io.Writer, home string, recs []migrate.BackupRecord, restor
 			pluralWord(len(failures), "was", "were"),
 			pluralWord(len(failures), "it was", "they were"))
 		for _, f := range failures {
-			fmt.Fprintf(out, "  • %s: %v\n", displayPath(home, f.path), f.err)
+			fmt.Fprintf(out, "  "+glyphBullet+" %s: %v\n", displayPath(home, f.path), f.err)
 		}
 		total := restored + len(failures)
 		return fmt.Errorf("jit migrate undo: %d of %s failed to restore", len(failures), countWord(total, "file", "files"))

--- a/internal/cli/unmount.go
+++ b/internal/cli/unmount.go
@@ -62,7 +62,7 @@ var unmountCmd = &cobra.Command{
 			home, _ := os.UserHomeDir()
 			lines := make([]string, 0, len(entries))
 			for _, e := range entries {
-				lines = append(lines, "  • "+displayPath(home, e.MountPath))
+				lines = append(lines, "  "+glyphBullet+" "+displayPath(home, e.MountPath))
 			}
 			return fmt.Errorf("jit unmount: no mount registered at %s, currently mounted:\n%s", mountPath, strings.Join(lines, "\n"))
 		}

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -1478,7 +1478,7 @@ var vaultPruneCmd = &cobra.Command{
 
 		fmt.Fprint(out, hlCmds(fmt.Sprintf("Pruning %s, each file's newest backup is kept, so `jit migrate undo` still works:\n", countWord(len(stale), "stale file backup", "stale file backups"))))
 		for _, r := range stale {
-			fmt.Fprintf(out, "  • %s (%s, backed up %s ago)\n", r.VaultPath, displayPath(home, r.OriginalPath), humanAgo(time.Since(time.Unix(r.UnixTS, 0))))
+			fmt.Fprintf(out, "  "+glyphBullet+" %s (%s, backed up %s ago)\n", r.VaultPath, displayPath(home, r.OriginalPath), humanAgo(time.Since(time.Unix(r.UnixTS, 0))))
 		}
 		// Both this and `jit vault orphans --prune` are destructive vault
 		// cleanups, and the word "prune" alone doesn't say which objects go.

--- a/internal/cli/withmounts.go
+++ b/internal/cli/withmounts.go
@@ -160,7 +160,7 @@ func printGlobalMountReminders(w io.Writer) {
 	var lines []string
 	for _, e := range entries {
 		if g, ok := globalMountGuidanceForPath(home, e.MountPath); ok {
-			lines = append(lines, "  • "+g.usageLine())
+			lines = append(lines, "  "+glyphBullet+" "+g.usageLine())
 		}
 	}
 	if len(lines) == 0 {

--- a/internal/migrate/mcpconfig.go
+++ b/internal/migrate/mcpconfig.go
@@ -20,13 +20,6 @@ import (
 	"github.com/jitpass/jit/internal/vault"
 )
 
-// mcpConfigFileNames mirrors internal/audit/mcpconfig.go's own list.
-var mcpConfigFileNames = map[string]bool{
-	"mcp.json":                   true,
-	".mcp.json":                  true,
-	"claude_desktop_config.json": true,
-}
-
 var mcpProfileNameSanitizer = regexp.MustCompile(`[^A-Za-z0-9_.\-]+`)
 
 // mcpServerRaw is one server entry decoded as raw JSON fields, so
@@ -144,7 +137,7 @@ func discoverMCPConfigFiles(home, cwd string, includeClaudeDesktop bool, accept 
 		if !d.Type().IsRegular() {
 			return nil
 		}
-		if mcpConfigFileNames[d.Name()] {
+		if audit.IsMCPConfigFileName(d.Name()) {
 			check(path)
 		}
 		return nil

--- a/internal/migrate/shimdir_test.go
+++ b/internal/migrate/shimdir_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/jitpass/jit/internal/wrap"
+)
+
+// TestHelperPathsLiveInWrapsShimDir pins the ".jit/shims" copies in
+// DockerHelperPath and GitHelperPath to the directory internal/wrap actually
+// owns and keeps on PATH.
+//
+// Both functions carry the path as "a small independent copy … rather than an
+// import of internal/wrap", and that stays as it is on purpose: migrate does
+// not import wrap in production, reversing that is the maintainer's call, and
+// the 2026-08-06 review declined to make it. What was missing is any check at
+// all — if wrap ever moves its shim directory, both helper scripts land in a
+// directory that is no longer on anyone's PATH, and docker/git report the
+// helper missing with nothing pointing at why. wrap is already in migrate's
+// transitive dependencies, and a TEST import adds no production edge — the
+// same shape the AEAD interop test uses between keychainwrap and agent.
+func TestHelperPathsLiveInWrapsShimDir(t *testing.T) {
+	const home = "/Users/fixture"
+	shimDir := wrap.ShimDir(home)
+	for name, path := range map[string]string{
+		"DockerHelperPath": DockerHelperPath(home),
+		"GitHelperPath":    GitHelperPath(home),
+	} {
+		if got := filepath.Dir(path); got != shimDir {
+			t.Errorf("%s puts its helper in %q, but wrap's shim directory is %q; "+
+				"docker/git would look the helper up on PATH and not find it", name, got, shimDir)
+		}
+	}
+}


### PR DESCRIPTION
The remaining mechanical items from the 2026-08-06 handoff. Three commits.

## 1. Glyph-literal enforcement (the follow-up scoped in #29)

`design/output-style.md` rule 5 claimed a test catches glyph literals at call sites; it never did. A **tokenizer** pass (not grep — glyphs in comments are prose and fine, and a naive count was ~30% inflated by them) found **82 string literals** in 14 files. All are now the `style.Glyph*` constants, via a `go/scanner`-based rewriter rather than hand edits. `internal/cli` gained the `glyphBullet`/`glyphBranch` re-exports it was missing.

**Rendered output is byte-identical**: scan, `scan --full`, status, doctor and `migrate --dry-run` captured against a fixture before and after; the only diff was the `+dirty` version suffix of the working-tree build.

`TestNoGlyphLiterals` closes the loop, tokenizer-based so comments stay free, with the same exemptions as the other style guards (test files, `style.go`, `markdown.go`) and `!` excluded as ordinary punctuation. Mutation-verified: a fresh `"  • "` planted in `internal/audit` — a package the older guards never looked at — is named by file and line.

*Merge note:* #29 corrected the doc to say "enforcement missing"; once both land, that paragraph should name `TestNoGlyphLiterals` — left un-edited here so the branches don't conflict on the same hunk.

## 2. Two contracts-by-reminder

- `mcpConfigFileNames` existed twice, migrate's copy behind a comment saying it "mirrors" audit's. migrate already imports audit in production, so the mirror is deleted — audit exports `IsMCPConfigFileName` and divergence is now impossible **by construction**.
- The `.jit/shims` copies in `DockerHelperPath`/`GitHelperPath` **stay copies** — the handoff calls reversing that documented decision the maintainer's call, and I didn't. What was missing was any check: if wrap moves its shim dir, both helper scripts land off PATH and docker/git report the helper missing with nothing pointing at why. A *test-only* wrap import now pins them (no production edge — the AEAD-interop shape). Mutation-verified.

## 3. The `~/` scope lie

```
before:  jit scan  ~/ · 17ms              (for jit scan token.txt)
after:   jit scan  ~/proj/.env · 0ms
         jit scan  ~/a, ~/b +2 more · 0ms  (many targets truncate, per house rule)
```

`ScanSummary` carries the targets (additive JSON field, no schema bump), and the shared header — one function renders both views — names them. The machine-wide `~/` was truthful and is byte-for-byte unchanged. Table-tested including the outside-home absolute case; mutation-verified against the old hardcoded label.

## Verification

Full suite green under `-race`; `gofmt`, `go vet` clean. Merges cleanly with #25–#30 (the one soft interaction with #29 is the doc note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9WVMxBcotR51QJsbYjBj4