### PR TITLE
docs: two claims the docs make that the code does not

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ echo 'source <(jit completion zsh)' >> ~/.zshrc && exec zsh
 ## How you actually use it
 
 ```sh
-jit scan                            # read-only. shows every plaintext secret. writes nothing.
+jit scan                            # read-only. changes no file it scans, prints no real value.
 jit vault init                      # make the vault (master key in your login keychain)
 jit migrate --dry-run               # preview the whole machine-wide fix plan
 jit migrate                         # apply it: shows plan, asks [y/N], one Touch ID

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -203,9 +203,16 @@ yourself (an Argon2id-derived key, machine-independent by design).
 
 ### Is `jit scan` safe to run on a sensitive machine?
 
-Yes. It is strictly read-only, never writes anything, and never prints a real
-value (every preview is masked). Use `jit scan --format ndjson` for
-machine-readable output under the same redaction rules.
+Yes. It never touches, encrypts or rewrites a single file it scans, and never
+prints a real value (every preview is masked). Use `jit scan --format ndjson`
+for machine-readable output under the same redaction rules.
+
+To be exact about "writes nothing": the scan itself writes nothing, and the
+guard test in `internal/audit` enforces that. The command around it appends a
+line to jit's own application audit log under
+`~/Library/Application Support/jitpass/`, the same as every other jit
+invocation, and `--output` writes the report file you asked for. Nothing in
+your home directory is read-modify-written by a scan.
 
 ### What about secrets already committed to git?
 

--- a/docs/why-jit.md
+++ b/docs/why-jit.md
@@ -25,8 +25,9 @@ default and keeps the plaintext out of the way the rest of the time.
 
 ## 1. See what is already exposed
 
-`jit scan` is a read-only scan of your machine. It never writes, moves, or
-"fixes" anything, so it is safe to run before you trust jit with anything else.
+`jit scan` is a read-only scan of your machine. It never rewrites, moves, or
+"fixes" a file it scans, so it is safe to run before you trust jit with
+anything else.
 In well under a second it tells you how many secrets you have, how many jit
 already protects, and the one command that protects the rest. (`jit scan
 --full` ranks every finding by risk; `--score` gives the 0-100 exposure

--- a/docs/wrap/index.md
+++ b/docs/wrap/index.md
@@ -14,7 +14,7 @@ in `ngrok.yml`. Those files are each tool's own territory, which
 jit wrap gh                # discover the token, vault it, scrub the file
 gh pr list                 # works exactly as before - token injected per call
 jit wrap list              # what's wrapped, shim health, PATH position
-jit wrap undo gh           # restore the original file byte-for-byte
+jit wrap undo gh           # take the shim back off PATH
 ```
 
 Under the hood it installs a PATH shim named after the tool (in
@@ -27,6 +27,13 @@ miss - at about 25 ms overhead per call with an unlocked service.
 
 [`jit scan`](../audit/index.md) flags the tokens worth wrapping and
 prints the one-command fix next to each.
+
+Unwrapping is two steps, because two things changed. `jit wrap undo <tool>`
+removes the shim and the `wrap-<tool>` profile; the tool's config file was
+scrubbed by `jit wrap`, so putting the token back in it is
+[`jit migrate undo`](../migrate/undo-and-remove.md) on that file. Run only
+the first and the tool stays logged out. See
+[troubleshooting](./troubleshooting.md#unwrap-jit-wrap-undo-tool).
 
 ## Shim-based plugins
 


### PR DESCRIPTION
Found while auditing the landing site against this repo. The site had copied both claims from here, so fixing them downstream alone would let them come back.

## `jit wrap undo` does not restore the scrubbed file

`docs/wrap/index.md`'s quick-reference block said:

```
jit wrap undo gh           # restore the original file byte-for-byte
```

`internal/wrap/undo.go` removes the shim, the `wrap-<tool>` profile and the manifest entry, and nothing else. The token was deleted out of the tool's config by `internal/wrap/scrub.go`, and only `jit migrate undo` on that file puts it back. `docs/wrap/troubleshooting.md` already documented this correctly, so the two pages contradicted each other — and the wrong one was in the block people copy from.

Follow the old line literally on `gh` and you are left with a tool that is still logged out and no indication a second command exists.

## "never writes anything" is not true of the command

`docs/faq.md` answered *"Is `jit scan` safe to run on a sensitive machine?"* with "strictly read-only, never writes anything". The **scan** is; the **command** is not. `scan` is not in `auditExcludedCommands` (`internal/cli/auditrecord.go`), so every run creates the config root if absent and appends to `audit.jsonl`; `--output` writes a report.

`internal/audit/readonly_test.go` already scopes the guarantee this way and explains why: it covers `internal/audit`, while `internal/cli` "legitimately writes (its config root, the audit log)".

All three sites now make the promise that is actually true and actually matters — that nothing in your home directory is rewritten. The FAQ, where someone is explicitly asking about a sensitive machine, spells out what *is* written and where.

## Testing

Docs only, no Go changed. `go run ./cmd/jit docs-gen` run; command reference is current.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015H7TchhguyfQfPoRvcNnvw