### PR TITLE
scan report: followable advice, whole commands, and a scanner that does not flag itself

### DIFF
--- a/internal/audit/archived.go
+++ b/internal/audit/archived.go
@@ -31,3 +31,36 @@ func LooksArchived(path string) bool {
 	}
 	return false
 }
+
+// dirDiscoverable reports whether naming a DIRECTORY above f's file would
+// rediscover it: `jit migrate <dir>` walks project files only (.env, tfvars,
+// k8s secret manifests, mcp configs, .npmrc — cli's discoverDirTarget), so a
+// finding of any other kind must keep its explicit path in a shortened
+// archived-group command, or the short command silently drops it.
+func dirDiscoverable(f Finding) bool {
+	switch f.FindingType {
+	case FindingTypeEnvFilePresent, FindingTypeIACVariableFile, FindingTypeMCPEmbeddedSecret:
+		return true
+	}
+	return filepath.Base(f.FilePath) == ".npmrc"
+}
+
+// commonDir returns the deepest directory containing every path, or "" when
+// the walk reaches the filesystem root first. Callers gate what the result
+// may be used for; this only computes the ancestor.
+func commonDir(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	common := filepath.Dir(paths[0])
+	for _, p := range paths[1:] {
+		for !strings.HasPrefix(filepath.Dir(p)+"/", common+"/") {
+			parent := filepath.Dir(common)
+			if parent == common {
+				return ""
+			}
+			common = parent
+		}
+	}
+	return common
+}

--- a/internal/audit/archived.go
+++ b/internal/audit/archived.go
@@ -32,6 +32,26 @@ func LooksArchived(path string) bool {
 	return false
 }
 
+// trashDirNames are the archivedDirNames components that mean "already
+// deleted once" rather than "kept on purpose". The distinction earns its own
+// remedy in the report: migrating a file out of the Trash would preserve
+// what deletion is about to fix, so the reader is told to finish the
+// deletion instead of being offered jit migrate.
+var trashDirNames = map[string]bool{".trash": true, "trash": true}
+
+// inTrash reports whether any path component of path matches trashDirNames,
+// case-insensitively. Every inTrash path also satisfies LooksArchived, so
+// callers ordering remedies must test trash FIRST or the archived branch
+// swallows it.
+func inTrash(path string) bool {
+	for _, part := range strings.Split(filepath.ToSlash(path), "/") {
+		if trashDirNames[strings.ToLower(part)] {
+			return true
+		}
+	}
+	return false
+}
+
 // dirDiscoverable reports whether naming a DIRECTORY above f's file would
 // rediscover it: `jit migrate <dir>` walks project files only (.env, tfvars,
 // k8s secret manifests, mcp configs, .npmrc — cli's discoverDirTarget), so a

--- a/internal/audit/content.go
+++ b/internal/audit/content.go
@@ -133,23 +133,29 @@ func scanFileContentForTokens(cfg Config, path string) ([]Finding, error) {
 		return nil, err
 	}
 
+	exampleLines := sourceExampleLines(path, tokens)
+
 	var findings []Finding
