### PR TITLE
brew: survive brew upgrade, and surface the dual-install trap

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ sudo mv jit /usr/local/bin/
 Apple Silicon only — on an Intel Mac, build from source with
 `go install github.com/jitpass/jit/cmd/jit@latest`.
 
+Pick one route. If you installed from the tarball before and are switching to
+Homebrew, remove the old copy after the `brew install` (`sudo rm
+/usr/local/bin/jit`); otherwise two jits sit on PATH upgrading separately, and
+`jit doctor` will flag it.
+
 Releases are signed with a Developer ID and notarized by Apple, so both paths
 run without a Gatekeeper prompt: Homebrew quarantines its downloads and
 Gatekeeper clears them against the notarization ticket, while `curl` (and `go

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -23,6 +23,12 @@ tar -xzf jitpass_darwin_arm64.tar.gz jit
 sudo mv jit /usr/local/bin/
 ```
 
+> **Already installed from the tarball and switching to Homebrew?** Remove the
+> old copy afterwards: `sudo rm /usr/local/bin/jit`. `brew install` doesn't
+> replace it, it adds a second jit, and PATH order then silently decides which
+> one your shell runs while each upgrades on its own track. `jit doctor` flags
+> this state and names both copies.
+
 That's the install done - continue with the **[Quickstart](./quickstart.md)**.
 The background service that lets you unlock once per session (instead of once per
 command) sets itself up automatically the first time you run `jit migrate` or
@@ -153,7 +159,10 @@ install locations.
 
 ## Upgrading
 
-On **v0.41.0 or newer**, upgrading is one command:
+Installed with Homebrew? It's `brew upgrade jitpass`; a Homebrew-managed jit
+declines to self-update and says so.
+
+Otherwise, on **v0.41.0 or newer**, upgrading is one command:
 
 ```sh
 jit upgrade

--- a/docs/reference/commands/jit_upgrade.md
+++ b/docs/reference/commands/jit_upgrade.md
@@ -18,9 +18,8 @@ If that path isn't writable (e.g. /usr/local/bin), you'll be prompted for sudo
 just for the move. Your vault and secrets are never touched.
 
 A jit installed by Homebrew is not self-replaced, since Homebrew owns that
-copy — run `brew upgrade jitpass` instead. Reinstall from the release
-tarball if you would rather this command manage it, so
-switch to a self-upgrading build (see the install guide).
+copy; run `brew upgrade jitpass` instead. If you'd rather this command
+manage it, reinstall from the release tarball (see the install guide).
 
 Only the published darwin/arm64 release is fetched this way; on any other
 platform, build from source with `go install github.com/jitpass/jit/cmd/jit@latest`.

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -535,13 +535,16 @@ const agentInstallDefaultTTL = 5 * time.Minute
 // agentBinaryPath is the path launchd should re-exec: this binary, with the
 // /usr/local/bin install symlink (or any shim) resolved. launchd runs this
 // exact path at every login, so a path that later moves out from under it
-// leaves the service pointing at nothing.
+// leaves the service pointing at nothing — which is exactly why a
+// Homebrew-managed jit keeps the bin symlink rather than resolving through
+// it into the version-numbered Caskroom copy `brew upgrade` deletes (see
+// stableBinaryPath).
 func agentBinaryPath() (string, error) {
 	exePath, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
-	return filepath.EvalSymlinks(exePath)
+	return stableBinaryPath(exePath)
 }
 
 // plistProgramPath returns the binary an installed plist actually runs — the
@@ -665,15 +668,63 @@ func installAgentService(ttl time.Duration, consent bool) (plistPath string, run
 // unlock, or notRunningHint's advice) rather than failing the user's real
 // command because a background convenience didn't take. Returns whether it just
 // installed the service, and whether the service is answering now.
+//
+// One exception to "installed means leave it alone": a plist whose program
+// binary is no longer on disk. That service can never come back by itself —
+// launchd has nothing to exec at next login, and the stale-binary
+// self-retire deliberately doesn't fire on a vanished file (agentbinary.go).
+// In the field this is what `brew upgrade` left behind before
+// stableBinaryPath: a plist recording the version-numbered Caskroom path the
+// upgrade then deleted. Repoint it at this binary, preserving the plist's
+// configured TTL and consent — but only when no agent is answering, because
+// an agent still running from a deleted binary keeps serving its session,
+// and booting it out would trade a live session for a repair that works just
+// as well once that agent is gone.
 func ensureAgentInstalled() (didInstall, running bool) {
 	if agentInstalled() {
-		return false, false
+		if !agentPlistOrphaned() {
+			return false, false
+		}
+		root, err := vaultRootDir()
+		if err != nil || agent.NewClient(agent.SocketPath(root)).Reachable() {
+			return false, false
+		}
+		ttl := agentInstallDefaultTTL
+		if configured, ok := configuredAgentTTL(); ok {
+			ttl = configured
+		}
+		_, running, err := installAgentService(ttl, configuredAgentConsent())
+		if err != nil {
+			return false, false
+		}
+		return true, running
 	}
 	_, running, err := installAgentService(agentInstallDefaultTTL, true)
 	if err != nil {
 		return false, false
 	}
 	return true, running
+}
+
+// agentPlistOrphaned reports whether the installed plist names a program
+// binary that no longer exists on disk. Only a definite "not there" counts —
+// an unreadable plist or a stat error that isn't NotExist answers false, so
+// uncertainty never triggers a reinstall.
+func agentPlistOrphaned() bool {
+	plistPath, err := agentPlistPath()
+	if err != nil {
+		return false
+	}
+	data, err := os.ReadFile(plistPath) // #nosec G304 -- jit's own launchd plist under the user's LaunchAgents dir
+	if err != nil {
+		return false
+	}
+	program, ok := plistProgramPath(data)
+	if !ok {
+		return false
+	}
+	_, err = os.Stat(program) // #nosec G703 -- stat-only existence probe of the binary named by jit's own plist
+	return os.IsNotExist(err)
 }
 
 var agentRestartCmd = &cobra.Command{

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -546,6 +546,8 @@ func findingLabel(f checkFinding) string {
 		return "[audit]"
 	case kindMCP:
 		return "[mcp]"
+	case kindInstall:
+		return "[install]"
 	default:
 		return ""
 	}
@@ -561,7 +563,7 @@ func findingLabel(f checkFinding) string {
 // that identifies the file off the first line (rule 6).
 func formatFinding(f checkFinding) string {
 	switch f.Kind {
-	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit, kindMCP:
+	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit, kindMCP, kindInstall:
 		return shortHome(f.Detail)
 	case kindMissing:
 		return fmt.Sprintf("%s: %s "+glyphAction+" %s, not in the vault", profileRef(f), f.Variable, f.Path)

--- a/internal/cli/doctorsections.go
+++ b/internal/cli/doctorsections.go
@@ -93,8 +93,84 @@ func gatherSystemFindings(root, cwd string, v *vault.Vault) ([]checkFinding, []s
 	findings = append(findings, backupFindings(v)...)
 	findings = append(findings, auditLogFindings(root)...)
 	findings = append(findings, mcpFindings(cwd)...)
+	findings = append(findings, installFindings()...)
 	wrapped, wrapOK := wrapFindings()
 	return append(findings, wrapped...), wrapOK
+}
+
+// jitInstall is one jit binary reachable on PATH: the name shells would use,
+// and the file it actually runs.
+type jitInstall struct {
+	path     string
+	resolved string
+}
+
+// jitInstallsOnPath returns every DISTINCT jit binary reachable on pathEnv,
+// in PATH order — one entry per resolved file, named by the first PATH hit
+// that reaches it, so /opt/homebrew/bin/jit and the Caskroom copy behind it
+// count once. The first entry is the jit shells actually run.
+func jitInstallsOnPath(pathEnv string) []jitInstall {
+	var out []jitInstall
+	seen := map[string]bool{}
+	for _, dir := range filepath.SplitList(pathEnv) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, "jit")
+		if !executableFile(candidate) {
+			continue
+		}
+		resolved, err := filepath.EvalSymlinks(candidate)
+		if err != nil || seen[resolved] {
+			continue
+		}
+		seen[resolved] = true
+		out = append(out, jitInstall{path: candidate, resolved: resolved})
+	}
+	return out
+}
+
+// installFindings warns when more than one jit install is on PATH — the
+// state every pre-Homebrew user reaches by `brew install`ing over a tarball
+// jit at /usr/local/bin. Observed in the field the day the cask shipped:
+// brew prints "successfully installed", `which jit` still answers the old
+// copy, and from then on `brew upgrade` refreshes a binary that never runs.
+// PATH-order gathering here, classification in installFindingsFrom so every
+// branch is testable without staging binaries on the real PATH.
+func installFindings() []checkFinding {
+	return installFindingsFrom(jitInstallsOnPath(os.Getenv("PATH")))
+}
+
+func installFindingsFrom(installs []jitInstall) []checkFinding {
+	if len(installs) < 2 {
+		return nil
+	}
+	winner := installs[0]
+	var out []checkFinding
+	for _, extra := range installs[1:] {
+		f := checkFinding{
+			Kind: kindInstall,
+			Path: extra.path,
+			Detail: fmt.Sprintf("a second jit at %s; shells run %s, and upgrading one never upgrades the other",
+				extra.path, winner.path),
+		}
+		// The one next step keeps the copy shells already run — doctor
+		// restores consistency, it doesn't pick a package manager. The
+		// either-or on the brew case is deliberate: the user who JUST ran
+		// `brew install` over a tarball jit most likely wants the opposite
+		// resolution, and telling only half the story sends them in circles.
+		switch {
+		case brewManaged(extra.resolved):
+			f.Action = fmt.Sprintf("`brew uninstall jitpass` to keep %s, or `sudo rm %s` to switch to the Homebrew copy",
+				winner.path, winner.path)
+		case brewManaged(winner.resolved):
+			f.Action = fmt.Sprintf("`sudo rm %s` to keep the Homebrew copy in charge", extra.path)
+		default:
+			f.Action = fmt.Sprintf("`sudo rm %s` to keep %s", extra.path, winner.path)
+		}
+		out = append(out, f)
+	}
+	return out
 }
 
 // auditLogFindings reports an audit trail that has stopped recording.
@@ -222,7 +298,7 @@ func executableFile(path string) bool {
 	if path == "" {
 		return false
 	}
-	info, err := os.Stat(path)
+	info, err := os.Stat(path) // #nosec G703 -- stat-only probe (MCP entries, PATH candidates); no content is read
 	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
 }
 

--- a/internal/cli/installfindings_test.go
+++ b/internal/cli/installfindings_test.go
@@ -1,0 +1,118 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestJitInstallsOnPathDedupesAndOrders pins the gathering half: one entry
+// per distinct resolved binary, in PATH order, named by the first hit — so
+// /opt/homebrew/bin/jit and a second PATH entry reaching the same Caskroom
+// file count once, and the first entry is the jit shells actually run.
+func TestJitInstallsOnPathDedupesAndOrders(t *testing.T) {
+	root := t.TempDir()
+	mk := func(rel string) string {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- a fake executable in a test fixture
+			t.Fatalf("WriteFile: %v", err)
+		}
+		return p
+	}
+	curl := mk("usr-local-bin/jit")
+	cask := mk("Caskroom/jitpass/0.80.1/jit")
+	brewBin := filepath.Join(root, "homebrew-bin")
+	if err := os.MkdirAll(brewBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(cask, filepath.Join(brewBin, "jit")); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	empty := filepath.Join(root, "no-jit-here")
+	if err := os.MkdirAll(empty, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	// curl dir first (the field shape: /usr/local/bin ahead of brew), then
+	// the brew bin symlink, then the Caskroom dir itself (same file again),
+	// then a dir with no jit.
+	pathEnv := strings.Join([]string{
+		filepath.Dir(curl), brewBin, filepath.Dir(cask), empty,
+	}, string(os.PathListSeparator))
+
+	installs := jitInstallsOnPath(pathEnv)
+	if len(installs) != 2 {
+		t.Fatalf("jitInstallsOnPath = %d installs (%v); want 2 — the Caskroom re-hit must dedupe against the bin symlink", len(installs), installs)
+	}
+	if installs[0].path != curl {
+		t.Errorf("installs[0].path = %s; want %s (PATH order decides which jit shells run)", installs[0].path, curl)
+	}
+	if installs[1].path != filepath.Join(brewBin, "jit") {
+		t.Errorf("installs[1].path = %s; want the bin symlink, the first name that reached the Caskroom copy", installs[1].path)
+	}
+}
+
+// TestInstallFindingsFrom pins the classification half: silent below two
+// installs, one advisory finding per shadowed copy, and the action matched
+// to who owns which copy.
+func TestInstallFindingsFrom(t *testing.T) {
+	if fs := installFindingsFrom(nil); fs != nil {
+		t.Errorf("installFindingsFrom(nil) = %v; want none", fs)
+	}
+	one := []jitInstall{{path: "/usr/local/bin/jit", resolved: "/usr/local/bin/jit"}}
+	if fs := installFindingsFrom(one); fs != nil {
+		t.Errorf("installFindingsFrom(one install) = %v; want none — a single jit is the healthy state", fs)
+	}
+
+	curl := jitInstall{path: "/usr/local/bin/jit", resolved: "/usr/local/bin/jit"}
+	brew := jitInstall{path: "/opt/homebrew/bin/jit", resolved: "/opt/homebrew/Caskroom/jitpass/0.80.1/jit"}
+
+	// The field shape: the old tarball copy shadows the fresh brew install.
+	// The either-or action is deliberate — this user most likely WANTS the
+	// brew copy, so recommending only its removal would send them in circles.
+	fs := installFindingsFrom([]jitInstall{curl, brew})
+	if len(fs) != 1 {
+		t.Fatalf("installFindingsFrom(curl, brew) = %d findings; want 1", len(fs))
+	}
+	f := fs[0]
+	if f.Kind != kindInstall {
+		t.Errorf("Kind = %q; want %q", f.Kind, kindInstall)
+	}
+	if !f.Kind.warning() {
+		t.Error("kindInstall must be advisory: nothing is unreadable, doctor must not fail the run on it")
+	}
+	if !strings.Contains(f.Detail, curl.path) || !strings.Contains(f.Detail, brew.path) {
+		t.Errorf("Detail = %q; want both copies named", f.Detail)
+	}
+	if !strings.Contains(f.Action, "brew uninstall jitpass") || !strings.Contains(f.Action, "sudo rm /usr/local/bin/jit") {
+		t.Errorf("Action = %q; want both resolutions offered when the shadowed copy is Homebrew's", f.Action)
+	}
+
+	// Reversed PATH order: brew wins, the tarball copy is dead weight.
+	fs = installFindingsFrom([]jitInstall{brew, curl})
+	if len(fs) != 1 {
+		t.Fatalf("installFindingsFrom(brew, curl) = %d findings; want 1", len(fs))
+	}
+	if want := "`sudo rm /usr/local/bin/jit` to keep the Homebrew copy in charge"; fs[0].Action != want {
+		t.Errorf("Action = %q; want %q", fs[0].Action, want)
+	}
+
+	// Neither copy is brew's: plain keep-the-winner.
+	local := jitInstall{path: "/Users/x/bin/jit", resolved: "/Users/x/bin/jit"}
+	fs = installFindingsFrom([]jitInstall{curl, local})
+	if len(fs) != 1 {
+		t.Fatalf("installFindingsFrom(curl, local) = %d findings; want 1", len(fs))
+	}
+	if want := "`sudo rm /Users/x/bin/jit` to keep /usr/local/bin/jit"; fs[0].Action != want {
+		t.Errorf("Action = %q; want %q", fs[0].Action, want)
+	}
+}

--- a/internal/cli/installpath.go
+++ b/internal/cli/installpath.go
@@ -1,0 +1,57 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// stableBinaryPath resolves exePath to the path a DURABLE reference should
+// record: the binary the launchd plist re-execs at every login, the target a
+// wrap shim symlinks to. For almost everyone that is plain EvalSymlinks —
+// resolve the install symlink or shim to the real file, so the reference
+// survives the name in front of it being rearranged.
+//
+// The exception is a Homebrew-managed jit, where full resolution lands in a
+// VERSIONED directory (/opt/homebrew/Caskroom/jitpass/0.80.1/jit) that the
+// very next `brew upgrade` deletes. Recording that path is how an upgrade
+// used to orphan the service plist and dangle every wrap shim at once. The
+// durable name in a brew install is the one brew relinks on every upgrade:
+// the prefix's bin symlink (/opt/homebrew/bin/jit). So when resolution ends
+// inside a Caskroom or Cellar, this recovers that bin path from the layout —
+// prefix/bin/<name>, the prefix being whatever sits above Caskroom — and
+// returns it only after proving it currently resolves back to the very same
+// file. Recovering from the layout rather than walking the symlinks in hand
+// means a DIRECT invocation of the Caskroom copy (launchd re-running an old
+// plist, a shim that resolved all the way through) heals onto the stable
+// name too, instead of re-recording the versioned one.
+//
+// Anything unexpected — no bin symlink, or one pointing at a different build
+// — falls back to the fully resolved path, which is at worst the old
+// behaviour.
+func stableBinaryPath(exePath string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return "", err
+	}
+	sep := string(filepath.Separator)
+	segs := strings.Split(resolved, sep)
+	brewIdx := -1
+	for i, seg := range segs {
+		if seg == "Caskroom" || seg == "Cellar" {
+			brewIdx = i
+			break
+		}
+	}
+	if brewIdx <= 0 {
+		return resolved, nil
+	}
+	prefix := strings.Join(segs[:brewIdx], sep)
+	candidate := filepath.Join(prefix, "bin", filepath.Base(resolved))
+	if r, cerr := filepath.EvalSymlinks(candidate); cerr == nil && r == resolved {
+		return candidate, nil
+	}
+	return resolved, nil
+}

--- a/internal/cli/installpath_test.go
+++ b/internal/cli/installpath_test.go
@@ -1,0 +1,208 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// brewFixture lays out a fake Homebrew prefix: a real binary inside a
+// version-numbered dir (relDir under the prefix) and the stable bin/<name>
+// symlink pointing at it. Returns the canonicalized prefix, so path
+// comparisons aren't tripped by /tmp resolving to /private/tmp.
+func brewFixture(t *testing.T, relDir, name string) (prefix, versioned, stable string) {
+	t.Helper()
+	dir := t.TempDir()
+	prefix, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", dir, err)
+	}
+	versioned = filepath.Join(prefix, relDir, name)
+	if err := os.MkdirAll(filepath.Dir(versioned), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(versioned, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- a fake executable in a test fixture
+		t.Fatalf("WriteFile: %v", err)
+	}
+	stable = filepath.Join(prefix, "bin", name)
+	if err := os.MkdirAll(filepath.Dir(stable), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(versioned, stable); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	return prefix, versioned, stable
+}
+
+// TestStableBinaryPathKeepsBrewBinSymlink pins the whole point of
+// stableBinaryPath: a brew-managed jit records the bin symlink brew relinks
+// on every upgrade, NOT the version-numbered Caskroom copy `brew upgrade`
+// deletes. Recording the versioned path is how an upgrade used to orphan
+// the service plist and dangle every wrap shim at once.
+func TestStableBinaryPathKeepsBrewBinSymlink(t *testing.T) {
+	_, _, stable := brewFixture(t, "Caskroom/jitpass/0.80.1", "jit")
+
+	got, err := stableBinaryPath(stable)
+	if err != nil {
+		t.Fatalf("stableBinaryPath(%s): %v", stable, err)
+	}
+	if got != stable {
+		t.Errorf("stableBinaryPath(%s) = %s; want the bin symlink kept, not resolved into the Caskroom", stable, got)
+	}
+}
+
+// TestStableBinaryPathHealsDirectCaskroomInvocation covers the invocation
+// with no symlink in hand: launchd re-running a plist that recorded the
+// versioned path, or a shim that resolved all the way through. The stable
+// name is recovered from the layout (prefix/bin/<name>), so even those
+// callers repoint durable references onto the path that survives upgrades.
+func TestStableBinaryPathHealsDirectCaskroomInvocation(t *testing.T) {
+	_, versioned, stable := brewFixture(t, "Caskroom/jitpass/0.80.1", "jit")
+
+	got, err := stableBinaryPath(versioned)
+	if err != nil {
+		t.Fatalf("stableBinaryPath(%s): %v", versioned, err)
+	}
+	if got != stable {
+		t.Errorf("stableBinaryPath(%s) = %s; want %s recovered from the layout", versioned, got, stable)
+	}
+}
+
+// TestStableBinaryPathCellarLayout: formulas unpack under Cellar with the
+// binary one level deeper (<prefix>/Cellar/<name>/<version>/bin/<name>);
+// the recovery is the same.
+func TestStableBinaryPathCellarLayout(t *testing.T) {
+	_, _, stable := brewFixture(t, "Cellar/jitpass/0.80.1/bin", "jit")
+
+	got, err := stableBinaryPath(stable)
+	if err != nil {
+		t.Fatalf("stableBinaryPath(%s): %v", stable, err)
+	}
+	if got != stable {
+		t.Errorf("stableBinaryPath(%s) = %s; want the bin symlink kept", stable, got)
+	}
+}
+
+// TestStableBinaryPathOutsideBrewResolvesFully pins that everyone NOT under
+// brew keeps the old behaviour exactly: full symlink resolution to the real
+// file.
+func TestStableBinaryPathOutsideBrewResolvesFully(t *testing.T) {
+	dir := t.TempDir()
+	root, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	real := filepath.Join(root, "build", "jit")
+	if err := os.MkdirAll(filepath.Dir(real), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- a fake executable in a test fixture
+		t.Fatalf("WriteFile: %v", err)
+	}
+	link := filepath.Join(root, "jit-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	for _, in := range []string{real, link} {
+		got, err := stableBinaryPath(in)
+		if err != nil {
+			t.Fatalf("stableBinaryPath(%s): %v", in, err)
+		}
+		if got != real {
+			t.Errorf("stableBinaryPath(%s) = %s; want %s (fully resolved)", in, got, real)
+		}
+	}
+}
+
+// TestStableBinaryPathRejectsMismatchedBinSymlink: when the prefix's bin
+// symlink points at a DIFFERENT build than the one running (mid-upgrade,
+// or a bin/jit that belongs to something else), the stable name would be a
+// lie — fall back to the resolved path rather than record a name that runs
+// another binary.
+func TestStableBinaryPathRejectsMismatchedBinSymlink(t *testing.T) {
+	prefix, versioned, stable := brewFixture(t, "Caskroom/jitpass/0.80.1", "jit")
+	other := filepath.Join(prefix, "Caskroom", "jitpass", "0.80.2", "jit")
+	if err := os.MkdirAll(filepath.Dir(other), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(other, []byte("#!/bin/sh\n# other\n"), 0o755); err != nil { // #nosec G306 -- a fake executable in a test fixture
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Remove(stable); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if err := os.Symlink(other, stable); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got, err := stableBinaryPath(versioned)
+	if err != nil {
+		t.Fatalf("stableBinaryPath(%s): %v", versioned, err)
+	}
+	if got != versioned {
+		t.Errorf("stableBinaryPath(%s) = %s; want the resolved path back when bin points elsewhere", versioned, got)
+	}
+}
+
+// TestStableBinaryPathNoBinSymlink: a Caskroom copy with no bin symlink at
+// all has no stable name to offer — resolved path, old behaviour.
+func TestStableBinaryPathNoBinSymlink(t *testing.T) {
+	_, versioned, stable := brewFixture(t, "Caskroom/jitpass/0.80.1", "jit")
+	if err := os.Remove(stable); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	got, err := stableBinaryPath(versioned)
+	if err != nil {
+		t.Fatalf("stableBinaryPath(%s): %v", versioned, err)
+	}
+	if got != versioned {
+		t.Errorf("stableBinaryPath(%s) = %s; want the resolved path back with no bin symlink", versioned, got)
+	}
+}
+
+// TestAgentPlistOrphaned pins the self-heal trigger in ensureAgentInstalled:
+// only a plist whose program binary is definitely gone counts as orphaned —
+// a healthy plist and a missing plist both answer false.
+func TestAgentPlistOrphaned(t *testing.T) {
+	home := shortFixtureHome(t)
+
+	if agentPlistOrphaned() {
+		t.Fatal("agentPlistOrphaned = true with no plist installed; want false")
+	}
+
+	dir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	plistPath := filepath.Join(dir, agentPlistLabel+".plist")
+
+	present := filepath.Join(home, "jit")
+	if err := os.WriteFile(present, []byte("#!/bin/sh\n"), 0o755); err != nil { // #nosec G306 -- a fake executable in a test fixture
+		t.Fatalf("WriteFile: %v", err)
+	}
+	plist := fmt.Sprintf(agentPlistTemplate, agentPlistLabel, present, (5 * time.Minute).String(), "", "/x/agent.log", "/x/agent.log")
+	if err := os.WriteFile(plistPath, []byte(plist), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if agentPlistOrphaned() {
+		t.Error("agentPlistOrphaned = true for a plist whose binary exists; want false")
+	}
+
+	gone := filepath.Join(home, "Caskroom", "jitpass", "0.80.1", "jit")
+	plist = fmt.Sprintf(agentPlistTemplate, agentPlistLabel, gone, (5 * time.Minute).String(), "", "/x/agent.log", "/x/agent.log")
+	if err := os.WriteFile(plistPath, []byte(plist), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if !agentPlistOrphaned() {
+		t.Error("agentPlistOrphaned = false for a plist whose binary is gone; want true")
+	}
+}

--- a/internal/cli/profilecheck.go
+++ b/internal/cli/profilecheck.go
@@ -115,6 +115,15 @@ const (
 	// and no error printed — from `jit upgrade` relocating the binary, a
 	// Homebrew-to-manual switch, or a workspace copied between machines.
 	kindMCP checkKind = "mcp"
+	// kindInstall: more than one distinct jit binary is reachable on PATH —
+	// the state every pre-Homebrew user lands in by running `brew install`
+	// over a tarball install at /usr/local/bin. Nothing shared breaks (vault,
+	// keychain and profiles are per-user, not per-binary), which is exactly
+	// why nobody notices: PATH order silently picks which copy runs, and the
+	// two upgrade on separate tracks — `brew upgrade` refreshing a binary
+	// shells never execute is the observed field shape. Advisory: no secret
+	// is unreadable, but the user should know which jit they are actually on.
+	kindInstall checkKind = "install"
 )
 
 // allCheckKinds enumerates every kind above, for the completeness tests that
@@ -129,7 +138,7 @@ var allCheckKinds = []checkKind{
 	kindParse, kindNotFound, kindMissing, kindCorrupt, kindVaultError,
 	kindBadPath, kindOrphan, kindShadowed, kindService, kindBackup,
 	kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit,
-	kindMCP,
+	kindMCP, kindInstall,
 }
 
 // warning reports whether a finding of this kind is advisory (does not fail
@@ -145,7 +154,7 @@ var allCheckKinds = []checkKind{
 // one process and must never fail a CI run.
 func (k checkKind) warning() bool {
 	switch k {
-	case kindOrphan, kindShadowed, kindService, kindBackup, kindMount, kindWrapEnv, kindAudit:
+	case kindOrphan, kindShadowed, kindService, kindBackup, kindMount, kindWrapEnv, kindAudit, kindInstall:
 		return true
 	default:
 		return false

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -96,9 +96,8 @@ var upgradeCmd = &cobra.Command{
 		"If that path isn't writable (e.g. /usr/local/bin), you'll be prompted for sudo\n" +
 		"just for the move. Your vault and secrets are never touched.\n\n" +
 		"A jit installed by Homebrew is not self-replaced, since Homebrew owns that\n" +
-		"copy — run `brew upgrade jitpass` instead. Reinstall from the release\n" +
-		"tarball if you would rather this command manage it, so\n" +
-		"switch to a self-upgrading build (see the install guide).\n\n" +
+		"copy; run `brew upgrade jitpass` instead. If you'd rather this command\n" +
+		"manage it, reinstall from the release tarball (see the install guide).\n\n" +
 		"Only the published darwin/arm64 release is fetched this way; on any other\n" +
 		"platform, build from source with `go install github.com/jitpass/jit/cmd/jit@latest`.",
 	Args:    cobra.NoArgs,
@@ -132,6 +131,19 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	// EvalSymlinks above deliberately follows into the Caskroom.
 	if brewManaged(exePath) {
 		return fmt.Errorf("jit upgrade: this jit is managed by Homebrew (%s), so it can't self-replace — run `brew upgrade jitpass` instead, or reinstall from the release tarball (https://github.com/%s/%s/releases/latest) if you want this command to manage it", exePath, upgradeRepoOwner, upgradeRepoName)
+	}
+
+	// The refusal above covers a brew-managed copy asked to self-update; the
+	// silent inverse is worse. A pre-Homebrew tarball jit shadowing a fresh
+	// `brew install` self-updates without complaint, and the user now has
+	// two copies on separate upgrade tracks with `brew upgrade` refreshing
+	// the one shells never run. Say so before proceeding, once per extra
+	// copy; the upgrade itself is still fine.
+	for _, other := range jitInstallsOnPath(os.Getenv("PATH")) {
+		if other.resolved == exePath {
+			continue
+		}
+		fmt.Fprint(out, hlCmds(fmt.Sprintf("Note: another jit is installed at %s; this upgrade won't touch it. `jit doctor` shows which copy your shell runs\n", other.path)))
 	}
 
 	client := &http.Client{Timeout: 60 * time.Second}

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"text/tabwriter"
@@ -108,7 +107,7 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 		if err != nil {
 			return fmt.Errorf("jit wrap: %w", err)
 		}
-		jitBinary, err := filepath.EvalSymlinks(exe)
+		jitBinary, err := stableBinaryPath(exe)
 		if err != nil {
 			return fmt.Errorf("jit wrap: %w", err)
 		}
@@ -137,7 +136,7 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 		if err != nil {
 			return fmt.Errorf("jit wrap: %w", err)
 		}
-		jitBinary, err := filepath.EvalSymlinks(exe)
+		jitBinary, err := stableBinaryPath(exe)
 		if err != nil {
 			return fmt.Errorf("jit wrap: %w", err)
 		}
@@ -233,7 +232,7 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 	if err != nil {
 		return fmt.Errorf("jit wrap: %w", err)
 	}
-	jitBinary, err := filepath.EvalSymlinks(exe)
+	jitBinary, err := stableBinaryPath(exe)
 	if err != nil {
 		return fmt.Errorf("jit wrap: %w", err)
 	}
@@ -305,7 +304,7 @@ var wrapAddCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("jit wrap add: %w", err)
 		}
-		jitBinary, err := filepath.EvalSymlinks(exe)
+		jitBinary, err := stableBinaryPath(exe)
 		if err != nil {
 			return fmt.Errorf("jit wrap add: %w", err)
 		}


### PR DESCRIPTION
## What

Two problems shipped with the cask, one latent and one observed in the field the day it went live.

### brew upgrade used to break the service and every wrap shim

Durable references (the launchd plist's `ProgramArguments`, wrap shim symlink targets) recorded the fully RESOLVED binary path — for a Homebrew install that is the version-numbered Caskroom directory the very next `brew upgrade` deletes. launchd was left pointing at nothing (the stale-binary self-retire deliberately doesn't fire on a vanished file, so nothing recovered), and every wrapped tool became a dangling symlink.

- New `stableBinaryPath` keeps the name brew RELINKS on every upgrade — the prefix's `bin` symlink — recovered from the layout rather than the symlink chain in hand, so even a direct Caskroom invocation (launchd re-running an old plist, a shim that resolved all the way through) heals onto the stable name. It returns the bin path only after proving it resolves back to the very same file; anything unexpected falls back to the old behaviour.
- `ensureAgentInstalled` repairs the state 0.80.x already left behind: a plist whose program binary is gone is repointed at this binary (preserving configured TTL and consent), but only when no agent is answering — an agent still running from a deleted binary keeps its session.

### Two jits on PATH, and nobody says so

A pre-Homebrew tarball user who runs `brew install` gets a second jit, and PATH order silently decides which one shells run — observed shape: brew prints "successfully installed" while `which jit` still answers /usr/local/bin/jit, and from then on `brew upgrade` refreshes a binary that never executes.

- `jit doctor` grows an advisory `[install]` finding: every distinct jit on PATH, which one shells actually run, and a removal action matched to who owns which copy.
- `jit upgrade` notes the other copies before self-updating (the silent inverse of its existing brew-managed refusal), and its help text loses a sentence two drafts had merged into nonsense.
- install.md + README migration note for tarball users switching to Homebrew.

## Testing

Full gate green: `go test -race ./...`, gofmt, vet, staticcheck, gosec (0), govulncheck (0), docs-gen. 8 new unit tests.

Live E2E on a real Mac with the cask installed:
1. `[install]` doctor finding on a genuine dual install — correct winner and action
2. wrap shim from a brew-managed jit → targets `/opt/homebrew/bin/jit`, not the Caskroom path
3. `jit service restart` repoints an old plist onto the stable path
4. simulated `brew upgrade` (new version dir, relink, delete old): agent self-restarted onto the new binary, shim and plist both survived
5. field-recovery: orphaned plist + dead agent healed by the first `jit unlock`
6. `jit upgrade` refusal (brew copy) and the new dual-install note (tarball copy) both render as previewed
7. real `brew reinstall` afterwards: plist survived the version-dir wipe with no intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJP8yGRWGcqSjzwxhMfEpQ