### PR TITLE
spike: download-redirect Worker, deployed at dl.jitpass.com

### DIFF
--- a/spike/dl-redirect/FINDINGS.md
+++ b/spike/dl-redirect/FINDINGS.md
@@ -1,0 +1,74 @@
+# Findings: download-redirect Worker (dl.jitpass.com)
+
+**Question.** GitHub's release API exposes exactly one number about downloads
+(`download_count`, cumulative, no who/when/where — verified against the full
+asset field list, and the org audit log neither covers public downloads nor
+exists below Enterprise). Can a one-hop redirect through a host we own give
+real per-download data — client type, version, country — without touching the
+binary, the bytes, or the signature chain?
+
+**Answer: yes.** 12/12 local checks pass (`test.sh`, wrangler v4 dev, no
+Cloudflare account needed). Worker is ~90 lines, logs one line, 302s to
+GitHub, never proxies a body.
+
+## What was proven
+
+1. **Byte integrity is preserved through the redirect.** A tarball fetched
+   via the Worker hash-matches the release's own published `checksums.txt`
+   (v0.81.0, `bea735b7…`). The cask's `sha256` therefore stays a hash of
+   GitHub's bytes; nothing about goreleaser's checksum flow changes.
+2. **All three client classes separate cleanly by user-agent.**
+   `Homebrew/…` → `brew`, `curl/…` → `curl`, and — the lucky find —
+   `internal/cli/upgrade.go` already sets `User-Agent: jit-upgrade` on all
+   three of its fetches (redirect page, checksums, tarball), so self-updates
+   are distinguishable with zero binary changes.
+3. **Country/colo come free** from `request.cf` (`country=IL colo=TLV` in the
+   local run). No IP is logged — the log line and the Analytics Engine row
+   carry client class, tag, asset, country, colo, and nothing else.
+4. **The path allowlist holds.** Tag must match `^v\d+\.\d+\.\d+$`, asset must
+   be one of the two shipped names; `evil.sh`, foreign repos, traversal
+   encodings, and `/` all 404. The Worker cannot be used as an open
+   redirector.
+5. **HEAD also 302s** (brew probes with HEAD before fetching).
+
+## Design decisions that should survive into production
+
+- **Redirect, never proxy.** The worst failure mode must be "download fails
+  loudly", never "different bytes served". A body-proxying worker would put
+  us in the serving path for real; a 302 keeps GitHub as the only origin.
+- **Log dimensions, not identities.** No IP, no full UA string. The privacy
+  story has to survive being read aloud in a security review: "we count
+  downloads by client type and country".
+- **`jit upgrade` stays pointed at GitHub.** Instrument acquisition (the cask
+  URL) only; the security-critical self-update path remains unmodified and
+  unmeasured. The redirect host must never become load-bearing for
+  `verifyStagedSignature`'s chain.
+
+## What production needs that the spike does not
+
+- A Cloudflare account + zone for jitpass.com; route `dl.jitpass.com/*` to
+  the Worker; uncomment the `[[analytics_engine_datasets]]` binding
+  (`DL_STATS` / `jit_downloads`) — Analytics Engine has no local emulation,
+  so it is deploy-verified only. Queryable with SQL from the dashboard/API;
+  free tier is ample at current volume.
+- The cask `url` in `.goreleaser.yml`'s `homebrew_casks` block pointed at
+  `https://dl.jitpass.com/jitpass/jit/releases/download/{tag}/…` (the Worker
+  mirrors GitHub's path shape exactly so the template is a hostname swap).
+- **Availability honesty:** the Worker becomes a hard dependency of
+  `brew install`. Keep it dumb (log + redirect only), and know that rolling
+  back is a one-line cask revert re-pointing at github.com.
+- A retention line on the site ("aggregate download stats by client type and
+  country; no IPs retained").
+
+## Known limits
+
+- New-asset names (e.g. a future darwin_amd64 tarball) must be added to
+  `ASSET_ALLOW` or they 404 — a release checklist item, and the failure is
+  loud (brew install errors), not silent.
+- The `/latest/` route logs `tag=latest`, not the resolved version. Per-tag
+  numbers come from the pinned-tag route the cask uses; `latest` is what
+  curl-instruction users hit, and their version is resolved by GitHub after
+  our hop. Acceptable: the cask (brew) and any pinned curl line carry tags.
+- `wrangler dev --log-level warn` suppresses the Worker's `console.log`;
+  use `--log-level log` (or `wrangler tail` in prod) to see classification
+  lines. test.sh's section [5] is informational for this reason.

--- a/spike/dl-redirect/FINDINGS.md
+++ b/spike/dl-redirect/FINDINGS.md
@@ -56,6 +56,16 @@ created in the dashboard (Enable is account-wide and one-time; deploying the
 binding before the dataset existed made every request 500 — create the
 dataset first, or expect that until the first successful write).
 
+That 500 episode set the Worker's fail-open rule, the same one
+`internal/guard` lives by: the stats write is wrapped in try/catch so
+measurement can never again break delivery. The remaining failure domain is
+Cloudflare itself (Worker down / zone gone): brew and the README curl line
+fail LOUDLY (no wrong bytes possible — the Worker never serves a body), and
+recovery needs no release: hand-edit `Casks/jitpass.rb` in the tap back to
+github.com and push, minutes not days. `jit upgrade` is outside the failure
+domain entirely — it never touches this host — and the docs keep the plain
+github.com URL as the stated curl alternative.
+
 NOTHING POINTS AT IT YET: the cask still says github.com. The remaining
 production step is the cask `url` swap in `.goreleaser.yml`, shipped with a
 release. Rollback at any time is re-pointing the cask at github.com.

--- a/spike/dl-redirect/FINDINGS.md
+++ b/spike/dl-redirect/FINDINGS.md
@@ -36,9 +36,18 @@ GitHub, never proxies a body.
 - **Redirect, never proxy.** The worst failure mode must be "download fails
   loudly", never "different bytes served". A body-proxying worker would put
   us in the serving path for real; a 302 keeps GitHub as the only origin.
-- **Log dimensions, not identities.** No IP, no full UA string. The privacy
-  story has to survive being read aloud in a security review: "we count
-  downloads by client type and country".
+- **Log dimensions, not identities.** No IP, no full UA string, no city (at
+  this volume a city+timestamp row is nearly a person). The privacy story has
+  to survive being read aloud in a security review: "we count downloads by
+  client type, platform, and country". What IS kept, all aggregate — blob
+  order is the query contract: client, tag, asset, country, macOS version,
+  arch, Homebrew version (the three platform facts parsed out of brew's UA,
+  which is then dropped), ASN org (separates CI/datacenter pulls from
+  residential — the bot filter GitHub's counter can't give), colo. arch is
+  the sleeper: x86_64 rows are the first real measure of Intel demand for
+  the arm64-only decision. If uniques ever matter, the documented option is
+  a daily-salted IP hash — count distinct machines per day with no way to
+  recover an address; not built until volume justifies it.
 - **`jit upgrade` stays pointed at GitHub.** Instrument acquisition (the cask
   URL) only; the security-critical self-update path remains unmodified and
   unmeasured. The redirect host must never become load-bearing for

--- a/spike/dl-redirect/FINDINGS.md
+++ b/spike/dl-redirect/FINDINGS.md
@@ -44,6 +44,22 @@ GitHub, never proxies a body.
   unmeasured. The redirect host must never become load-bearing for
   `verifyStagedSignature`'s chain.
 
+## Deployed 2026-08-08 — live verification
+
+The Worker is LIVE at `dl.jitpass.com` (account `d48d87db…`, free plan — all
+of Workers, the custom domain, and Analytics Engine fit the free tier). The
+full suite re-run against the live edge: **11/11** — 302s exact for all four
+client classes on both routes, allowlist 404s hold, HEAD redirects, and the
+tarball fetched through the live edge hash-matches v0.81.0's published
+checksums.txt (`bea735b7…`). Analytics Engine dataset `jit_downloads` was
+created in the dashboard (Enable is account-wide and one-time; deploying the
+binding before the dataset existed made every request 500 — create the
+dataset first, or expect that until the first successful write).
+
+NOTHING POINTS AT IT YET: the cask still says github.com. The remaining
+production step is the cask `url` swap in `.goreleaser.yml`, shipped with a
+release. Rollback at any time is re-pointing the cask at github.com.
+
 ## What production needs that the spike does not
 
 - A Cloudflare account + zone for jitpass.com; route `dl.jitpass.com/*` to

--- a/spike/dl-redirect/test.sh
+++ b/spike/dl-redirect/test.sh
@@ -1,0 +1,84 @@
+#!/bin/zsh
+# Drive the redirect Worker locally (wrangler dev, no Cloudflare account
+# needed) and prove the four things the production change depends on:
+#   1. every client class gets a 302 to the exact GitHub URL
+#   2. the path allowlist rejects open-redirect probes with 404
+#   3. bytes fetched THROUGH the redirect hash-match the release's own
+#      published checksums.txt (the cask sha256 therefore stays valid)
+#   4. a HEAD request (brew probes with one) also redirects
+set -uo pipefail
+cd "$(dirname "$0")"
+
+PORT=8787
+BASE="http://127.0.0.1:$PORT"
+PASS=0; FAIL=0
+ok()  { echo "  ✓ $1"; PASS=$((PASS+1)); }
+bad() { echo "  ✗ $1"; FAIL=$((FAIL+1)); }
+
+echo "[dl-redirect spike] starting wrangler dev ..."
+npx --yes wrangler@4 dev --port $PORT --log-level warn > wrangler-dev.log 2>&1 &
+WPID=$!
+trap 'kill $WPID 2>/dev/null' EXIT
+
+for i in {1..60}; do
+  curl -s -o /dev/null "$BASE/" && break
+  sleep 1
+done
+curl -s -o /dev/null "$BASE/" || { echo "wrangler dev never came up — see wrangler-dev.log"; exit 1; }
+echo "[dl-redirect spike] up on $BASE"
+
+TAG=$(curl -s https://api.github.com/repos/jitpass/jit/releases/latest | /usr/bin/python3 -c 'import json,sys; print(json.load(sys.stdin)["tag_name"])')
+echo "[dl-redirect spike] latest release: $TAG"
+echo
+
+echo "[1] 302 + exact Location, per client class"
+for ua in "Homebrew/4.3.0 (Macintosh; arm64 Mac OS X 15)" "curl/8.7.1" "jit-upgrade" "Mozilla/5.0 (Macintosh)"; do
+  hdr=$(curl -s -o /dev/null -A "$ua" -w '%{http_code} %{redirect_url}' \
+    "$BASE/jitpass/jit/releases/download/$TAG/jitpass_darwin_arm64.tar.gz")
+  want="302 https://github.com/jitpass/jit/releases/download/$TAG/jitpass_darwin_arm64.tar.gz"
+  [ "$hdr" = "$want" ] && ok "UA '$ua' -> $hdr" || bad "UA '$ua' -> got '$hdr' want '$want'"
+done
+hdr=$(curl -s -o /dev/null -w '%{http_code} %{redirect_url}' \
+  "$BASE/jitpass/jit/releases/latest/download/checksums.txt")
+case "$hdr" in
+  "302 https://github.com/jitpass/jit/releases/latest/download/checksums.txt") ok "latest/checksums.txt -> $hdr";;
+  *) bad "latest/checksums.txt -> $hdr";;
+esac
+echo
+
+echo "[2] allowlist: open-redirect probes must 404"
+for p in \
+  "/jitpass/jit/releases/download/$TAG/evil.sh" \
+  "/jitpass/jit/releases/download/not-a-tag/jitpass_darwin_arm64.tar.gz" \
+  "/jitpass/jit/releases/download/..%2f..%2fevil/jitpass_darwin_arm64.tar.gz" \
+  "/other/repo/releases/download/$TAG/jitpass_darwin_arm64.tar.gz" \
+  "/" ; do
+  code=$(curl -s -o /dev/null -w '%{http_code}' "$BASE$p")
+  [ "$code" = "404" ] && ok "404 $p" || bad "want 404 got $code for $p"
+done
+echo
+
+echo "[3] byte integrity through the redirect (the check the cask sha256 depends on)"
+curl -sL -A "Homebrew/4.3.0" -o /tmp/dl-spike.tar.gz \
+  "$BASE/jitpass/jit/releases/download/$TAG/jitpass_darwin_arm64.tar.gz"
+curl -sL -o /tmp/dl-spike-sums.txt \
+  "$BASE/jitpass/jit/releases/download/$TAG/checksums.txt"
+got=$(shasum -a 256 /tmp/dl-spike.tar.gz | cut -d' ' -f1)
+want=$(grep 'jitpass_darwin_arm64.tar.gz' /tmp/dl-spike-sums.txt | cut -d' ' -f1)
+[ -n "$got" ] && [ "$got" = "$want" ] \
+  && ok "sha256 through redirect matches published checksums.txt ($got)" \
+  || bad "sha256 mismatch: got=$got want=$want"
+echo
+
+echo "[4] HEAD also redirects (brew probes with HEAD before fetching)"
+code=$(curl -s -o /dev/null -I -w '%{http_code}' \
+  "$BASE/jitpass/jit/releases/download/$TAG/jitpass_darwin_arm64.tar.gz")
+[ "$code" = "302" ] && ok "HEAD -> 302" || bad "HEAD -> $code"
+echo
+
+echo "[5] the log line the Worker emits (classification evidence)"
+grep -o 'dl client=[^ ]* tag=[^ ]* asset=[^ ]*' wrangler-dev.log | sort | uniq -c | sed 's/^/  /'
+echo
+
+echo "── $PASS passed, $FAIL failed"
+exit $((FAIL > 0))

--- a/spike/dl-redirect/worker.js
+++ b/spike/dl-redirect/worker.js
@@ -1,0 +1,92 @@
+// spike: download-redirect Worker for dl.jitpass.com.
+//
+// The whole job: log one line about the request, then 302 to the real GitHub
+// release asset. GitHub keeps serving the bytes, the cask's sha256 stays a
+// hash of GitHub's bytes, and the Developer ID signature check in `jit
+// upgrade` is untouched. If this Worker is wrong in any way the worst case
+// must be "download fails loudly", never "different bytes served" — which is
+// why it only ever redirects to a URL it builds from an allowlisted shape,
+// and never proxies a body.
+//
+// Routes (mirroring GitHub's own path shape so the cask template is trivial):
+//   GET /jitpass/jit/releases/download/<tag>/<asset>   -> 302 pinned tag
+//   GET /jitpass/jit/releases/latest/download/<asset>  -> 302 latest
+//   anything else                                      -> 404
+//
+// What gets logged, and deliberately nothing more:
+//   client class (brew | curl | jit-upgrade | browser | other), tag, asset,
+//   country, Cloudflare colo. NO IP, NO full user-agent string, NO cookies.
+//   The privacy story must survive being read aloud: "we count downloads by
+//   client type and country". Analytics Engine rows carry no IP unless you
+//   write one — so we don't.
+
+const OWNER = "jitpass";
+const REPO = "jit";
+
+// Only assets a release actually publishes; anything else 404s rather than
+// becoming an open redirect namespace.
+const ASSET_ALLOW = /^(jitpass_darwin_arm64\.tar\.gz|checksums\.txt)$/;
+const TAG_ALLOW = /^v\d+\.\d+\.\d+$/;
+
+function classifyUA(ua) {
+  if (!ua) return "other";
+  if (ua.startsWith("jit-upgrade")) return "jit-upgrade";
+  if (ua.includes("Homebrew")) return "brew";
+  if (ua.startsWith("curl/") || ua.startsWith("Wget/")) return "curl";
+  if (ua.includes("Mozilla/")) return "browser";
+  return "other";
+}
+
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const parts = url.pathname.split("/").filter(Boolean);
+
+    // /jitpass/jit/releases/download/<tag>/<asset>
+    // /jitpass/jit/releases/latest/download/<asset>
+    let tag = null;
+    let asset = null;
+    if (
+      parts.length === 6 &&
+      parts[0] === OWNER && parts[1] === REPO &&
+      parts[2] === "releases" && parts[3] === "download" &&
+      TAG_ALLOW.test(parts[4]) && ASSET_ALLOW.test(parts[5])
+    ) {
+      tag = parts[4];
+      asset = parts[5];
+    } else if (
+      parts.length === 6 &&
+      parts[0] === OWNER && parts[1] === REPO &&
+      parts[2] === "releases" && parts[3] === "latest" &&
+      parts[4] === "download" && ASSET_ALLOW.test(parts[5])
+    ) {
+      tag = "latest";
+      asset = parts[5];
+    } else {
+      return new Response("not found\n", { status: 404 });
+    }
+
+    const dest = tag === "latest"
+      ? `https://github.com/${OWNER}/${REPO}/releases/latest/download/${asset}`
+      : `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${asset}`;
+
+    const client = classifyUA(request.headers.get("user-agent") || "");
+    const country = (request.cf && request.cf.country) || "??";
+    const colo = (request.cf && request.cf.colo) || "??";
+
+    // Always console.log (visible in `wrangler tail` / dev); additionally
+    // write an Analytics Engine row when the binding exists (deployed only —
+    // AE has no local emulation worth trusting).
+    console.log(`dl client=${client} tag=${tag} asset=${asset} country=${country} colo=${colo}`);
+    if (env.DL_STATS) {
+      // blobs: dimensions to group by; doubles: the count. No IP, ever.
+      env.DL_STATS.writeDataPoint({
+        blobs: [client, tag, asset, country],
+        doubles: [1],
+        indexes: [client],
+      });
+    }
+
+    return Response.redirect(dest, 302);
+  },
+};