-	seenVendor := map[string]bool{} // one finding per (file, vendor): see below
+	byVendor := map[string]int{} // index into findings; one per (file, vendor): see below
 	for _, tk := range tokens {
 		// One finding per (file, vendor). record_id is
 		// finding_type+file_path+key_name and key_name is the vendor, so a
 		// second occurrence of the same vendor in the same file would collide
 		// on record_id anyway; collapsing here keeps the report from listing
 		// structurally identical duplicates. The first occurrence's line
-		// number is the one reported.
-		if seenVendor[tk.Vendor] {
-			continue
+		// number is the one reported — EXCEPT when that line was a source
+		// comment and a later one is not: the collapse must not let a
+		// documentation example shadow a real credential further down the
+		// same file, uncounting both.
+		if i, ok := byVendor[tk.Vendor]; ok {
+			if !findings[i].SourceExample || exampleLines[tk.Line] {
+				continue
+			}
 		}
-		seenVendor[tk.Vendor] = true
 
 		ln := tk.Line
 		vendor := tk.Vendor
-		findings = append(findings, cfg.ValueFinding(ValueFindingParams{
+		f := cfg.ValueFinding(ValueFindingParams{
 			FindingType:  FindingTypeExposedSecret,
 			FilePath:     path,
 			Line:         &ln,
@@ -158,9 +164,74 @@ func scanFileContentForTokens(cfg Config, path string) ([]Finding, error) {
 			BaseSeverity: SeverityHigh,
 			Confidence:   ConfidenceHigh,
 			Evidence:     "value matches a known vendor credential format",
-		}))
+		})
+		f.SourceExample = exampleLines[ln]
+		if i, ok := byVendor[tk.Vendor]; ok {
+			findings[i] = f
+		} else {
+			byVendor[tk.Vendor] = len(findings)
+			findings = append(findings, f)
+		}
 	}
 	return findings, nil
+}
+
+// sourceCodeExts are the extensions sourceExampleLines will judge comment
+// context in. Shell scripts are deliberately absent: a commented-out
+// `# export TOKEN=...` in someone's setup script is exactly the shape a REAL
+// leaked credential takes, while a comment in compiled-language source is
+// overwhelmingly a documentation example.
+var sourceCodeExts = map[string]bool{
+	".go": true, ".rs": true, ".py": true, ".rb": true, ".js": true,
+	".jsx": true, ".ts": true, ".tsx": true, ".java": true, ".kt": true,
+	".swift": true, ".c": true, ".h": true, ".cc": true, ".cpp": true,
+	".hpp": true, ".cs": true, ".php": true, ".scala": true, ".lua": true,
+	".sql": true, ".m": true, ".mm": true,
+}
+
+// sourceCommentLeads are the line-leading markers that make a source line a
+// comment. Line-leading ONLY, on purpose: searching for "//" anywhere before
+// the match would classify every `postgres://user:pass@host` string literal
+// as a comment — the scheme separator IS the marker. A trailing comment
+// holding a credential therefore stays counted, which errs the right way.
+var sourceCommentLeads = []string{"//", "/*", "*", "#", "--"}
+
+// sourceExampleLines returns the token-holding lines of a source-code file
+// whose match sits in a comment (see Finding.SourceExample), nil for
+// non-source files. One extra pass over a file the sweep has already read
+// once; bounded by the same line scanner.
+func sourceExampleLines(path string, tokens []FileToken) map[int]bool {
+	if len(tokens) == 0 || !sourceCodeExts[strings.ToLower(filepath.Ext(path))] {
+		return nil
+	}
+	want := map[int]bool{}
+	for _, tk := range tokens {
+		want[tk.Line] = true
+	}
+
+	file, err := openFile(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	example := map[int]bool{}
+	scanner := newLineScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if !want[lineNum] {
+			continue
+		}
+		trimmed := strings.TrimSpace(scanner.Text())
+		for _, lead := range sourceCommentLeads {
+			if strings.HasPrefix(trimmed, lead) {
+				example[lineNum] = true
+				break
+			}
+		}
+	}
+	return example
 }
 
 // isPureTokenFile reports whether path's entire meaningful content is bare

--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -302,7 +302,18 @@ type Finding struct {
 	// and a contract with every consumer; this exists to let the human-facing
 	// report print a range it already knows. Give it a json tag and a version
 	// when a consumer actually asks for it, not before.
-	EndLine                  *int    `json:"-"`
+	EndLine *int `json:"-"`
+	// KeyKind says WHAT kind of key a private-key finding covers, when the
+	// sniffer can tell — today only the GCP service-account JSON shape. The
+	// advice attached to the finding depends on it: "add a passphrase" is
+	// impossible to follow for a service-account key, which can only be
+	// revoked where it was issued. Empty means "an SSH-shaped key", the
+	// default the advice was written for.
+	//
+	// Deliberately NOT serialized, on EndLine's contract: key_name already
+	// carries the human name of the kind for NDJSON consumers, so this
+	// stays a rendering input until a consumer asks for more.
+	KeyKind                  string  `json:"-"`
 	ValuePreview             *string `json:"value_preview"`
 	ProductionIndicatorMatch bool    `json:"production_indicator_match"`
 	PublicIPMatch            *string `json:"public_ip_match"`

--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -340,6 +340,22 @@ type Finding struct {
 	// Set centrally by Scan, not by the individual scanners.
 	TestFixture bool `json:"test_fixture"`
 
+	// SourceExample is true when the matched value sits on a comment line of
+	// a source-code file: a documentation example, not a stored credential.
+	// The canonical case is jit's own tokenpatterns.go, whose doc comments
+	// argue about credential shapes BY EXAMPLE and which a real scan
+	// (2026-08-07) reported as an exposed database password — a scanner that
+	// flags its own source teaches users to disbelieve the report. Like a
+	// fixture, the finding stays visible in --full and NDJSON but is not
+	// charged to the coverage ledger. The accepted miss: a commented-out
+	// REAL credential in source is indistinguishable from an example and
+	// lands here too, which is why the footer names the bucket instead of
+	// silently dropping it.
+	//
+	// Set by the content sweep at construction (it alone has the line text),
+	// not by tagArchivedAndFixtures. Not serialized, on EndLine's contract.
+	SourceExample bool `json:"-"`
+
 	// Remedy says who can act on this finding: "migrate" and "wrap" mean jit
 	// can (FixCommand holds the exact command), "manual" means only the user
 	// can (rotate, delete, seal — the Evidence says which). Set centrally by

--- a/internal/audit/privatekey.go
+++ b/internal/audit/privatekey.go
@@ -5,6 +5,7 @@ package audit
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -14,6 +15,10 @@ import (
 
 	"golang.org/x/crypto/ssh"
 )
+
+// keyKindGCPServiceAccount marks a Finding whose file is a Google Cloud
+// service-account key, for Finding.KeyKind.
+const keyKindGCPServiceAccount = "gcp_service_account"
 
 // privateKeyPEMHeaders identify a private key by content, not filename —
 // real-world review (2026-07-06) showed public CA certificate bundles
@@ -204,17 +209,24 @@ func inspectPrivateKeyFile(cfg Config, path string, inSSHDir bool) (*Finding, er
 		issues = append(issues, fmt.Sprintf("loose file permissions (mode %o, should be 0600 or stricter)", info.Mode().Perm()))
 	}
 
-	_, parseErr := ssh.ParseRawPrivateKey(content)
-	var passphraseErr *ssh.PassphraseMissingError
-	switch {
-	case parseErr == nil:
-		// Parsed successfully with no passphrase supplied at all — unencrypted.
-		issues = append(issues, "no passphrase set")
-	case errors.As(parseErr, &passphraseErr):
-		// Encrypted — this is the good case, not an issue.
-	default:
-		// Unparseable for some other reason (corrupt, unsupported format) —
-		// don't claim anything about passphrase status either way.
+	isGCPSA := isGCPServiceAccountKey(content)
+	if !isGCPSA {
+		// The passphrase probe is an SSH question, and asking it of a
+		// service-account key can only mislead: the JSON envelope never
+		// parses, and the key has no passphrase to add anyway — its only
+		// protection is revocation at the provider.
+		_, parseErr := ssh.ParseRawPrivateKey(content)
+		var passphraseErr *ssh.PassphraseMissingError
+		switch {
+		case parseErr == nil:
+			// Parsed successfully with no passphrase supplied at all — unencrypted.
+			issues = append(issues, "no passphrase set")
+		case errors.As(parseErr, &passphraseErr):
+			// Encrypted — this is the good case, not an issue.
+		default:
+			// Unparseable for some other reason (corrupt, unsupported format) —
+			// don't claim anything about passphrase status either way.
+		}
 	}
 
 	if len(issues) == 0 {
@@ -227,6 +239,30 @@ func inspectPrivateKeyFile(cfg Config, path string, inSSHDir bool) (*Finding, er
 	f.Severity = SeverityHigh // RFC.md §4 risk table: all three trigger conditions here map to High
 	f.Confidence = ConfidenceHigh
 	f.Evidence = strings.Join(issues, "; ")
+	if isGCPSA {
+		f.KeyKind = keyKindGCPServiceAccount
+		name := "Google Cloud service-account key"
+		f.KeyName = &name
+	}
 	f.RecordID = RecordID(f.FindingType, f.FilePath, nil)
 	return &f, nil
+}
+
+// isGCPServiceAccountKey reports whether content is a Google Cloud
+// service-account key file: the JSON envelope `gcloud iam service-accounts
+// keys create` writes, with the PEM key embedded under "private_key". The
+// shape is already FOUND by looksLikePrivateKey's escaped-newline path; this
+// tells the report which key it found, because the advice differs — a
+// passphrase cannot be added to one of these, and deleting the file does not
+// revoke it (a real scan, 2026-08-07, told the user "add a passphrase
+// (ssh-keygen -p)" for two of them in ~/Downloads).
+func isGCPServiceAccountKey(content []byte) bool {
+	var sa struct {
+		Type       string `json:"type"`
+		PrivateKey string `json:"private_key"`
+	}
+	if json.Unmarshal(content, &sa) != nil {
+		return false
+	}
+	return sa.Type == "service_account" && strings.Contains(sa.PrivateKey, "PRIVATE KEY")
 }

--- a/internal/audit/privatekey_test.go
+++ b/internal/audit/privatekey_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/pem"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"golang.org/x/crypto/ssh"
@@ -221,6 +222,66 @@ func TestLooksLikePrivateKeyNeedsABody(t *testing.T) {
 				t.Errorf("looksLikePrivateKey() = %v, want %v", got, c.want)
 			}
 		})
+	}
+}
+
+// A GCP service-account key is found like any stray key, but must be NAMED as
+// what it is — the SSH advice attached to the plain kind ("add a passphrase")
+// is impossible to follow for one, and the report needs KeyKind to say so.
+// The evidence must also stay silent about passphrases: the scanner never
+// established anything about one, and a real scan (2026-08-07) showed the
+// claim being invented downstream.
+func TestScanPrivateKeysGCPServiceAccountKey(t *testing.T) {
+	home := t.TempDir()
+	downloads := filepath.Join(home, "Downloads")
+	mkdirAll(t, downloads)
+
+	content := []byte(`{"type":"service_account","project_id":"security-504007",` +
+		`"private_key":"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ\n-----END PRIVATE KEY-----\n",` +
+		`"client_email":"svc@security-504007.iam.gserviceaccount.com"}`)
+	if err := os.WriteFile(filepath.Join(downloads, "security-504007-7b1189f6fcd9.json"), content, 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	findings, err := ScanPrivateKeys(Config{HomeDir: home})
+	if err != nil {
+		t.Fatalf("ScanPrivateKeys: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+	}
+	f := findings[0]
+	if f.KeyKind != keyKindGCPServiceAccount {
+		t.Errorf("KeyKind = %q, want %q", f.KeyKind, keyKindGCPServiceAccount)
+	}
+	if f.KeyName == nil || *f.KeyName != "Google Cloud service-account key" {
+		t.Errorf("KeyName = %v, want the kind's human name", f.KeyName)
+	}
+	if strings.Contains(f.Evidence, "passphrase") {
+		t.Errorf("evidence claims passphrase status for a service-account key: %q", f.Evidence)
+	}
+}
+
+// The plain SSH kind keeps an empty KeyKind — it is the default every
+// existing advice string was written for.
+func TestScanPrivateKeysSSHKeyHasNoKeyKind(t *testing.T) {
+	home := t.TempDir()
+	downloads := filepath.Join(home, "Downloads")
+	mkdirAll(t, downloads)
+
+	if err := os.WriteFile(filepath.Join(downloads, "stray_key"), generateUnencryptedKeyPEM(t), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	findings, err := ScanPrivateKeys(Config{HomeDir: home})
+	if err != nil {
+		t.Fatalf("ScanPrivateKeys: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+	}
+	if f := findings[0]; f.KeyKind != "" || f.KeyName != nil {
+		t.Errorf("KeyKind = %q, KeyName = %v; want empty for an SSH-shaped key", f.KeyKind, f.KeyName)
 	}
 }
 

--- a/internal/audit/remedy.go
+++ b/internal/audit/remedy.go
@@ -263,8 +263,11 @@ func annotateCauseGroups(findings []Finding) {
 //
 // Test fixtures are excluded for the neighbouring reason: the match is real,
 // but the credential is not the user's to rotate (see LooksTestFixture).
+// Source examples are the third face of the same rule: a credential-shaped
+// value in a comment documents a shape, it does not store a secret
+// (Finding.SourceExample).
 func CountedAsSecret(f Finding) bool {
-	if f.TestFixture {
+	if f.TestFixture || f.SourceExample {
 		return false
 	}
 	switch f.Severity {

--- a/internal/audit/target_test.go
+++ b/internal/audit/target_test.go
@@ -235,6 +235,88 @@ func TestScanFileContentForTokensSpecificWins(t *testing.T) {
 	}
 }
 
+// A vendor match on a COMMENT line of source code documents a shape rather
+// than storing a secret: found and shown, but tagged SourceExample and not
+// charged to the ledger. The same value in real code stays counted, and a
+// comment example must never shadow a real credential further down the file
+// through the per-vendor collapse.
+func TestScanFileContentForTokensSourceExample(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("comment-only match is a source example", func(t *testing.T) {
+		p := filepath.Join(dir, "tokendoc.go")
+		writeFile(t, p, "package x\n\n// e.g. psql postgres://app:Re4lLook1ngPw@db/app\n")
+		findings, err := scanFileContentForTokens(Config{HomeDir: dir}, p)
+		if err != nil {
+			t.Fatalf("scanFileContentForTokens: %v", err)
+		}
+		if len(findings) != 1 {
+			t.Fatalf("got %d findings, want 1: %+v", len(findings), findings)
+		}
+		if !findings[0].SourceExample {
+			t.Error("comment-line match not tagged SourceExample")
+		}
+		if CountedAsSecret(findings[0]) {
+			t.Error("source example charged to the ledger")
+		}
+	})
+
+	t.Run("a real credential outranks the example above it", func(t *testing.T) {
+		p := filepath.Join(dir, "tokencode.go")
+		writeFile(t, p, "package x\n\n// e.g. psql postgres://app:Re4lLook1ngPw@db/app\nvar dsn = \"postgres://app:An0therRe4lPw@db/app\"\n")
+		findings, err := scanFileContentForTokens(Config{HomeDir: dir}, p)
+		if err != nil {
+			t.Fatalf("scanFileContentForTokens: %v", err)
+		}
+		if len(findings) != 1 {
+			t.Fatalf("got %d findings, want 1 (per-vendor collapse): %+v", len(findings), findings)
+		}
+		if findings[0].SourceExample {
+			t.Error("the non-comment occurrence must win the per-vendor collapse")
+		}
+		if findings[0].Line == nil || *findings[0].Line != 4 {
+			t.Errorf("Line = %v, want 4 (the code line, not the comment)", findings[0].Line)
+		}
+	})
+
+	t.Run("comment context is ignored outside source files", func(t *testing.T) {
+		p := filepath.Join(dir, "creds.txt")
+		writeFile(t, p, "# postgres://app:Re4lLook1ngPw@db/app\n")
+		findings, err := scanFileContentForTokens(Config{HomeDir: dir}, p)
+		if err != nil {
+			t.Fatalf("scanFileContentForTokens: %v", err)
+		}
+		if len(findings) != 1 || findings[0].SourceExample {
+			t.Errorf("a .txt line is not source; got %+v", findings)
+		}
+	})
+}
+
+// And the file itself, mirroring TestJitsOwnPatternListIsNotAPrivateKey: the
+// pattern list argues about credential shapes by example in its doc comments,
+// and a real scan (2026-08-07) charged the user an exposed database password
+// for it. Every match in it must stay uncharged, whatever examples a rewrite
+// adds.
+func TestJitsOwnPatternListIsNotCharged(t *testing.T) {
+	findings, err := scanFileContentForTokens(Config{HomeDir: "/"}, "tokenpatterns.go")
+	if err != nil {
+		t.Fatalf("scanFileContentForTokens: %v", err)
+	}
+	for _, f := range findings {
+		if CountedAsSecret(f) {
+			line, vendor := 0, "?"
+			if f.Line != nil {
+				line = *f.Line
+			}
+			if f.KeyName != nil {
+				vendor = *f.KeyName
+			}
+			t.Errorf("tokenpatterns.go:%d (%s) counts toward the ledger; "+
+				"a scanner that charges the user for its own source teaches them to disbelieve the report", line, vendor)
+		}
+	}
+}
+
 // TestScanFileContentForTokensClean: an ordinary text file yields nothing.
 func TestScanFileContentForTokensClean(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -6,6 +6,7 @@ package audit
 import (
 	"fmt"
 	"io"
+	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
@@ -606,6 +607,10 @@ type triageManualGroup struct {
 	// in N and in which files, and printing three near-identical headers with
 	// three identical actions spent nine lines saying one thing three times.
 	noun string
+	// hintSamples is one constituent sample per entry in hints, same index,
+	// kept by the merge so collapsePatternHints can regenerate a combined
+	// hint instead of parsing the strings it would be folding.
+	hintSamples []Finding
 }
 
 // triageActionGroup is one block of the red section: every problem that ends
@@ -878,6 +883,7 @@ func mergeManualGroups(groups []triageManualGroup, home string) []triageManualGr
 		i, ok := at[k]
 		if !ok {
 			at[k] = len(out)
+			g.hintSamples = []Finding{g.sample}
 			out = append(out, g)
 			continue
 		}
@@ -886,6 +892,7 @@ func mergeManualGroups(groups []triageManualGroup, home string) []triageManualGr
 		m.files += g.files
 		m.details = append(m.details, g.details...)
 		m.hints = append(m.hints, g.hints...)
+		m.hintSamples = append(m.hintSamples, g.sample)
 		m.critical = m.critical || g.critical
 		if g.sortKey < m.sortKey {
 			m.sortKey = g.sortKey
@@ -923,7 +930,79 @@ func mergeManualGroups(groups []triageManualGroup, home string) []triageManualGr
 			out[i].kind, out[i].action = manualAction(out[i].sample, out[i].ctx, home)
 		}
 	}
+	for i := range out {
+		collapsePatternHints(&out[i], home)
+	}
 	return out
+}
+
+// collapsePatternHints replaces a merged group's per-file view hints with ONE
+// hint covering every file, when they are the same command differing only in
+// path. A real scan (2026-08-07) printed the identical JWT grep nine times
+// under one group, once per paste-cache file — nine lines reading as one
+// instruction stuttered. The keep-every-hint rule mergeManualGroups documents
+// is about hints that DIFFER (each names an address the reader must reach);
+// hints identical up to path carry one instruction, and a single grep over
+// all the files runs it in one paste.
+//
+// Regenerated from the constituents' samples, never parsed out of the hint
+// strings — and only for the full-pattern grep form: line-addressed history
+// hints and agent-copy breakdowns each name coordinates that a shared
+// command cannot stand for.
+func collapsePatternHints(m *triageManualGroup, home string) {
+	if len(m.hints) < 2 || len(m.hintSamples) != len(m.hints) {
+		return
+	}
+	ere := patternEREFor(m.hintSamples[0])
+	if ere == "" {
+		return
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, s := range m.hintSamples {
+		if s.FilePath == "" || patternEREFor(s) != ere ||
+			s.FindingType == FindingTypeShellHistorySecret ||
+			s.FindingType == FindingTypeAgentCachedSecret {
+			return
+		}
+		if !seen[s.FilePath] {
+			seen[s.FilePath] = true
+			paths = append(paths, s.FilePath)
+		}
+	}
+	if len(paths) < 2 {
+		return
+	}
+	// -f1,2 rather than the single-file form's -f1: multi-file grep prefixes
+	// each hit with its path, so fields one and two are path:line — the
+	// content field stays cut off, which is the property the whole hint
+	// exists to keep.
+	m.hints = []string{fmt.Sprintf("lines: grep -nE '%s' %s | cut -d: -f1,2",
+		ere, combinedPathExpr(paths, home))}
+}
+
+// combinedPathExpr renders several paths as one shell word when a glob can
+// honestly stand for them — same directory, same extension, nothing needing
+// quotes — and falls back to listing each path. The glob may match files
+// beyond the group's; grep finding nothing extra in them is harmless, and
+// "~/.claude/paste-cache/*.txt" reads where nine hash-named paths do not.
+func combinedPathExpr(paths []string, home string) string {
+	dir, ext := filepath.Dir(paths[0]), filepath.Ext(paths[0])
+	glob := ext != ""
+	for _, p := range paths[1:] {
+		if filepath.Dir(p) != dir || filepath.Ext(p) != ext {
+			glob = false
+			break
+		}
+	}
+	if glob && shellBarePath(dir) {
+		return ShortenHome(home, dir) + "/*" + ext
+	}
+	quoted := make([]string, len(paths))
+	for i, p := range paths {
+		quoted[i] = shellSafePath(home, p)
+	}
+	return strings.Join(quoted, " ")
 }
 
 // writeHistoryGuardOffer adds the prevention line when this scan found a

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -1005,6 +1005,11 @@ func manualTitle(causes []*triageCause, files []string, worst Finding, home stri
 // manualNoun is the one-line "what is this" for a single manual secret.
 func manualNoun(f Finding) string {
 	switch {
+	case f.FindingType == FindingTypePrivateKeyRisk && f.KeyKind == keyKindGCPServiceAccount:
+		// Named for what it is, not the bucket it was found by: "at-risk
+		// private key" plus passphrase advice sent a real user toward
+		// ssh-keygen -p for a key that cannot take a passphrase (2026-08-07).
+		return "An exposed Google Cloud service-account key"
 	case f.FindingType == FindingTypePrivateKeyRisk:
 		return "An at-risk private key"
 	case selfRotating(f):
@@ -1452,6 +1457,7 @@ type manualContext struct {
 // under the group, printed once for all of it.
 const (
 	kindTrash          = "empty the trash"
+	kindIAMKey         = "rotate in IAM, then delete the file"
 	kindArchived       = "name the file — the sweep skips archived folders"
 	kindPassphrase     = "add a passphrase"
 	kindSelfRotating   = "sign out and back in"
@@ -1484,6 +1490,14 @@ func manualAction(f Finding, ctx manualContext, home string) (kind, action strin
 		// directories, so whatever else is true of the secret, the instruction
 		// has to name the file explicitly or it will not run.
 		return kindArchived, fmt.Sprintf("jit migrate %s", shellSafePath(home, f.FilePath))
+	case f.FindingType == FindingTypePrivateKeyRisk && f.KeyKind == keyKindGCPServiceAccount:
+		// Not the passphrase advice below: a service-account key has no
+		// passphrase to add, and the only revocation lives at the provider.
+		files := "this file"
+		if ctx.secrets > 1 {
+			files = "these files"
+		}
+		return kindIAMKey, "rotate the key in IAM, then delete " + files
 	case f.FindingType == FindingTypePrivateKeyRisk:
 		return kindPassphrase, "add a passphrase (ssh-keygen -p) or move the key somewhere safer"
 	case selfRotating(f):
@@ -1565,6 +1579,8 @@ func actionNote(kind string) string {
 			archivedDeletionNote
 	case kindTrash:
 		return "this file is already on its way out — migrating it would preserve what deletion is about to fix"
+	case kindIAMKey:
+		return "deleting the file does not revoke the key — only deleting the key in IAM does"
 	}
 	return ""
 }

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -268,13 +268,21 @@ func WriteTriageReport(w io.Writer, findings []Finding, summary ScanSummary, hom
 			// now") read as a warning state — amber's job, and it already has
 			// the "!" glyph above to do it with.
 			_, _ = cmd.Fprint(w, style.GlyphAction+" ")
-			// One line, truncated, never wrapped. A many-path `jit migrate`
-			// command used to wrap to five lines, and a wrapped command is the
-			// worst of both: too long to read as a line, and no longer
-			// copy-pasteable as one either. Head-kept truncation shows the
-			// command and its first targets; the full file list is the report
-			// above, which is where the reader just came from.
-			fmt.Fprintln(w, termtext.TruncTail(ag.action, max(20, termtext.Width()-len(triageNoteIndent)-2)))
+			// One line either way, but which kind of line decides the cut. A
+			// sentence action ("rotate them now, …") truncates, never wraps:
+			// it restates the group header, so its tail is expendable. A
+			// COMMAND is the opposite — cut anywhere it stops being a
+			// command, and a real scan (2026-08-07) shipped an archived-group
+			// `jit migrate …` whose ellipsis ate half its targets. The
+			// archived action is the one command on these arrows, so it
+			// prints whole as ONE logical line; the parent-directory form
+			// keeps it short, and the explicit-path fallback soft-wraps in
+			// the terminal while still pasting as a single command.
+			if ag.kind == kindArchived {
+				fmt.Fprintln(w, ag.action)
+			} else {
+				fmt.Fprintln(w, termtext.TruncTail(ag.action, max(20, termtext.Width()-len(triageNoteIndent)-2)))
+			}
 		}
 		fmt.Fprintln(w)
 	}
@@ -665,23 +673,36 @@ func groupManualByAction(groups []triageManualGroup, home string) []triageAction
 		// would print one path for a block listing several, and a reader who
 		// ran it would fix that file and silently leave the rest — having been
 		// shown them and given a command that appeared to cover them.
-		// runMigratePath takes several targets, so name them all; the line
-		// wraps, which is what a command is allowed to do.
+		//
+		// Naming every file is honest but unreadable: a real scan (2026-08-07)
+		// printed six ~70-char paths on the arrow line. When one directory
+		// covers the whole group AND naming it would rediscover every file
+		// (`jit migrate <dir>` walks project files only), the command is that
+		// directory — the shortest line that keeps the promise. The directory
+		// must itself look archived, so the shortening can never widen the
+		// command past the boundary the reader consented to: ~/Documents is
+		// not a thing this line may name because two archives sit under it.
+		// Anything else falls back to the full path list, printed whole.
 		if b.kind == kindArchived {
 			seen := map[string]bool{}
-			var paths []string
+			var raw, paths []string
+			discoverable := true
 			for _, it := range b.items {
 				if it.sample.FilePath == "" {
 					continue
 				}
-				p := shellSafePath(home, it.sample.FilePath)
-				if seen[p] {
+				discoverable = discoverable && dirDiscoverable(it.sample)
+				if seen[it.sample.FilePath] {
 					continue
 				}
-				seen[p] = true
-				paths = append(paths, p)
+				seen[it.sample.FilePath] = true
+				raw = append(raw, it.sample.FilePath)
+				paths = append(paths, shellSafePath(home, it.sample.FilePath))
 			}
-			if len(paths) > 0 {
+			switch dir := commonDir(raw); {
+			case discoverable && len(raw) > 1 && dir != "" && LooksArchived(dir):
+				b.action = "jit migrate " + shellSafePath(home, dir)
+			case len(paths) > 0:
 				b.action = "jit migrate " + strings.Join(paths, " ")
 			}
 		}

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -258,8 +258,14 @@ func WriteTriageReport(w io.Writer, findings []Finding, summary ScanSummary, hom
 				writeManualItem(w, g, bold, red, yellowBold)
 			}
 			if ag.note != "" {
-				fmt.Fprint(w, triageNoteIndent)
-				termtext.Wrap(w, len(triageNoteIndent), triageNoteIndent, ag.note)
+				// A note may carry several facts, one per \n-separated line,
+				// each wrapped on its own — flowing them into one paragraph
+				// would glue "…still vaults it" to "already protected…" mid-
+				// line, and the one-fact-per-line rule is the house style's.
+				for _, fact := range strings.Split(ag.note, "\n") {
+					fmt.Fprint(w, triageNoteIndent)
+					termtext.Wrap(w, len(triageNoteIndent), triageNoteIndent, fact)
+				}
 			}
 			fmt.Fprint(w, triageNoteIndent)
 			// The arrow is cyan because it is the action motif; the
@@ -702,6 +708,12 @@ func groupManualByAction(groups []triageManualGroup, home string) []triageAction
 			switch dir := commonDir(raw); {
 			case discoverable && len(raw) > 1 && dir != "" && LooksArchived(dir):
 				b.action = "jit migrate " + shellSafePath(home, dir)
+				// The note's first line must describe the command actually
+				// printed: "naming a file" under a folder command reads as a
+				// mismatch, and the folder form has its own fact to state —
+				// the walk inside an explicit target skips nothing.
+				b.note = "bare jit migrate walks past archive/ and backups/ on purpose — these are counted above, and naming this folder explicitly migrates everything findable inside it\n" +
+					archivedDeletionNote
 			case len(paths) > 0:
 				b.action = "jit migrate " + strings.Join(paths, " ")
 			}
@@ -1439,6 +1451,7 @@ type manualContext struct {
 // are read as a list — the sentence that explains the fix is the arrow line
 // under the group, printed once for all of it.
 const (
+	kindTrash          = "empty the trash"
 	kindArchived       = "name the file — the sweep skips archived folders"
 	kindPassphrase     = "add a passphrase"
 	kindSelfRotating   = "sign out and back in"
@@ -1458,8 +1471,15 @@ func manualAction(f Finding, ctx manualContext, home string) (kind, action strin
 		them = "them"
 	}
 	switch {
+	case inTrash(f.FilePath):
+		// Above archived, which would otherwise swallow it (every trash path
+		// looks archived). Trash is the one archived-looking place where even
+		// migrate-by-name is the wrong offer: the user already decided this
+		// file should not exist, and vaulting it would preserve what deletion
+		// is about to fix. Finishing the deletion IS the remedy.
+		return kindTrash, "empty the Trash, then rotate anything it held"
 	case f.Archived:
-		// First, because archived is a property of WHERE the file is and it
+		// Next, because archived is a property of WHERE the file is and it
 		// overrides every remedy below: bare `jit migrate` walks past these
 		// directories, so whatever else is true of the secret, the instruction
 		// has to name the file explicitly or it will not run.
@@ -1536,10 +1556,23 @@ func actionNote(kind string) string {
 	case kindProtectInPlace:
 		return "or move the secret out of the file, then rotate it"
 	case kindArchived:
-		return "bare jit migrate walks past archive/, backups/ and .trash/ on purpose — these are counted above, and naming a file explicitly still vaults it"
+		// Two facts on two lines (the renderer splits on \n): what the sweep
+		// does and why the group exists, then the remedy migrate cannot offer
+		// — for a copy whose live sibling is already protected, deletion
+		// beats vaulting a stale secret, and only the note can say so
+		// because scan never deletes anything.
+		return "bare jit migrate walks past archive/ and backups/ on purpose — these are counted above, and naming a file explicitly still vaults it\n" +
+			archivedDeletionNote
+	case kindTrash:
+		return "this file is already on its way out — migrating it would preserve what deletion is about to fix"
 	}
 	return ""
 }
+
+// archivedDeletionNote is the second line of the archived group's note, kept
+// identical between the file-list and folder forms of the group so the two
+// cannot drift apart in wording.
+const archivedDeletionNote = "already protected the live copy? deleting the archived one is the cleaner fix"
 
 func formatDuration(ms int64) string {
 	if ms >= 1000 {

--- a/internal/audit/triage.go
+++ b/internal/audit/triage.go
@@ -388,6 +388,7 @@ func writeTriageFooter(w io.Writer, findings []Finding, summary ScanSummary, hom
 	// a line here claiming otherwise would contradict it.
 	quiet := 0
 	fixtures := 0
+	examples := 0
 	for _, f := range findings {
 		switch {
 		case f.TestFixture:
@@ -396,6 +397,10 @@ func writeTriageFooter(w io.Writer, findings []Finding, summary ScanSummary, hom
 			// credentials to rotate. Lumping them under "low-confidence"
 			// would misdescribe both groups.
 			fixtures++
+		case f.SourceExample:
+			// Separate for the same reason: jit matched the value and is
+			// saying it documents a shape rather than storing a secret.
+			examples++
 		case !CountedAsSecret(f):
 			quiet++
 		}
@@ -408,6 +413,9 @@ func writeTriageFooter(w io.Writer, findings []Finding, summary ScanSummary, hom
 	var notCounted []string
 	if fixtures > 0 {
 		notCounted = append(notCounted, countWord(fixtures, "test fixture", "test fixtures"))
+	}
+	if examples > 0 {
+		notCounted = append(notCounted, countWord(examples, "source example", "source examples"))
 	}
 	if quiet > 0 {
 		notCounted = append(notCounted, countWord(quiet, "low-confidence sighting", "low-confidence sightings"))

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -195,41 +195,90 @@ func TestManualGroupsAccountForEveryManualSecret(t *testing.T) {
 }
 
 // One arrow per group is only honest if that arrow covers the whole group.
-// The archived block's action names paths, so a block listing two archived
-// files must name both — regenerating from the worst item alone printed one
-// path under two items, and running it would have fixed one and left the
-// other, having just shown the reader both.
-func TestArchivedActionNamesEveryFileInItsGroup(t *testing.T) {
-	mk := func(id, path string) Finding {
+// Regenerating the archived command from the worst item alone printed one
+// path under two items; naming every path was honest but grew unreadable
+// (six ~70-char paths on one line, 2026-08-07). The command is now the
+// deepest archived directory when naming it rediscovers every file, and the
+// full path list — never truncated — when it would not.
+func TestArchivedActionCoversItsWholeGroup(t *testing.T) {
+	mk := func(id, ftype, path string) Finding {
 		return Finding{
-			RecordID: id, FindingType: FindingTypeEnvFilePresent,
+			RecordID: id, FindingType: ftype,
 			Severity: SeverityHigh, Remedy: RemedyMigrate, Archived: true,
 			FilePath: path, Evidence: "secret-shaped",
 		}
 	}
-	findings := []Finding{
-		mk("a", "/Users/alex/Documents/archive/one/.env"),
-		mk("b", "/Users/alex/Documents/archive/two/.env"),
-	}
-	annotateCauseGroups(findings)
-	groups := groupManualByAction(triageGroupManual(findings, "/Users/alex"), "/Users/alex")
-
-	var archived *triageActionGroup
-	for i := range groups {
-		if groups[i].kind == kindArchived {
-			archived = &groups[i]
+	archivedAction := func(t *testing.T, findings []Finding) string {
+		t.Helper()
+		annotateCauseGroups(findings)
+		groups := groupManualByAction(triageGroupManual(findings, "/Users/alex"), "/Users/alex")
+		for i := range groups {
+			if groups[i].kind == kindArchived {
+				return groups[i].action
+			}
 		}
-	}
-	if archived == nil {
 		t.Fatalf("no archived group: %+v", groups)
+		return ""
 	}
-	if len(archived.items) != 2 {
-		t.Fatalf("archived group has %d items, want 2", len(archived.items))
-	}
-	for _, want := range []string{"archive/one/.env", "archive/two/.env"} {
-		if !strings.Contains(archived.action, want) {
-			t.Errorf("action %q does not name %q", archived.action, want)
+
+	t.Run("one archived parent covers the group", func(t *testing.T) {
+		action := archivedAction(t, []Finding{
+			mk("a", FindingTypeEnvFilePresent, "/Users/alex/Documents/archive/one/.env"),
+			mk("b", FindingTypeEnvFilePresent, "/Users/alex/Documents/archive/two/.env"),
+		})
+		if want := "jit migrate ~/Documents/archive"; action != want {
+			t.Errorf("action = %q, want %q", action, want)
 		}
+	})
+
+	t.Run("two archives fall back to full paths", func(t *testing.T) {
+		// The common ancestor is ~/Documents, which is NOT archived —
+		// naming it would sweep live projects the reader never consented to.
+		action := archivedAction(t, []Finding{
+			mk("a", FindingTypeEnvFilePresent, "/Users/alex/Documents/archive/one/.env"),
+			mk("b", FindingTypeEnvFilePresent, "/Users/alex/Documents/backups/two/.env"),
+		})
+		for _, want := range []string{"archive/one/.env", "backups/two/.env"} {
+			if !strings.Contains(action, want) {
+				t.Errorf("action %q does not name %q", action, want)
+			}
+		}
+	})
+
+	t.Run("a non-dir-discoverable file falls back to full paths", func(t *testing.T) {
+		// A loose token file is reached only by its explicit path — the dir
+		// walk finds project files, so the shortened command would silently
+		// drop it.
+		action := archivedAction(t, []Finding{
+			mk("a", FindingTypeEnvFilePresent, "/Users/alex/Documents/archive/one/.env"),
+			mk("b", FindingTypeExposedSecret, "/Users/alex/Documents/archive/two/token.txt"),
+		})
+		for _, want := range []string{"archive/one/.env", "archive/two/token.txt"} {
+			if !strings.Contains(action, want) {
+				t.Errorf("action %q does not name %q", action, want)
+			}
+		}
+	})
+}
+
+// The rendered arrow line must carry the archived command WHOLE. TruncTail
+// used to apply here, and its ellipsis ate half the targets of a real scan's
+// six-path command (2026-08-07) — the pre-render action string was complete,
+// so only a rendered-output assertion can hold the line.
+func TestArchivedCommandRendersUntruncated(t *testing.T) {
+	long := "/Users/alex/Documents/archive/a-project-directory-name-well-past-eighty-columns-of-terminal/deeper-still/.env"
+	findings := []Finding{{
+		RecordID: "a", FindingType: FindingTypeEnvFilePresent,
+		Severity: SeverityHigh, Remedy: RemedyMigrate, Archived: true,
+		FilePath: long, Evidence: "secret-shaped",
+	}}
+	annotateCauseGroups(findings)
+
+	var buf bytes.Buffer
+	WriteTriageReport(&buf, findings, ScanSummary{}, "/Users/alex", ComputeCoverage("/Users/alex", "", findings))
+	want := "jit migrate ~/Documents/archive/a-project-directory-name-well-past-eighty-columns-of-terminal/deeper-still/.env"
+	if !strings.Contains(buf.String(), want) {
+		t.Errorf("rendered report cut the archived command; want it whole:\n%s", buf.String())
 	}
 }
 

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -334,6 +334,32 @@ func TestArchivedNoteOffersDeletion(t *testing.T) {
 	}
 }
 
+// A source example renders in the footer's uncounted tally, in its own
+// bucket — neither charged to YOUR SECRETS nor lumped under low-confidence,
+// which would misdescribe it (jit is not unsure; it is saying the value
+// documents a shape).
+func TestSourceExampleInFooterBucket(t *testing.T) {
+	vendor := "Database connection string with embedded credentials"
+	ln := 100
+	findings := []Finding{{
+		RecordID: "e", FindingType: FindingTypeExposedSecret,
+		Severity: SeverityHigh, Remedy: RemedyManual, SourceExample: true,
+		FilePath: "/Users/alex/code/scanner/patterns.go", Line: &ln, KeyName: &vendor,
+		Evidence: "value matches a known vendor credential format",
+	}}
+	annotateCauseGroups(findings)
+
+	var buf bytes.Buffer
+	WriteTriageReport(&buf, findings, ScanSummary{}, "/Users/alex", ComputeCoverage("/Users/alex", "", findings))
+	out := buf.String()
+	if !strings.Contains(out, "1 source example") {
+		t.Errorf("footer missing the source-example bucket:\n%s", out)
+	}
+	if strings.Contains(out, "patterns.go") {
+		t.Errorf("an uncounted source example must not render as a finding:\n%s", out)
+	}
+}
+
 // Nine JWTs in nine paste-cache files printed the identical grep hint nine
 // times — one instruction stuttered. Hints identical up to path collapse to
 // one grep over all the files; hints that genuinely differ keep the

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -261,6 +261,79 @@ func TestArchivedActionCoversItsWholeGroup(t *testing.T) {
 	})
 }
 
+// Trash is the one archived-looking place where even migrate-by-name is the
+// wrong offer: the user already decided the file should not exist, so the
+// remedy is finishing the deletion, not vaulting. Every trash path also
+// LooksArchived, so this pins the ordering that keeps the archived branch
+// from swallowing it.
+func TestTrashFindingsGetTheirOwnGroup(t *testing.T) {
+	mk := func(id, path string) Finding {
+		return Finding{
+			RecordID: id, FindingType: FindingTypeEnvFilePresent,
+			Severity: SeverityHigh, Remedy: RemedyMigrate, Archived: true,
+			FilePath: path, Evidence: "secret-shaped",
+		}
+	}
+	findings := []Finding{
+		mk("t", "/Users/alex/.Trash/old-project/.env"),
+		mk("a", "/Users/alex/Documents/archive/one/.env"),
+	}
+	annotateCauseGroups(findings)
+	groups := groupManualByAction(triageGroupManual(findings, "/Users/alex"), "/Users/alex")
+
+	var trash, archived *triageActionGroup
+	for i := range groups {
+		switch groups[i].kind {
+		case kindTrash:
+			trash = &groups[i]
+		case kindArchived:
+			archived = &groups[i]
+		}
+	}
+	if trash == nil || archived == nil {
+		t.Fatalf("want one trash and one archived group, got: %+v", groups)
+	}
+	if want := "empty the Trash, then rotate anything it held"; trash.action != want {
+		t.Errorf("trash action = %q, want %q", trash.action, want)
+	}
+	if strings.Contains(archived.action, ".Trash") {
+		t.Errorf("archived action %q reaches into the Trash; migrate must not be offered there", archived.action)
+	}
+	if strings.Contains(archived.note, ".trash") {
+		t.Errorf("archived note %q still claims to cover .trash — that group exists now", archived.note)
+	}
+}
+
+// The archived note carries two facts on two lines: the sweep's behaviour and
+// the deletion alternative migrate cannot offer. Rendered, not just stored —
+// the renderer splits on \n, and flowing the facts into one wrapped paragraph
+// would glue them mid-line.
+func TestArchivedNoteOffersDeletion(t *testing.T) {
+	mk := func(id, path string) Finding {
+		return Finding{
+			RecordID: id, FindingType: FindingTypeEnvFilePresent,
+			Severity: SeverityHigh, Remedy: RemedyMigrate, Archived: true,
+			FilePath: path, Evidence: "secret-shaped",
+		}
+	}
+	findings := []Finding{
+		mk("a", "/Users/alex/Documents/archive/one/.env"),
+		mk("b", "/Users/alex/Documents/archive/two/.env"),
+	}
+	annotateCauseGroups(findings)
+
+	var buf bytes.Buffer
+	WriteTriageReport(&buf, findings, ScanSummary{}, "/Users/alex", ComputeCoverage("/Users/alex", "", findings))
+	// The note wraps at terminal width, so match against the report with its
+	// line breaks flattened back to spaces.
+	flat := strings.Join(strings.Fields(buf.String()), " ")
+	for _, want := range []string{archivedDeletionNote, "naming this folder"} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("rendered archived note missing %q:\n%s", want, buf.String())
+		}
+	}
+}
+
 // The rendered arrow line must carry the archived command WHOLE. TruncTail
 // used to apply here, and its ellipsis ate half the targets of a real scan's
 // six-path command (2026-08-07) — the pre-render action string was complete,

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -334,6 +334,40 @@ func TestArchivedNoteOffersDeletion(t *testing.T) {
 	}
 }
 
+// A GCP service-account key must never be handed the SSH advice: it cannot
+// take a passphrase, and deleting the file does not revoke it. A real scan
+// (2026-08-07) told the user to run ssh-keygen -p on two IAM keys in
+// ~/Downloads — this pins the whole rendered corrective: noun, group header,
+// action, and the IAM note.
+func TestGCPServiceAccountKeyAdvice(t *testing.T) {
+	name := "Google Cloud service-account key"
+	findings := []Finding{{
+		RecordID: "k", FindingType: FindingTypePrivateKeyRisk,
+		KeyKind: keyKindGCPServiceAccount, KeyName: &name,
+		Severity: SeverityHigh, Remedy: RemedyManual,
+		FilePath: "/Users/alex/Downloads/security-504007-7b1189f6fcd9.json",
+		Evidence: "private key found outside ~/.ssh",
+	}}
+	annotateCauseGroups(findings)
+
+	var buf bytes.Buffer
+	WriteTriageReport(&buf, findings, ScanSummary{}, "/Users/alex", ComputeCoverage("/Users/alex", "", findings))
+	flat := strings.Join(strings.Fields(buf.String()), " ")
+	for _, want := range []string{
+		"An exposed Google Cloud service-account key",
+		"[rotate in IAM, then delete the file]",
+		"rotate the key in IAM, then delete this file",
+		"only deleting the key in IAM does",
+	} {
+		if !strings.Contains(flat, want) {
+			t.Errorf("report missing %q:\n%s", want, buf.String())
+		}
+	}
+	if strings.Contains(flat, "ssh-keygen") {
+		t.Errorf("report offers ssh-keygen for a service-account key:\n%s", buf.String())
+	}
+}
+
 // The rendered arrow line must carry the archived command WHOLE. TruncTail
 // used to apply here, and its ellipsis ate half the targets of a real scan's
 // six-path command (2026-08-07) — the pre-render action string was complete,

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -334,6 +334,72 @@ func TestArchivedNoteOffersDeletion(t *testing.T) {
 	}
 }
 
+// Nine JWTs in nine paste-cache files printed the identical grep hint nine
+// times — one instruction stuttered. Hints identical up to path collapse to
+// one grep over all the files; hints that genuinely differ keep the
+// keep-every-hint rule.
+func TestIdenticalPatternHintsCollapse(t *testing.T) {
+	jwt := "JSON Web Token (JWT)"
+	mk := func(id, path string) Finding {
+		return Finding{
+			RecordID: id, FindingType: FindingTypeExposedSecret,
+			Severity: SeverityHigh, Remedy: RemedyManual, FilePath: path,
+			KeyName: &jwt, Evidence: "value matches a known vendor credential format",
+		}
+	}
+
+	t.Run("same directory and extension collapse to a glob", func(t *testing.T) {
+		findings := []Finding{
+			mk("a", "/Users/alex/.claude/paste-cache/44b238b43bfc1875.txt"),
+			mk("b", "/Users/alex/.claude/paste-cache/b644a758e6f952fe.txt"),
+			mk("c", "/Users/alex/.claude/paste-cache/100c53a2bedb7481.txt"),
+		}
+		annotateCauseGroups(findings)
+		groups := triageGroupManual(findings, "/Users/alex")
+		g := findGroupByNoun(t, groups, "An exposed JWT")
+		if len(g.hints) != 1 {
+			t.Fatalf("got %d hints, want 1 collapsed: %q", len(g.hints), g.hints)
+		}
+		for _, want := range []string{"grep -nE", "~/.claude/paste-cache/*.txt", "cut -d: -f1,2"} {
+			if !strings.Contains(g.hints[0], want) {
+				t.Errorf("collapsed hint %q missing %q", g.hints[0], want)
+			}
+		}
+		if len(g.details) != 3 {
+			t.Errorf("details must survive the hint collapse untouched, got %d, want 3", len(g.details))
+		}
+	})
+
+	t.Run("different directories still collapse, naming each path", func(t *testing.T) {
+		findings := []Finding{
+			mk("a", "/Users/alex/notes/one.txt"),
+			mk("b", "/Users/alex/dumps/two.txt"),
+		}
+		annotateCauseGroups(findings)
+		groups := triageGroupManual(findings, "/Users/alex")
+		g := findGroupByNoun(t, groups, "An exposed JWT")
+		if len(g.hints) != 1 {
+			t.Fatalf("got %d hints, want 1 collapsed: %q", len(g.hints), g.hints)
+		}
+		for _, want := range []string{"~/notes/one.txt", "~/dumps/two.txt"} {
+			if !strings.Contains(g.hints[0], want) {
+				t.Errorf("collapsed hint %q missing %q", g.hints[0], want)
+			}
+		}
+	})
+}
+
+func findGroupByNoun(t *testing.T, groups []triageManualGroup, noun string) triageManualGroup {
+	t.Helper()
+	for _, g := range groups {
+		if g.noun == noun {
+			return g
+		}
+	}
+	t.Fatalf("no group with noun %q: %+v", noun, groups)
+	return triageManualGroup{}
+}
+
 // A GCP service-account key must never be handed the SSH advice: it cannot
 // take a passphrase, and deleting the file does not revoke it. A real scan
 // (2026-08-07) told the user to run ssh-keygen -p on two IAM keys in


### PR DESCRIPTION
Fixes five defects surfaced by a real-machine \`jit scan\` (2026-08-07), reviewed and approved block-by-block via rendered previews.

## What changed

- **GCP service-account keys get IAM advice.** The private-key sniffer deliberately matches the escaped-newline PEM inside a service-account JSON, but everything downstream treated it as an SSH key: the real scan told the user to run \`ssh-keygen -p\` on two IAM keys in \`~/Downloads\`, and the "no passphrase" claim was invented downstream of evidence that never established it. New non-serialized \`Finding.KeyKind\` + JSON envelope sniff; the report now renders "An exposed Google Cloud service-account key" under \`[rotate in IAM, then delete the file]\`, with a note stating the fact people get wrong: deleting the file does not revoke the key.
- **The archived group's command prints whole, and short.** The arrow line named every file and then \`TruncTail\` cut it at terminal width, so the real scan shipped a six-path \`jit migrate\` command whose ellipsis ate targets four through six. The command is now the deepest common **archived** directory when naming it would rediscover every file in the group (explicit targets never apply the archive skip), and the full path list otherwise; either way the rendered arrow no longer truncates commands. A rendered-width test pins it, closing the gap that let the old version ship (the pre-render string was complete; only the rendering cut it).
- **\`.trash\` is its own remedy, not an archive.** Migrating a file the user already decided to delete would preserve what deletion is about to fix. Trash findings now group under \`[empty the trash]\`; the archived note gains a deletion-peer line for copies whose live sibling is already protected.
- **Identical hints collapse.** Nine JWTs across nine paste-cache files printed the identical grep hint nine times. Hints identical up to path now fold into one grep (a glob when directory and extension allow), with \`cut -d: -f1,2\` keeping multi-file output to path:line and never content.
- **jit no longer flags its own source.** \`tokenpatterns.go\`'s doc comment argues for keeping a connection-string shape matchable by example, and the example matched. Vendor matches on comment-leading lines of source files are now tagged \`SourceExample\`: visible in \`--full\`, named in the footer ("N source examples"), excluded from the coverage ledger like fixtures. The per-vendor collapse prefers a non-comment occurrence so an example can never shadow a real credential below it, and a dogfood test scans \`tokenpatterns.go\` itself.

## Deliberately unchanged

The bare-sweep archive skip was re-litigated and kept: migrate's continuity promise buys nothing in an archive, backups exist to be byte-stable, and naming a path is the consent that reaches them. Scan-vs-migrate purity was investigated and is NOT divergent (assignment spans leave \`KEY=\` residue in both), so no change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144rDJE7M4Njf8zjxuvqrFK