--- a/spike/dl-redirect/worker.js
+++ b/spike/dl-redirect/worker.js
@@ -77,14 +77,23 @@ export default {
     // Always console.log (visible in `wrangler tail` / dev); additionally
     // write an Analytics Engine row when the binding exists (deployed only —
     // AE has no local emulation worth trusting).
-    console.log(`dl client=${client} tag=${tag} asset=${asset} country=${country} colo=${colo}`);
-    if (env.DL_STATS) {
-      // blobs: dimensions to group by; doubles: the count. No IP, ever.
-      env.DL_STATS.writeDataPoint({
-        blobs: [client, tag, asset, country],
-        doubles: [1],
-        indexes: [client],
-      });
+    //
+    // FAIL OPEN, same rule internal/guard lives by: measurement must never
+    // break delivery. Before the dataset existed, writeDataPoint threw and
+    // every download 500'd — counting took the redirect down. Nothing in
+    // this block may prevent the 302.
+    try {
+      console.log(`dl client=${client} tag=${tag} asset=${asset} country=${country} colo=${colo}`);
+      if (env.DL_STATS) {
+        // blobs: dimensions to group by; doubles: the count. No IP, ever.
+        env.DL_STATS.writeDataPoint({
+          blobs: [client, tag, asset, country],
+          doubles: [1],
+          indexes: [client],
+        });
+      }
+    } catch (e) {
+      // swallowed deliberately: a lost data point over a lost download
     }
 
     return Response.redirect(dest, 302);

--- a/spike/dl-redirect/worker.js
+++ b/spike/dl-redirect/worker.js
@@ -37,6 +37,17 @@ function classifyUA(ua) {
   return "other";
 }
 
+// Pull the aggregate platform facts out of Homebrew's UA without storing the
+// UA itself: "Homebrew/4.6.19 (Macintosh; arm64 Mac OS X 15.5)". arch is the
+// one that matters — jit is arm64-only by decision, and x86_64 rows here are
+// the first real measure of Intel demand. Non-brew UAs yield "" (curl's UA
+// says nothing about the OS).
+function platformFromUA(ua) {
+  const m = /Homebrew\/([\d.]+) \(Macintosh; (\w+) Mac OS X ([\d.]+)\)/.exec(ua || "");
+  if (!m) return { brewVersion: "", arch: "", os: "" };
+  return { brewVersion: m[1], arch: m[2], os: m[3] };
+}
+
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
@@ -70,9 +81,15 @@ export default {
       ? `https://github.com/${OWNER}/${REPO}/releases/latest/download/${asset}`
       : `https://github.com/${OWNER}/${REPO}/releases/download/${tag}/${asset}`;
 
-    const client = classifyUA(request.headers.get("user-agent") || "");
+    const ua = request.headers.get("user-agent") || "";
+    const client = classifyUA(ua);
+    const { brewVersion, arch, os } = platformFromUA(ua);
     const country = (request.cf && request.cf.country) || "??";
     const colo = (request.cf && request.cf.colo) || "??";
+    // ASN org separates datacenter/CI pulls (GitHub Actions, AWS, ...) from
+    // residential ISPs — the bot filter GitHub's own counter can never give.
+    // An org name is an aggregate fact about a network, not about a person.
+    const asnOrg = (request.cf && request.cf.asOrganization) || "";
 
     // Always console.log (visible in `wrangler tail` / dev); additionally
     // write an Analytics Engine row when the binding exists (deployed only —
@@ -83,11 +100,14 @@ export default {
     // every download 500'd — counting took the redirect down. Nothing in
     // this block may prevent the 302.
     try {
-      console.log(`dl client=${client} tag=${tag} asset=${asset} country=${country} colo=${colo}`);
+      console.log(`dl client=${client} tag=${tag} asset=${asset} country=${country} colo=${colo} arch=${arch} os=${os} asn=${asnOrg}`);
       if (env.DL_STATS) {
-        // blobs: dimensions to group by; doubles: the count. No IP, ever.
+        // blobs: dimensions to group by; doubles: the count. No IP, no full
+        // UA, no city — aggregate facts only. Blob order is the query
+        // contract: 1=client 2=tag 3=asset 4=country 5=os 6=arch
+        // 7=brewVersion 8=asnOrg 9=colo.
         env.DL_STATS.writeDataPoint({
-          blobs: [client, tag, asset, country],
+          blobs: [client, tag, asset, country, os, arch, brewVersion, asnOrg, colo],
           doubles: [1],
           indexes: [client],
         });

--- a/spike/dl-redirect/wrangler.toml
+++ b/spike/dl-redirect/wrangler.toml
@@ -1,0 +1,12 @@
+# spike config — local `wrangler dev` needs none of the account fields.
+# Deployment (later, not this spike) adds: the dl.jitpass.com route and the
+# [[analytics_engine_datasets]] binding below, uncommented.
+name = "jit-dl-redirect"
+main = "worker.js"
+compatibility_date = "2026-08-01"
+
+# Deployed-only: aggregated download stats, queryable with SQL from the
+# Cloudflare dashboard/API. Free tier is fine at this volume.
+# [[analytics_engine_datasets]]
+# binding = "DL_STATS"
+# dataset = "jit_downloads"

--- a/spike/dl-redirect/wrangler.toml
+++ b/spike/dl-redirect/wrangler.toml
@@ -1,12 +1,16 @@
-# spike config — local `wrangler dev` needs none of the account fields.
-# Deployment (later, not this spike) adds: the dl.jitpass.com route and the
-# [[analytics_engine_datasets]] binding below, uncommented.
+# Local `wrangler dev` ignores the account-side fields; `wrangler deploy`
+# uses all of them. The custom domain creates the dl.jitpass.com DNS record
+# on the zone automatically at deploy time.
 name = "jit-dl-redirect"
 main = "worker.js"
 compatibility_date = "2026-08-01"
 
-# Deployed-only: aggregated download stats, queryable with SQL from the
-# Cloudflare dashboard/API. Free tier is fine at this volume.
-# [[analytics_engine_datasets]]
-# binding = "DL_STATS"
-# dataset = "jit_downloads"
+routes = [
+  { pattern = "dl.jitpass.com", custom_domain = true }
+]
+
+# Aggregated download stats, queryable with SQL from the dashboard/API.
+# Free tier is ample at this volume. No local emulation — deploy-verified.
+[[analytics_engine_datasets]]
+binding = "DL_STATS"
+dataset = "jit_downloads"


### PR DESCRIPTION
GitHub's release API exposes a single cumulative `download_count` — no client, no geo, no history. This spike proves (and now runs, live at dl.jitpass.com) a one-hop 302 redirect Worker that yields per-download client type (brew / curl / jit-upgrade), version, and country, with no binary change, no IP logged, and no change to where bytes come from.

- 12/12 local checks + 11/11 re-run against the live edge, including sha256-through-redirect against the release's own published checksums.txt
- allowlisted tag/asset shapes only — cannot be used as an open redirector
- `jit upgrade` stays pointed at GitHub; nothing references dl.jitpass.com yet (the cask URL swap is a separate future change)
- free tier throughout: Workers, custom domain, Analytics Engine (`jit_downloads` dataset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014u3dFWfjDLQHwod5eTb5bh