### PR TITLE
audit: durable mount-serve events · wrap: five AI-agent CLIs

### DIFF
--- a/docs/getting-started/how-it-works.md
+++ b/docs/getting-started/how-it-works.md
@@ -72,8 +72,9 @@ That's an MCP server your editor started, wanting the secrets in your
 
 The same provenance is kept afterwards: `jit service status` shows who
 unlocked the current session, and `jit audit` lists every unlock,
-every prompt that was declined, every lock, and what the open session was
-used for in between. Who the caller is comes from the kernel (its
+every prompt that was declined, every lock, what the open session was
+used for in between, and every read of a live-mounted credential file -
+decoy or real, and by which process. Who the caller is comes from the kernel (its
 pid on the socket, then its command line and parent chain), never from
 anything the caller says about itself. It is used to *explain* and to
 *audit*, never to decide. More in **[Provenance](../service/provenance.md)**

--- a/docs/reference/commands/jit_audit.md
+++ b/docs/reference/commands/jit_audit.md
@@ -24,10 +24,20 @@ Repeated rejections collapse into one line carrying a count; a collapsed line
 names the first caller of that window, because keying them per caller would let
 a flood of throwaway processes push every real event out of the history.
 
+Mount reads are here too, as kind=serve: every time a reader opened a live
+mount, whether it got the decoy (--status decoy) or the real value (--status
+real), why, and — best-effort, from the kernel — which program read it and what
+launched that program. A decoy read is jit working as designed, and it is also
+the one signal that names a process reading a credential file it has no business
+in. Same-mount, same-reader, same-verdict reads inside a short window collapse
+into one line carrying a count, because a file watcher re-reads a mount
+continuously and an uncollapsed read would push every unlock out of the log.
+
 Output is a grouped text timeline, newest first. --format logfmt prints one
 key=value line per event instead, so it reads and greps like a real service
 log. Narrow either without grep using the flags: --kind
-cmd,unlock,use,grant,lock,service,error, --status ok|failed|denied|approved,
+cmd,unlock,use,grant,serve,lock,service,error, --status
+ok|failed|denied|approved|decoy|real,
 --since and --until
 (an age like 2h/3d or a date), --parent (the launching ancestor, e.g. claude),
 --secret (a secret name an unlock touched), --user, and --grep (a regexp over the
@@ -56,12 +66,12 @@ jit audit [flags]
   -f, --follow          print the matching tail, then stream new entries live (text only)
       --format string   output format: "text" (default), "logfmt" (one key=value line per event), or "json" (default "text")
       --grep string     only entries whose rendered line matches this regular expression
-      --kind strings    only these kinds (comma-separated): cmd, unlock, use, grant, lock, service, error
+      --kind strings    only these kinds (comma-separated): cmd, unlock, use, grant, serve, lock, service, error
       --limit int       show at most this many recent matching entries (0 for all) (default 50)
       --parent string   only entries whose launched-by ancestor contains this (e.g. claude)
       --secret string   only auth events that touched a secret whose name contains this
       --since string    only entries at or after this time: an age (2h, 90m, 3d) or a date ("2026-07-23" or "2026-07-23 09:00")
-      --status string   only this status: ok, failed, denied, or approved
+      --status string   only this status: ok, failed, denied, approved, decoy, or real
       --until string    only entries at or before this time (same forms as --since)
       --user string     only commands this user ran (auth events carry no user)
 ```

--- a/docs/service/provenance.md
+++ b/docs/service/provenance.md
@@ -35,8 +35,8 @@ is not authenticating one, and jit doesn't pretend otherwise (see
   triggered it while it's still up - it answers immediately instead of
   waiting for the prompt to resolve.
 - `jit audit` prints the durable audit log: every jit command that ran,
-  interleaved with every unlock, grant, denial, use, and lock the service has
-  seen and what caused each. It's logfmt, newest first, so it greps like a real
+  interleaved with every unlock, grant, denial, use, mount read (decoy or
+  real), and lock the service has seen and what caused each. It's logfmt, newest first, so it greps like a real
   service log:
 
   ```
@@ -47,7 +47,7 @@ is not authenticating one, and jit doesn't pretend otherwise (see
   time=2026-07-22 13:18:02 level=warn kind=unlock status=denied method=touchid-or-passcode reason="local authentication failed: the user canceled" cmd="~/some-script.sh" parent=Code
   ```
 
-Among the auth events, six kinds appear:
+Among the auth events, seven kinds appear:
 
 - **unlock (status=ok)** - a Touch ID/passcode prompt the human approved, with
   the command that triggered it and what launched that command.
@@ -72,6 +72,19 @@ Among the auth events, six kinds appear:
   not ten). The secret names are what the calling jit process reported
   about itself - useful for audit, labeled `caller-reported` because,
   unlike everything else on these lines, they don't come from the kernel.
+- **serve** - a reader opened a live mount, and what it got: the decoy
+  (`status=decoy`) or the real value (`status=real`), why that verdict, and -
+  best-effort, from the kernel - which program read it and what launched that
+  program. A decoy read is jit working as designed, and it is also the one
+  signal that names a process reading a credential file it has no business in;
+  filter for those with `jit audit --status decoy`. The real half answers what
+  a grant approval alone can't: not "was this authorized" but "was it actually
+  read". Same-mount, same-reader, same-verdict reads inside a window collapse
+  into one line carrying a `count` - a dev server's file watcher re-reads a
+  mount continuously, and uncollapsed it would push every unlock out of the
+  history, the same erasure the error kind's collapsing prevents. An identity
+  carried over from a just-missed scan is marked `reader_likely` and rendered
+  "(likely)", never as certainty.
 - **lock** - what dropped the session: an idle timeout, the maximum session age
   (a session ends 8 hours after the unlock that opened it, however busy it has
   been), the screen locking, or an explicit `jit lock`.

--- a/docs/why-jit.md
+++ b/docs/why-jit.md
@@ -128,7 +128,9 @@ The caller identity comes from the kernel (its process id on the socket, then
 its command line and parent chain), never from anything the caller says about
 itself, so it cannot be faked. It is used to explain and to audit, never to
 decide. `jit service status` shows who unlocked the current session;
-`jit audit` lists every unlock, every declined prompt, and every lock.
+`jit audit` lists every unlock, every declined prompt, every lock, and
+every read of a live-mounted credential file - including which process
+read it and whether it got the real value or a decoy.
 
 **Why it matters:** this is 2026. The AI agents and MCP servers in your editor
 run with your full permissions and can read every secret you own. jit puts a

--- a/docs/wrap/cline.md
+++ b/docs/wrap/cline.md
@@ -1,0 +1,54 @@
+---
+title: Wrap the Cline CLI with jit
+description: Keep your Anthropic API key out of ~/.cline/settings/providers.json - injected as ANTHROPIC_API_KEY just-in-time.
+---
+
+# cline - Cline CLI
+
+`cline auth -p anthropic -k <key>` caches the key in plaintext JSON at
+`~/.cline/settings/providers.json`. Wrapping moves it into the vault and
+injects it as `ANTHROPIC_API_KEY` - which cline reads from the
+environment - into each `cline` invocation only.
+
+## Wrap it
+
+```sh
+jit wrap cline
+```
+
+jit reads the Anthropic `apiKey` from `providers.json`, stores it at
+`wrap-cline/ANTHROPIC_API_KEY`, scrubs the plaintext (original backed up
+encrypted), and installs the `~/.jit/shims/cline` shim plus the
+`wrap-cline` profile.
+
+## Verify
+
+```sh
+cline -P anthropic "say hi"
+```
+
+## How it works
+
+The shim injects `ANTHROPIC_API_KEY` from the vault into each `cline`
+process. With the file's key scrubbed, cline picks the key up from the
+environment. Details: [how wrapping works](./index.md).
+
+## Undo
+
+```sh
+jit wrap undo cline
+```
+
+## Notes
+
+- **This wraps the Anthropic API-key setup** (`-P anthropic`). Cline's
+  default hosted provider (`cline`) signs in with OAuth and stores no API
+  key in `providers.json` - nothing to wrap there, and it's never touched.
+  Other API-key providers (OpenRouter, etc.) keep their entries; only the
+  Anthropic key is vaulted.
+- **Cline runs commands as child processes**, and `ANTHROPIC_API_KEY` in
+  its environment is inherited by them - the same tradeoff as `claude`.
+  Unlike `codex` there is no scoped per-tool variable to prefer; the wrap
+  still beats a key at rest in plaintext JSON.
+- A re-`cline auth` with `-k` writes plaintext again - re-run
+  `jit wrap cline` after.

--- a/docs/wrap/copilot.md
+++ b/docs/wrap/copilot.md
@@ -1,0 +1,56 @@
+---
+title: Wrap the GitHub Copilot CLI with jit
+description: Keep your Copilot PAT out of shell exports - injected as COPILOT_GITHUB_TOKEN just-in-time.
+---
+
+# copilot - GitHub Copilot CLI
+
+Copilot CLI's programmatic auth is a fine-grained personal access token
+(with the "Copilot Requests" permission), which GitHub's docs have you
+`export` - landing a GitHub credential in a shell rc file and in every
+process your shell starts. Wrapping stores the PAT in the vault and
+injects it into each `copilot` invocation only.
+
+## Wrap it
+
+There is no standard file the PAT lives in (the interactive `/login`
+stores an OAuth session, not your PAT), so vault the token first, then
+wrap:
+
+```sh
+jit vault set wrap-copilot/COPILOT_GITHUB_TOKEN
+jit wrap copilot
+```
+
+## Verify
+
+```sh
+copilot -p "say hi"
+```
+
+## How it works
+
+The shim injects `COPILOT_GITHUB_TOKEN` from the vault - deliberately not
+`GH_TOKEN` or `GITHUB_TOKEN`, although copilot reads all three. Copilot
+runs the commands you ask it to as child processes; the generic variables
+in that inherited environment would authenticate `gh` and every git
+credential flow in every one of those children, not just Copilot itself.
+`COPILOT_GITHUB_TOKEN` is Copilot CLI's own variable, and it takes
+precedence over the other two. Details: [how wrapping works](./index.md).
+
+## Undo
+
+```sh
+jit wrap undo copilot
+```
+
+## Notes
+
+- **An interactive `/login` session is left alone.** If you signed in
+  through the browser flow, there's no PAT to wrap and no need for one -
+  the wrap is for the PAT path (automation, or avoiding the OAuth grant).
+- The PAT must be a **user-owned fine-grained token** with the
+  **Copilot Requests** permission; organization-owned tokens can't carry
+  that permission.
+- If the token is already a plaintext `export` in `~/.zshrc`,
+  `jit migrate ~/.zshrc` handles that copy.

--- a/docs/wrap/cursor-agent.md
+++ b/docs/wrap/cursor-agent.md
@@ -1,0 +1,53 @@
+---
+title: Wrap the Cursor CLI with jit
+description: Keep your Cursor API key out of shell exports - injected as CURSOR_API_KEY just-in-time.
+---
+
+# cursor-agent - Cursor CLI
+
+Cursor's CLI takes an API key for automation via the `CURSOR_API_KEY`
+environment variable, and its docs have you `export` it - which lands the
+key in a shell rc file and in every process your shell starts. Wrapping
+stores the key in the vault and injects it into each `cursor-agent`
+invocation only.
+
+## Wrap it
+
+There is no standard file the key lives in (browser login stores an OAuth
+session, not an API key), so vault the key first, then wrap:
+
+```sh
+jit vault set wrap-cursor-agent/CURSOR_API_KEY
+jit wrap cursor-agent
+```
+
+## Verify
+
+```sh
+cursor-agent status
+```
+
+## How it works
+
+The shim injects `CURSOR_API_KEY` from the vault into each `cursor-agent`
+process. Details: [how wrapping works](./index.md).
+
+## Undo
+
+```sh
+jit wrap undo cursor-agent
+```
+
+## Notes
+
+- **The installer creates two names for the same binary**: `agent`
+  (primary in Cursor's docs) and `cursor-agent` (legacy). This catalog
+  entry shims `cursor-agent` - a name that can only mean Cursor. If you
+  invoke it as `agent`, wrap that name by hand:
+  `jit wrap add agent --env CURSOR_API_KEY=wrap-cursor-agent/CURSOR_API_KEY`
+  (both shims then read the same vault secret).
+- **Browser login (`agent login`) is left alone.** It stores an OAuth
+  session, not the API key, and doesn't need wrapping - the wrap is for
+  the API-key automation path (scripts, CI, headless use).
+- If the key is already a plaintext `export` in `~/.zshrc`,
+  `jit migrate ~/.zshrc` handles that copy.

--- a/docs/wrap/index.md
+++ b/docs/wrap/index.md
@@ -58,6 +58,11 @@ One page per tool - requirements, verification, and per-tool gotchas:
 | [`claude`](./claude-code.md) | `ANTHROPIC_API_KEY` | nowhere standard - `jit vault set wrap-claude/ANTHROPIC_API_KEY` first |
 | [`gemini`](./gemini.md) | `GEMINI_API_KEY` | `~/.gemini/.env` (or `~/.env` as a fallback) |
 | [`codex`](./codex.md) | `CODEX_API_KEY` | `~/.codex/auth.json`'s `OPENAI_API_KEY` field (API-key logins only) |
+| [`cursor-agent`](./cursor-agent.md) | `CURSOR_API_KEY` | nowhere standard - `jit vault set wrap-cursor-agent/CURSOR_API_KEY` first |
+| [`copilot`](./copilot.md) | `COPILOT_GITHUB_TOKEN` | nowhere standard (login stores OAuth, not the PAT) - `jit vault set wrap-copilot/COPILOT_GITHUB_TOKEN` first |
+| [`cline`](./cline.md) | `ANTHROPIC_API_KEY` | `~/.cline/settings/providers.json` (the Anthropic provider's `apiKey`) |
+| [`opencode`](./opencode.md) | `ANTHROPIC_API_KEY` | `~/.local/share/opencode/auth.json` (the `anthropic` entry's `key`; OAuth logins untouched) |
+| [`kiro-cli`](./kiro-cli.md) | `KIRO_API_KEY` | nowhere standard (login is subscription OAuth) - `jit vault set wrap-kiro-cli/KIRO_API_KEY` first |
 | [`sentry-cli`](./sentry-cli.md) | `SENTRY_AUTH_TOKEN` | `~/.sentryclirc` (the `[auth] token`) |
 | [`snyk`](./snyk.md) | `SNYK_TOKEN` | `~/.config/configstore/snyk.json` (the `api` field) |
 | [`circleci`](./circleci.md) | `CIRCLECI_CLI_TOKEN` | `~/.circleci/cli.yml` |

--- a/docs/wrap/kiro-cli.md
+++ b/docs/wrap/kiro-cli.md
@@ -40,9 +40,9 @@ jit wrap undo kiro-cli
 
 ## Notes
 
-- **The interactive subscription login is left alone.** Signing in with
-  AWS Builder ID / Identity Center stores an OAuth session, not an API
-  key - the wrap is for the headless/API-key path (scripts, CI).
+- **The interactive subscription login is left alone.** The browser
+  sign-in stores an OAuth session, not an API key - the wrap is for the
+  headless/API-key path (scripts, CI).
 - API keys are generated in the Kiro dashboard and are only available on
   paid plans; if your subscription is admin-managed, API key generation
   has to be enabled by the administrator first.

--- a/docs/wrap/kiro-cli.md
+++ b/docs/wrap/kiro-cli.md
@@ -1,0 +1,50 @@
+---
+title: Wrap the Kiro CLI with jit
+description: Keep your Kiro API key out of shell exports - injected as KIRO_API_KEY just-in-time.
+---
+
+# kiro-cli - Kiro CLI
+
+Kiro CLI's headless mode authenticates with an API key in the
+`KIRO_API_KEY` environment variable, and the docs have you `export` it -
+which lands the key in a shell rc file, CI config, and every process your
+shell starts. Wrapping stores the key in the vault and injects it into
+each `kiro-cli` invocation only.
+
+## Wrap it
+
+There is no standard file the key lives in (the interactive login is
+subscription OAuth, not an API key), so vault the key first, then wrap:
+
+```sh
+jit vault set wrap-kiro-cli/KIRO_API_KEY
+jit wrap kiro-cli
+```
+
+## Verify
+
+```sh
+kiro-cli chat --no-interactive "say hi"
+```
+
+## How it works
+
+The shim injects `KIRO_API_KEY` from the vault into each `kiro-cli`
+process. Details: [how wrapping works](./index.md).
+
+## Undo
+
+```sh
+jit wrap undo kiro-cli
+```
+
+## Notes
+
+- **The interactive subscription login is left alone.** Signing in with
+  AWS Builder ID / Identity Center stores an OAuth session, not an API
+  key - the wrap is for the headless/API-key path (scripts, CI).
+- API keys are generated in the Kiro dashboard and are only available on
+  paid plans; if your subscription is admin-managed, API key generation
+  has to be enabled by the administrator first.
+- If the key is already a plaintext `export` in `~/.zshrc`,
+  `jit migrate ~/.zshrc` handles that copy.

--- a/docs/wrap/opencode.md
+++ b/docs/wrap/opencode.md
@@ -1,0 +1,52 @@
+---
+title: Wrap OpenCode with jit
+description: Keep your Anthropic API key out of ~/.local/share/opencode/auth.json - injected as ANTHROPIC_API_KEY just-in-time.
+---
+
+# opencode - OpenCode
+
+OpenCode's `/connect` command stores provider API keys in plaintext JSON
+at `~/.local/share/opencode/auth.json`. Wrapping moves the Anthropic key
+into the vault and injects it as `ANTHROPIC_API_KEY` - which OpenCode
+reads from the environment - into each `opencode` invocation only.
+
+## Wrap it
+
+```sh
+jit wrap opencode
+```
+
+jit reads the Anthropic `key` from `auth.json`, stores it at
+`wrap-opencode/ANTHROPIC_API_KEY`, scrubs the plaintext (original backed
+up encrypted), and installs the `~/.jit/shims/opencode` shim plus the
+`wrap-opencode` profile.
+
+## Verify
+
+```sh
+opencode run "say hi"
+```
+
+## How it works
+
+The shim injects `ANTHROPIC_API_KEY` from the vault into each `opencode`
+process. With the file's key scrubbed, OpenCode picks the key up from the
+environment. Details: [how wrapping works](./index.md).
+
+## Undo
+
+```sh
+jit wrap undo opencode
+```
+
+## Notes
+
+- **Only the Anthropic API key is vaulted.** Other providers'
+  credentials in the same `auth.json` - including OAuth logins, which
+  store tokens rather than an API key - are left exactly as they were.
+- **A Claude subscription (OAuth) login has no API key to wrap**; if
+  that's how you connected Anthropic, there's nothing to find, and the
+  wrap installs the shim anyway, ready for
+  `jit vault set wrap-opencode/ANTHROPIC_API_KEY` if you switch to a key.
+- A re-`/connect` with an API key writes plaintext again - re-run
+  `jit wrap opencode` after.

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -160,6 +160,36 @@ const (
 	// greppable line in the same trail as every unlock. Enriched with the
 	// peer's provenance (By/ByPID/LaunchedBy) when the kernel still names it.
 	KindError = "error"
+	// KindServe marks one mount read reaching its content decision: a reader
+	// opened a live mount and got either the decoy or the real value. Op is
+	// OpServeDecoy or OpServeReal, Cause says WHY that verdict, Labels names
+	// the credential, and By/ByPID/LaunchedBy carry internal/lineage's
+	// best-effort answer to who read it.
+	//
+	// The decoy half is the point: a process with no business reading a
+	// credential file, quietly handed a fake one, is a honeytoken-shaped
+	// signal — and until this existed jit produced that signal on every
+	// single read and then discarded it, keeping only the newest one per
+	// mount, in memory, gone at the next service restart. The real half
+	// closes the other end of the same question: a KindApproved event
+	// proves a grant was AUTHORIZED, never that the credential was actually
+	// read, and those are different facts on the day one matters.
+	//
+	// Necessarily collapsed before it is ever written (see the CLI's
+	// serveAuditor): the serve path runs once per reader rendezvous and a
+	// file-watcher loop re-reads a mount continuously, so an uncollapsed
+	// serve event would be an eviction primitive against this very ring —
+	// the same hazard recordRejectedClass defends against, arrived at from
+	// the other direction.
+	KindServe = "serve"
+)
+
+// The Op values a KindServe event carries: which content the reader got.
+// They are the serve's outcome, so `jit audit` renders them on the status
+// axis (--status decoy / --status real) rather than inventing a new one.
+const (
+	OpServeDecoy = "decoy"
+	OpServeReal  = "real"
 )
 
 // Response answers a Request.
@@ -267,6 +297,14 @@ type SessionEvent struct {
 	// (see challengeReason); this is the investigative version.
 	By    string `json:"by,omitempty"`
 	ByPID int32  `json:"by_pid,omitempty"`
+	// ByLikely marks By/ByPID as an identity carried over from an earlier
+	// scan rather than observed for THIS event — true on a mount serve whose
+	// lineage scan raced the reader's open but found the same process still
+	// alive and still holding the mount (internal/cli's identifyReader). It
+	// means "almost certainly this process" and must never be rendered as
+	// certainty; an audit trail that lies is worse than one that admits it
+	// doesn't know.
+	ByLikely bool `json:"by_likely,omitempty"`
 	// LaunchedBy is the nearest ancestor that explains the call — "claude",
 	// "Code" — with the shells that merely relayed it skipped. Empty when a
 	// human ran jit at a prompt themselves, because then there is nothing to
@@ -326,6 +364,13 @@ type MountRevealStatus struct {
 	// record was a line in the agent's own log file. Nil when nothing has
 	// read the mount since the agent process started (this is in-memory
 	// state, not persisted).
+	//
+	// Deliberately still only the LATEST, and still not persisted: this
+	// answers "what is happening to this mount right now", which is the
+	// question `jit service status` is open to answer. Every serve is ALSO
+	// recorded durably as a KindServe event (collapsed — see the CLI's
+	// serveAuditor), and that is what answers "what happened last Tuesday".
+	// Neither substitutes for the other, so don't collapse them into one.
 	LastServe *MountServeEvent `json:"last_serve,omitempty"`
 	// Grants are the run-scoped reveal grants currently active on this
 	// mount (usually zero or one): each names the jit-run target whose

--- a/internal/audit/wrapcli_test.go
+++ b/internal/audit/wrapcli_test.go
@@ -105,6 +105,57 @@ func TestScanWrappableCLITokensSkipsEnvFamilySources(t *testing.T) {
 	}
 }
 
+// Cline's providers.json sits in BOTH scanners' territory: ScanAgentStores
+// sweeps it with the vendor patterns (an sk-ant- key matches) and
+// ScanWrappableCLITokens extracts from it by catalog selector. The whole
+// scan must report the key once, as the wrap finding — the sweep's
+// exposed_secret duplicate for the same file+value falls to
+// dropRedundantExposedSecrets, exactly the seam codex's auth.json has
+// composed through since both scanners existed. This test pins that the
+// NEW overlap rides the same rails rather than assuming it.
+func TestScanWrappableCLITokensAndAgentStoreSweepDontDoubleReport(t *testing.T) {
+	home := t.TempDir()
+	// A value the Anthropic vendor pattern genuinely matches, so the
+	// collision is real, not hypothetical.
+	key := "sk-ant-api03-FIXTUREclineOverlap0123456789abcdefFIXTURE"
+	writeWrapFixture(t, home, ".cline/settings/providers.json",
+		`{
+  "version": 1,
+  "providers": {
+    "anthropic": {
+      "settings": {
+        "provider": "anthropic",
+        "apiKey": "`+key+`",
+        "model": "claude-sonnet-5"
+      }
+    }
+  }
+}
+`)
+
+	all, _, err := Scan(Config{HomeDir: home, ScannerVersion: "test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(home, ".cline/settings/providers.json")
+	var got []Finding
+	for _, f := range all {
+		if f.FilePath == target {
+			got = append(got, f)
+		}
+	}
+	if len(got) != 1 {
+		t.Fatalf("cline's providers.json reported %d times across the scan, want 1: %+v", len(got), got)
+	}
+	if got[0].FindingType != FindingTypeWrappableCLIToken {
+		t.Errorf("the surviving finding is %s, want the actionable %s",
+			got[0].FindingType, FindingTypeWrappableCLIToken)
+	}
+	if !strings.Contains(got[0].Evidence, "jit wrap cline") {
+		t.Errorf("surviving finding doesn't name the fix; evidence = %q", got[0].Evidence)
+	}
+}
+
 func TestScanWrappableCLITokensOneFindingPerTool(t *testing.T) {
 	home := t.TempDir()
 	// ngrok's v3 and v2 selectors both match this file; only the first

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -216,6 +216,14 @@ var agentRunCmd = &cobra.Command{
 			hist.append(e)
 			fmt.Fprintf(stderr, "jit service: %s\n", e.Cause)
 		}
+		// Mount reads join the same trail: which reader got a decoy, which got
+		// the real value, and why. Collapsed by the auditor before they reach
+		// here — a watcher loop must not be able to evict the history it is
+		// being written into — and started only now that there is somewhere
+		// durable to put them.
+		mounts.serveAudit.emit = hist.append
+		mounts.serveAudit.labelFn = mounts.serveAuditLabel
+		mounts.serveAudit.start()
 
 		if err := server.Listen(); err != nil {
 			return fmt.Errorf("jit service run: %w", err)

--- a/internal/cli/agenthistory.go
+++ b/internal/cli/agenthistory.go
@@ -58,13 +58,21 @@ func newHistoryLog(root string, stderr io.Writer) *historyLog {
 // of session events (they used to be double-written as prose into agent.log,
 // which carried a much larger 5MB cap): `jit audit` now reads only here, so
 // the depth that was effectively in agent.log lives here instead.
+//
+// Mount serves (KindServe) are the one kind that could plausibly test this,
+// since a file watcher re-reads a mount without limit. They can't, because
+// they are collapsed over serveAuditWindow before they are written: one mount
+// pinned by one looping reader costs ~720 events a day at the absolute worst,
+// so even that pathological case retains a fortnight rather than evicting the
+// unlocks. That bound is the whole reason serveAuditor exists — see its file.
 const historyMaxBytes = 2 * 1024 * 1024
 
-// append writes one event as a JSON line. Open-per-append on purpose:
-// events are a handful per day, and never holding an fd means a trim (or a
-// curious user truncating the file by hand) can't strand writes behind a
-// stale offset. Failures are logged and swallowed — durable history is a
-// nicety, and a full disk must never make an unlock fail.
+// append writes one event as a JSON line. Open-per-append on purpose: events
+// arrive at human pace (unlocks, grants, and mount serves already collapsed
+// to at most one per mount/reader per serveAuditWindow), and never holding an
+// fd means a trim (or a curious user truncating the file by hand) can't
+// strand writes behind a stale offset. Failures are logged and swallowed —
+// durable history is a nicety, and a full disk must never make an unlock fail.
 func (h *historyLog) append(e agent.SessionEvent) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/internal/cli/agenthistory.go
+++ b/internal/cli/agenthistory.go
@@ -62,8 +62,8 @@ func newHistoryLog(root string, stderr io.Writer) *historyLog {
 // Mount serves (KindServe) are the one kind that could plausibly test this,
 // since a file watcher re-reads a mount without limit. They can't, because
 // they are collapsed over serveAuditWindow before they are written: one mount
-// pinned by one looping reader costs ~720 events a day at the absolute worst,
-// so even that pathological case retains a fortnight rather than evicting the
+// pinned by one looping reader costs ~24 events a day at the absolute worst,
+// so even that pathological case retains a year rather than evicting the
 // unlocks. That bound is the whole reason serveAuditor exists — see its file.
 const historyMaxBytes = 2 * 1024 * 1024
 

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -72,6 +72,9 @@ var auditKindAliases = map[string]string{
 	"grant":    "grant",
 	"approve":  "grant",
 	"approved": "grant",
+	"serve":    "serve",
+	"read":     "serve",
+	"mount":    "serve",
 }
 
 // compileAuditFilter turns the raw flags into an auditFilter, rejecting an
@@ -90,7 +93,7 @@ func compileAuditFilter() (auditFilter, error) {
 				}
 				canon, ok := auditKindAliases[k]
 				if !ok {
-					return f, fmt.Errorf("unknown --kind %q: choose from cmd, unlock, use, grant, lock, service, error (denials are --status denied)", k)
+					return f, fmt.Errorf("unknown --kind %q: choose from cmd, unlock, use, grant, serve, lock, service, error (denials are --status denied)", k)
 				}
 				f.kinds[canon] = true
 			}
@@ -99,10 +102,14 @@ func compileAuditFilter() (auditFilter, error) {
 	if auditStatus != "" {
 		s := strings.ToLower(auditStatus)
 		switch s {
-		case "ok", "failed", "denied", "approved":
+		// decoy/real are a mount serve's outcome, so they belong on this axis
+		// rather than on a flag of their own: --status decoy is the tripwire
+		// query ("what read a credential file and got a fake"), --status real
+		// its counterpart ("what actually received the value").
+		case "ok", "failed", "denied", "approved", "decoy", "real":
 			f.status = s
 		default:
-			return f, fmt.Errorf("unknown --status %q: choose from ok, failed, denied, approved", auditStatus)
+			return f, fmt.Errorf("unknown --status %q: choose from ok, failed, denied, approved, decoy, real", auditStatus)
 		}
 	}
 	var err error
@@ -251,10 +258,19 @@ var auditCmd = &cobra.Command{
 		"Repeated rejections collapse into one line carrying a count; a collapsed line\n" +
 		"names the first caller of that window, because keying them per caller would let\n" +
 		"a flood of throwaway processes push every real event out of the history.\n\n" +
+		"Mount reads are here too, as kind=serve: every time a reader opened a live\n" +
+		"mount, whether it got the decoy (--status decoy) or the real value (--status\n" +
+		"real), why, and — best-effort, from the kernel — which program read it and what\n" +
+		"launched that program. A decoy read is jit working as designed, and it is also\n" +
+		"the one signal that names a process reading a credential file it has no business\n" +
+		"in. Same-mount, same-reader, same-verdict reads inside a short window collapse\n" +
+		"into one line carrying a count, because a file watcher re-reads a mount\n" +
+		"continuously and an uncollapsed read would push every unlock out of the log.\n\n" +
 		"Output is a grouped text timeline, newest first. --format logfmt prints one\n" +
 		"key=value line per event instead, so it reads and greps like a real service\n" +
 		"log. Narrow either without grep using the flags: --kind\n" +
-		"cmd,unlock,use,grant,lock,service,error, --status ok|failed|denied|approved,\n" +
+		"cmd,unlock,use,grant,serve,lock,service,error, --status\n" +
+		"ok|failed|denied|approved|decoy|real,\n" +
 		"--since and --until\n" +
 		"(an age like 2h/3d or a date), --parent (the launching ancestor, e.g. claude),\n" +
 		"--secret (a secret name an unlock touched), --user, and --grep (a regexp over the\n" +
@@ -808,6 +824,60 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 			pairs = append(pairs, kv{"count", strconv.FormatInt(e.Count, 10)})
 		}
 		pairs = appendAuthContext(pairs, home, e)
+	case agent.KindServe:
+		// One mount read, collapsed. status carries the verdict (decoy | real)
+		// rather than a new axis, because that IS the serve's outcome and
+		// --status is where a reader already looks for one. The decoy rows are
+		// the tripwire — amber, and counted in the header — while the real ones
+		// answer the question a grant approval never could: not "was this
+		// authorized" but "was it actually read".
+		kind = "serve"
+		status = agent.OpServeDecoy
+		if e.Op == agent.OpServeReal {
+			status = agent.OpServeReal
+		}
+		level := "info"
+		if status == agent.OpServeDecoy {
+			level = "warn"
+			lineColor = cWarn
+		}
+		reader := serveReaderName(e)
+		if status == agent.OpServeDecoy {
+			subject = "decoy served to " + reader
+		} else {
+			subject = "real value served to " + reader
+		}
+		if e.Count > 1 {
+			subject = fmt.Sprintf("%s ×%d", subject, e.Count)
+		}
+		pairs = append(pairs,
+			kv{"level", level}, kv{"kind", "serve"}, kv{"status", status})
+		if len(e.Labels) > 0 {
+			pairs = append(pairs, kv{"mount", strings.Join(e.Labels, ", ")})
+		}
+		if e.Count > 1 {
+			pairs = append(pairs, kv{"count", strconv.FormatInt(e.Count, 10)})
+		}
+		if e.By != "" {
+			pairs = append(pairs, kv{"reader", shortenCommand(home, e.By)})
+		}
+		if e.ByPID != 0 {
+			pairs = append(pairs, kv{"reader_pid", strconv.FormatInt(int64(e.ByPID), 10)})
+		}
+		// The inference marker travels with the identity it qualifies, in both
+		// views: a carried-over reader is "almost certainly" this process, and
+		// a trail that renders that as certainty is worse than one that says
+		// less (identifyReader's own doctrine).
+		if e.ByLikely {
+			pairs = append(pairs, kv{"reader_likely", "true"})
+		}
+		if e.LaunchedBy != "" {
+			pairs = append(pairs, kv{"parent", e.LaunchedBy})
+		}
+		detail = e.Cause
+		if e.Cause != "" {
+			pairs = append(pairs, kv{"reason", e.Cause})
+		}
 	case agent.KindError:
 		// A socket-boundary failure the service refused or hit: a rejected
 		// peer, a malformed request, the accept loop dying. op names which and
@@ -862,6 +932,25 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 		subject: subject,
 		detail:  detail,
 	}
+}
+
+// serveReaderName names who read a mount, for the human report's subject.
+//
+// Three honest states, never four: the program's own name when lineage saw it
+// open the mount, the same name marked "likely" when the identity is carried
+// over from an earlier scan of that mount, and an explicit admission when the
+// scan missed it outright. A fast-closing reader legitimately evades the scan
+// (which is exactly why lineage is audit-only and gates nothing), so the third
+// case is normal rather than exceptional and must read that way.
+func serveReaderName(e agent.SessionEvent) string {
+	if e.By == "" {
+		return "an unidentified reader"
+	}
+	name := filepath.Base(e.By)
+	if e.ByLikely {
+		return name + " (likely)"
+	}
+	return name
 }
 
 // authMethodLabel names the local-auth method the way the dialog does, for
@@ -931,10 +1020,10 @@ func init() {
 	auditCmd.Flags().StringVar(&auditFormat, "format", "text", `output format: "text" (default), "logfmt" (one key=value line per event), or "json"`)
 	auditCmd.Flags().IntVar(&auditLimit, "limit", 50, "show at most this many recent matching entries (0 for all)")
 	auditCmd.Flags().BoolVarP(&auditFollow, "follow", "f", false, "print the matching tail, then stream new entries live (text only)")
-	auditCmd.Flags().StringSliceVar(&auditKinds, "kind", nil, "only these kinds (comma-separated): cmd, unlock, use, grant, lock, service, error")
+	auditCmd.Flags().StringSliceVar(&auditKinds, "kind", nil, "only these kinds (comma-separated): cmd, unlock, use, grant, serve, lock, service, error")
 	auditCmd.Flags().StringVar(&auditSince, "since", "", `only entries at or after this time: an age (2h, 90m, 3d) or a date ("2026-07-23" or "2026-07-23 09:00")`)
 	auditCmd.Flags().StringVar(&auditUntil, "until", "", "only entries at or before this time (same forms as --since)")
-	auditCmd.Flags().StringVar(&auditStatus, "status", "", "only this status: ok, failed, denied, or approved")
+	auditCmd.Flags().StringVar(&auditStatus, "status", "", "only this status: ok, failed, denied, approved, decoy, or real")
 	auditCmd.Flags().StringVar(&auditUser, "user", "", "only commands this user ran (auth events carry no user)")
 	auditCmd.Flags().StringVar(&auditParent, "parent", "", "only entries whose launched-by ancestor contains this (e.g. claude)")
 	auditCmd.Flags().StringVar(&auditSecret, "secret", "", "only auth events that touched a secret whose name contains this")

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -49,6 +49,170 @@ func seedAuditFixtures(t *testing.T, home string) {
 	})
 }
 
+// seedServeFixtures plants the two mount-read outcomes: a decoy handed to a
+// process nobody granted anything to, and the real value handed to a tool
+// inside a grant.
+func seedServeFixtures(t *testing.T, home string) {
+	t.Helper()
+	root := filepath.Join(home, "Library", "Application Support", "jitpass")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	h := newHistoryLog(root, nil)
+	h.append(agent.SessionEvent{
+		UnixTime: 5000, Kind: agent.KindServe, Op: agent.OpServeDecoy,
+		By: "/usr/local/bin/node", ByPID: 48213, LaunchedBy: "Code",
+		Labels: []string{"gcp"}, Count: 34,
+		Cause: "no jit run grant or consent approval covered the reader",
+	})
+	h.append(agent.SessionEvent{
+		UnixTime: 5100, Kind: agent.KindServe, Op: agent.OpServeReal,
+		By: "/opt/homebrew/bin/terraform", ByPID: 48044, LaunchedBy: "claude",
+		Labels: []string{"aws"}, Count: 1,
+		Cause: "authorized by a jit run grant",
+	})
+}
+
+// A decoy read is the honeytoken-shaped signal the mount design produces on
+// every read and, before this, discarded: it must render as its own kind, name
+// the reader and its launcher, and say why that reader got a fake.
+func TestAuditRendersDecoyServe(t *testing.T) {
+	home := withFixtureHome(t)
+	seedServeFixtures(t, home)
+
+	out, err := execAuditLogfmt(t)
+	if err != nil {
+		t.Fatalf("jit audit: %v", err)
+	}
+	for _, want := range []string{
+		"kind=serve", "status=decoy", "mount=gcp", "count=34",
+		"reader_pid=48213", "parent=Code",
+		`reason="no jit run grant or consent approval covered the reader"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("decoy serve line missing %q, got:\n%s", want, out)
+		}
+	}
+}
+
+// The counterpart fact a grant approval can never supply: the credential was
+// not just authorized, it was actually read, by this program.
+func TestAuditRendersRealServe(t *testing.T) {
+	home := withFixtureHome(t)
+	seedServeFixtures(t, home)
+
+	out, err := execAuditLogfmt(t, "--status", "real")
+	if err != nil {
+		t.Fatalf("jit audit --status real: %v", err)
+	}
+	if !strings.Contains(out, "status=real") || !strings.Contains(out, "mount=aws") {
+		t.Errorf("--status real dropped the real serve, got:\n%s", out)
+	}
+	if strings.Contains(out, "status=decoy") {
+		t.Errorf("--status real leaked a decoy serve, got:\n%s", out)
+	}
+}
+
+// --status decoy is the tripwire query. It must narrow to decoy serves and
+// nothing else, including excluding the real serves of the same kind.
+func TestAuditFilterByStatusDecoy(t *testing.T) {
+	home := withFixtureHome(t)
+	seedAuditFixtures(t, home)
+	seedServeFixtures(t, home)
+
+	out, err := execAuditLogfmt(t, "--status", "decoy")
+	if err != nil {
+		t.Fatalf("jit audit --status decoy: %v", err)
+	}
+	if !strings.Contains(out, "status=decoy") {
+		t.Errorf("--status decoy dropped the decoy serve, got:\n%s", out)
+	}
+	for _, unwanted := range []string{"status=real", "kind=cmd", "kind=unlock"} {
+		if strings.Contains(out, unwanted) {
+			t.Errorf("--status decoy leaked %q, got:\n%s", unwanted, out)
+		}
+	}
+}
+
+func TestAuditFilterByKindServe(t *testing.T) {
+	home := withFixtureHome(t)
+	seedAuditFixtures(t, home)
+	seedServeFixtures(t, home)
+
+	out, err := execAuditLogfmt(t, "--kind", "serve")
+	if err != nil {
+		t.Fatalf("jit audit --kind serve: %v", err)
+	}
+	if n := strings.Count(out, "kind=serve"); n != 2 {
+		t.Errorf("--kind serve showed %d serve lines, want 2, got:\n%s", n, out)
+	}
+	if strings.Contains(out, "kind=cmd") {
+		t.Errorf("--kind serve leaked a command line, got:\n%s", out)
+	}
+}
+
+// --parent is what makes this worth having: "what did the things Claude
+// launched actually read". It must reach serve events, not only auth ones.
+func TestAuditFilterByParentReachesServes(t *testing.T) {
+	home := withFixtureHome(t)
+	seedServeFixtures(t, home)
+
+	out, err := execAuditLogfmt(t, "--parent", "Code")
+	if err != nil {
+		t.Fatalf("jit audit --parent: %v", err)
+	}
+	if !strings.Contains(out, "status=decoy") {
+		t.Errorf("--parent Code dropped the serve Code's process caused, got:\n%s", out)
+	}
+	if strings.Contains(out, "status=real") {
+		t.Errorf("--parent Code leaked a claude-launched serve, got:\n%s", out)
+	}
+}
+
+// A carried-over reader identity is an inference (identifyReader's doctrine:
+// the scan is rate-limited and races a fast-closing reader). Neither view may
+// present it as certainty.
+func TestAuditMarksAnInferredReaderAsLikely(t *testing.T) {
+	e := authEntry("/Users/alice", agent.SessionEvent{
+		UnixTime: 6000, Kind: agent.KindServe, Op: agent.OpServeDecoy,
+		By: "/usr/local/bin/node", ByPID: 999, ByLikely: true, Labels: []string{"gcp"},
+	})
+	if !strings.Contains(e.subject, "likely") {
+		t.Errorf("report subject = %q, want it to mark the identity as an inference", e.subject)
+	}
+	if !strings.Contains(e.match, "reader_likely=true") {
+		t.Errorf("logfmt line = %q, want reader_likely=true", e.match)
+	}
+}
+
+// A fast-closing reader legitimately evades the scan, so "we don't know" is a
+// normal outcome and must read as an admission rather than as a name.
+func TestAuditServeWithoutAnIdentifiedReader(t *testing.T) {
+	e := authEntry("/Users/alice", agent.SessionEvent{
+		UnixTime: 6000, Kind: agent.KindServe, Op: agent.OpServeDecoy, Labels: []string{"gcp"},
+	})
+	if !strings.Contains(e.subject, "unidentified") {
+		t.Errorf("report subject = %q, want it to admit the reader wasn't identified", e.subject)
+	}
+	if strings.Contains(e.match, "reader=") {
+		t.Errorf("logfmt line claimed a reader it never had: %q", e.match)
+	}
+}
+
+// The header counts decoy ROWS, not the collapsed count each row carries: one
+// looping watcher would otherwise report thousands and read like a breach.
+func TestAuditHeaderCountsDecoyRowsNotReads(t *testing.T) {
+	var buf bytes.Buffer
+	entries := []auditEntry{
+		{t: time.Unix(5000, 0), kind: "serve", status: "decoy", subject: "decoy served to node ×34"},
+		{t: time.Unix(4000, 0), kind: "serve", status: "real", subject: "real value served to terraform"},
+	}
+	writeAuditHeader(&buf, entries)
+	if got := buf.String(); !strings.Contains(got, "1 decoy read") {
+		t.Errorf("header = %q, want it to count 1 decoy row (not 34 reads)", got)
+	}
+}
+
 // TestCommandEntrySurfacesFreshAuth: a command that forced its own fresh
 // Touch ID/passcode (jit migrate undo/remove set Record.Auth) must show that
 // in the audit line, so the trail proves a plaintext-restoring or

--- a/internal/cli/auditreport.go
+++ b/internal/cli/auditreport.go
@@ -78,6 +78,9 @@ func printAuditReport(w io.Writer, entries []auditEntry, filtered bool) {
 	if _, denied := auditOutcomeCounts(entries); denied > 0 {
 		hint += " · " + cPath.Sprint("--status denied") + " for refusals"
 	}
+	if auditDecoyRows(entries) > 0 {
+		hint += " · " + cPath.Sprint("--status decoy") + " for reads that got decoys"
+	}
 	hint += " · --format logfmt for the machine form"
 	termtext.Wrap(w, 4, "    ", hint)
 }
@@ -111,6 +114,13 @@ func writeAuditHeader(w io.Writer, entries []auditEntry) {
 	if denied > 0 {
 		head += fmt.Sprintf(" · %d denied", denied)
 	}
+	// Decoy reads are counted in ROWS, not in the collapsed Count each row
+	// carries: the header's job is "how much of what follows is this", and a
+	// single looping watcher would otherwise report thousands and read like a
+	// breach.
+	if decoy := auditDecoyRows(entries); decoy > 0 {
+		head += fmt.Sprintf(" · %s", countWord(decoy, "decoy read", "decoy reads"))
+	}
 	_, _ = fmt.Fprintln(w, head)
 	fmt.Fprintln(w)
 }
@@ -127,6 +137,18 @@ func auditOutcomeCounts(entries []auditEntry) (failed, denied int) {
 		}
 	}
 	return failed, denied
+}
+
+// auditDecoyRows counts serve events that handed over a decoy — the rows the
+// header calls out and the footer offers a filter for.
+func auditDecoyRows(entries []auditEntry) int {
+	n := 0
+	for _, e := range entries {
+		if e.kind == "serve" && e.status == "decoy" {
+			n++
+		}
+	}
+	return n
 }
 
 func sameDay(a, b time.Time) bool {
@@ -305,6 +327,12 @@ func auditGlyph(e auditEntry) (string, *color.Color) {
 	case e.status == "denied":
 		return glyphWarn, cWarn
 	case e.kind == "lock":
+		return glyphWarn, cWarn
+	// A decoy serve is jit working exactly as designed, so it is not a risk —
+	// but it is the row a reader is scanning for, and internal/style already
+	// assigns amber ○ to "decoy". A real serve is glyphOK's documented
+	// "serving real", which falls through below.
+	case e.status == "decoy":
 		return glyphWarn, cWarn
 	default:
 		return glyphOK, cOK

--- a/internal/cli/mountgrants.go
+++ b/internal/cli/mountgrants.go
@@ -171,14 +171,35 @@ func (m *mountManager) serveContent(path string, sm *servedMount) []byte {
 		}
 	}
 
+	now := time.Now()
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
 	content, decoy := sm.decoy, true
 	if sm.real != nil && authorized {
 		content, decoy = sm.real, false
 	}
-	sm.lastServe = &serveRecord{at: time.Now(), decoy: decoy, reader: sm.pendingReader, grantServed: !decoy && grantServed}
+	rec := serveRecord{at: now, decoy: decoy, reader: sm.pendingReader, grantServed: !decoy && grantServed}
+	sm.lastServe = &rec
+	hadReal, resolveErr := sm.real != nil, sm.lastResolveErr
+	sm.mu.Unlock()
+
+	// Durable audit, outside sm.mu on purpose: the auditor takes its own lock
+	// and a finished aggregate is appended to a file, neither of which belongs
+	// on a mount's critical section — every reader of every mount waits behind
+	// it. The auditor collapses before writing, so this call is a map lookup
+	// and a counter increment on all but one read in a window.
+	m.serveAudit.record(now, path, serveReason(decoy, grantServed, hadReal, resolveErr), rec)
 	return content
+}
+
+// serveAuditLabel names the credential a mount holds the way the user would,
+// so `jit audit --secret gcp` finds reads of the gcp mount. Falls back to the
+// display path, which is what a project .env has instead of a name — an
+// unnamed mount must still be identifiable in the trail.
+func (m *mountManager) serveAuditLabel(path string) string {
+	if cred, ok := m.credentialMount(path); ok {
+		return cred
+	}
+	return displayPath(m.home, path)
 }
 
 // consentVerdict caches serveContent's best-effort consent decision for one

--- a/internal/cli/mountmanager.go
+++ b/internal/cli/mountmanager.go
@@ -102,6 +102,12 @@ type mountManager struct {
 	stdout     io.Writer
 	stderr     io.Writer
 
+	// serveAudit turns mount reads into durable `jit audit` events, collapsed
+	// so a watcher loop can't evict the trail it is being written to. Zero
+	// value (no emit) is inert, so every test that constructs a bare
+	// mountManager keeps working and pays nothing.
+	serveAudit serveAuditor
+
 	mu     sync.Mutex
 	wg     sync.WaitGroup
 	served map[string]*servedMount
@@ -174,11 +180,13 @@ type readerIdentity struct {
 }
 
 // serveRecord is one completed content decision: what a connected reader
-// was served, when, and (best-effort) by whom. Kept as each mount's
-// single most recent event — enough for `jit service status` to answer
-// "why did my app get decoys" without a log spelunk, and the natural
-// first cut of RFC.md §5's anomaly-signal scope without building any of
-// its persistence.
+// was served, when, and (best-effort) by whom. Two consumers, deliberately
+// different in lifetime: each mount keeps its single most recent record so
+// `jit service status` can answer "why did my app get decoys" about right
+// now, and every record is also handed to serveAuditor, which collapses
+// them into the durable `jit audit` trail (RFC.md §5's anomaly signal).
+// The in-memory one answers "what is happening"; the durable one answers
+// "what happened last Tuesday", and neither substitutes for the other.
 type serveRecord struct {
 	at     time.Time
 	decoy  bool
@@ -886,4 +894,7 @@ func (m *mountManager) shutdown() {
 		sm.cancel()
 	}
 	m.wg.Wait()
+	// After wg.Wait, so the last in-flight serve's event is already recorded
+	// and gets written by this flush rather than being dropped.
+	m.serveAudit.stopFlusher()
 }

--- a/internal/cli/mountserveaudit.go
+++ b/internal/cli/mountserveaudit.go
@@ -1,0 +1,292 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"sync"
+	"time"
+
+	"github.com/jitpass/jit/internal/agent"
+)
+
+// Making a mount read durable in `jit audit` is mostly a volume problem, not
+// a plumbing one.
+//
+// The signal is worth having: a process with no business reading a credential
+// file, quietly handed a decoy, is honeytoken-shaped, and jit already knows
+// the mount, the verdict and (best-effort, via internal/lineage) who read it.
+// It produced that on EVERY read and kept only the newest one per mount, in
+// memory, discarded at the next service restart.
+//
+// The reason it can't simply be appended is that serveContent runs once per
+// reader rendezvous, and the readers that matter most are exactly the ones
+// that loop: a dev server's file watcher re-reads a mount continuously
+// (readStormThreshold and readLogMinGap exist because 635k identical stderr
+// lines in one afternoon was a reported bug). agent-history.jsonl is capped
+// at historyMaxBytes and the ring at MaxSessionEvents, both evicting
+// oldest-first — so an uncollapsed serve event is an eviction primitive
+// against the very trail it is being added to, quietly pushing out every real
+// unlock and denial. That is the hazard recordRejectedClass documents,
+// reached from the other direction: there a hostile caller mints events, here
+// an ordinary watcher does it by accident, and the trail is destroyed either
+// way.
+//
+// So serves collapse BEFORE they are written. Same discipline as the agent's
+// use events, with the aggregation key chosen so a collapse can never merge
+// two facts a reader would need apart: mount, reader identity, and the
+// decoy/real verdict. A watcher hammering one mount is one line carrying a
+// count; the same mount read by a DIFFERENT process, or handed different
+// content, is always its own line.
+type serveAuditor struct {
+	// window is how long one aggregate accumulates before it is written.
+	window time.Duration
+	// emit appends a finished event to the durable trail. Nil disables the
+	// auditor entirely (every test that doesn't care, and any future caller
+	// with no history file), which is why every method tolerates a nil
+	// receiver field rather than requiring a constructor.
+	emit func(agent.SessionEvent)
+	// labelFn names the credential a mount holds. Resolved through labels
+	// below rather than called per read: the lookup walks jit's global-mount
+	// table building candidate paths, which is cheap once and wasteful on
+	// every rendezvous of a mount being read in a loop. Nil falls back to the
+	// mount path, which is always identifiable if not always pretty.
+	labelFn func(mount string) string
+
+	mu      sync.Mutex
+	pending map[serveKey]*serveAggregate
+	// labels caches labelFn per mount path. A mount's credential name cannot
+	// change while it is mounted, so this never needs invalidating.
+	labels map[string]string
+	// stop closes the flusher goroutine; nil until start() is called.
+	stop chan struct{}
+	done chan struct{}
+}
+
+// serveAuditWindow is how long same-mount, same-reader, same-verdict serves
+// merge into one durable event.
+//
+// Chosen against the two failure modes, not for a round number. Too short and
+// a watcher loop still floods the trail: at readLogMinGap's 30s a single
+// looping mount would mint 2,880 events a day, enough to evict a week of real
+// unlocks. Too long and `jit audit --follow` stops being a live view of what
+// is reading your credentials, which is most of the point of recording it.
+// Two minutes keeps a looping mount to ~720 events/day worst case while still
+// surfacing a read well inside the time it takes to notice something is off.
+const serveAuditWindow = 2 * time.Minute
+
+// serveAuditFlushInterval paces the background flush. An aggregate is written
+// when its window closes even if nothing reads the mount again — without this
+// a single decoy read on an otherwise idle machine would sit unwritten until
+// the next lock or shutdown, which is precisely the read most worth seeing
+// promptly. Deliberately finer than serveAuditWindow so an aggregate is never
+// held much past it.
+const serveAuditFlushInterval = 15 * time.Second
+
+// maxPendingServes bounds the pending map. The ordinary key space is small
+// (mounts × live readers), but a burst of short-lived readers each get their
+// own pid and therefore their own key, so the map needs a ceiling that isn't
+// "however many processes the machine can spawn". Hitting it flushes
+// everything rather than dropping anything: the events are already collapsed,
+// and writing them early costs a slightly shorter window, not a lost fact.
+const maxPendingServes = 64
+
+// serveKey is one aggregate's identity. Deliberately includes the reader and
+// the verdict: collapsing across either would merge facts an investigation
+// needs separated ("who read it" and "what did they get").
+type serveKey struct {
+	mount     string
+	readerPID int32
+	reader    string
+	decoy     bool
+}
+
+type serveAggregate struct {
+	start time.Time
+	event agent.SessionEvent
+}
+
+// start launches the background flusher. Safe to call with no emit set (it
+// does nothing), and safe to call once — the manager owns the lifecycle and
+// calls stopFlusher from shutdown.
+func (a *serveAuditor) start() {
+	if a == nil || a.emit == nil || a.stop != nil {
+		return
+	}
+	a.stop = make(chan struct{})
+	a.done = make(chan struct{})
+	go func() {
+		defer close(a.done)
+		t := time.NewTicker(serveAuditFlushInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-a.stop:
+				return
+			case now := <-t.C:
+				a.emitAll(a.take(false, now))
+			}
+		}
+	}()
+}
+
+// stopFlusher ends the background flusher and writes everything still
+// pending, so a service shutting down doesn't discard the window it was in
+// the middle of.
+func (a *serveAuditor) stopFlusher() {
+	if a == nil {
+		return
+	}
+	if a.stop != nil {
+		close(a.stop)
+		<-a.done
+		a.stop, a.done = nil, nil
+	}
+	a.emitAll(a.take(true, time.Now()))
+}
+
+// record folds one completed serve into its aggregate, writing out any
+// aggregate whose window has closed. reason is why this reader got this
+// content.
+func (a *serveAuditor) record(now time.Time, mount, reason string, rec serveRecord) {
+	if a == nil || a.emit == nil {
+		return
+	}
+	key := serveKey{mount: mount, readerPID: rec.reader.pid, reader: rec.reader.execPath, decoy: rec.decoy}
+
+	a.mu.Lock()
+	if a.pending == nil {
+		a.pending = map[serveKey]*serveAggregate{}
+	}
+	agg := a.pending[key]
+	if agg == nil {
+		label := a.labelLocked(mount)
+		op := agent.OpServeReal
+		if rec.decoy {
+			op = agent.OpServeDecoy
+		}
+		e := agent.SessionEvent{
+			UnixTime: now.Unix(),
+			Kind:     agent.KindServe,
+			Op:       op,
+			Cause:    reason,
+		}
+		if rec.reader.identified {
+			e.By = rec.reader.execPath
+			e.ByPID = rec.reader.pid
+			e.LaunchedBy = rec.reader.launchedBy
+			e.ByLikely = rec.reader.likely
+		}
+		if label != "" {
+			e.Labels = []string{label}
+		}
+		agg = &serveAggregate{start: now, event: e}
+		a.pending[key] = agg
+	}
+	agg.event.Count++
+	// A verdict that changes mid-window is a different key, so the reason
+	// recorded here can only drift within one verdict (a lock arriving between
+	// two decoy reads, say). Keep the LATEST, because "why am I getting decoys
+	// right now" is the question, and the newest answer is the true one.
+	if reason != "" {
+		agg.event.Cause = reason
+	}
+	// An identity can arrive late: the scan that missed this reader's open may
+	// find it on the next read, and both reads share a key only when the pid
+	// matches, so this fills in a launcher rather than overwriting a name.
+	if agg.event.LaunchedBy == "" && rec.reader.identified {
+		agg.event.LaunchedBy = rec.reader.launchedBy
+	}
+	over := len(a.pending) >= maxPendingServes
+	a.mu.Unlock()
+
+	a.emitAll(a.take(over, now))
+}
+
+// take removes and returns the aggregates ready to be written — every one
+// when all is set, otherwise those whose window has closed — oldest first so
+// the trail stays chronological.
+func (a *serveAuditor) take(all bool, now time.Time) []agent.SessionEvent {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if len(a.pending) == 0 {
+		return nil
+	}
+	var out []agent.SessionEvent
+	for k, agg := range a.pending {
+		if all || now.Sub(agg.start) >= a.windowOrDefault() {
+			out = append(out, agg.event)
+			delete(a.pending, k)
+		}
+	}
+	sortEventsByTime(out)
+	return out
+}
+
+// labelLocked resolves a mount's credential name, memoized. Caller holds a.mu.
+func (a *serveAuditor) labelLocked(mount string) string {
+	if a.labelFn == nil {
+		return mount
+	}
+	if l, ok := a.labels[mount]; ok {
+		return l
+	}
+	l := a.labelFn(mount)
+	if a.labels == nil {
+		a.labels = map[string]string{}
+	}
+	a.labels[mount] = l
+	return l
+}
+
+func (a *serveAuditor) windowOrDefault() time.Duration {
+	if a.window > 0 {
+		return a.window
+	}
+	return serveAuditWindow
+}
+
+// emitAll writes finished events, never under a.mu: emit appends to a file,
+// and holding the auditor's lock across it would put a disk write on the
+// serve path's critical section.
+func (a *serveAuditor) emitAll(events []agent.SessionEvent) {
+	if a == nil || a.emit == nil {
+		return
+	}
+	for _, e := range events {
+		a.emit(e)
+	}
+}
+
+func sortEventsByTime(events []agent.SessionEvent) {
+	for i := 1; i < len(events); i++ {
+		for j := i; j > 0 && events[j].UnixTime < events[j-1].UnixTime; j-- {
+			events[j], events[j-1] = events[j-1], events[j]
+		}
+	}
+}
+
+// serveReason says, in the user's terms, why a reader got what it got. It is
+// the durable form of the one question the mount design provokes — "why is my
+// app reading decoys" — which until now was answerable only by reading the
+// service's raw log.
+func serveReason(decoy, viaGrant, hadReal bool, resolveErr string) string {
+	if !decoy {
+		if viaGrant {
+			return "authorized by a jit run grant"
+		}
+		return "approved by a per-process consent prompt"
+	}
+	if hadReal {
+		return "no jit run grant or consent approval covered the reader"
+	}
+	if resolveErr != "" {
+		return "no real value is resolved: " + resolveErr
+	}
+	return "the vault session is locked, so no real value is resolved"
+}

--- a/internal/cli/mountserveaudit.go
+++ b/internal/cli/mountserveaudit.go
@@ -71,19 +71,24 @@ type serveAuditor struct {
 // Chosen against the two failure modes, not for a round number. Too short and
 // a watcher loop still floods the trail: at readLogMinGap's 30s a single
 // looping mount would mint 2,880 events a day, enough to evict a week of real
-// unlocks. Too long and `jit audit --follow` stops being a live view of what
-// is reading your credentials, which is most of the point of recording it.
-// Two minutes keeps a looping mount to ~720 events/day worst case while still
-// surfacing a read well inside the time it takes to notice something is off.
-const serveAuditWindow = 2 * time.Minute
+// unlocks. Too long and the trail stops being a live view of what is reading
+// your credentials. An hour holds a looping mount to ~24 events/day — noise a
+// year of history absorbs without evicting anything — and the latency cost
+// lands only on the SECOND read and later: the first read of a fresh
+// (mount, reader, verdict) opens a new aggregate, and an aggregate is written
+// as soon as its window closes, so a lone decoy probe still surfaces, once,
+// about an hour after it happened. What the width actually buys is that the
+// 3,599 reads behind it become a count instead of a line each.
+const serveAuditWindow = time.Hour
 
 // serveAuditFlushInterval paces the background flush. An aggregate is written
 // when its window closes even if nothing reads the mount again — without this
 // a single decoy read on an otherwise idle machine would sit unwritten until
 // the next lock or shutdown, which is precisely the read most worth seeing
-// promptly. Deliberately finer than serveAuditWindow so an aggregate is never
-// held much past it.
-const serveAuditFlushInterval = 15 * time.Second
+// promptly. A minute of slack against an hour-wide window is nothing, and a
+// once-a-minute wake is what a long-lived launchd service can afford to
+// spend on bookkeeping.
+const serveAuditFlushInterval = time.Minute
 
 // maxPendingServes bounds the pending map. The ordinary key space is small
 // (mounts × live readers), but a burst of short-lived readers each get their

--- a/internal/cli/mountserveaudit_test.go
+++ b/internal/cli/mountserveaudit_test.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/agent"
+)
+
+// collector is a serveAuditor sink that keeps what was written, so a test can
+// assert on the events rather than on the file they'd land in.
+type collector struct {
+	mu     sync.Mutex
+	events []agent.SessionEvent
+}
+
+func (c *collector) append(e agent.SessionEvent) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *collector) all() []agent.SessionEvent {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]agent.SessionEvent{}, c.events...)
+}
+
+func newTestAuditor(window time.Duration) (*serveAuditor, *collector) {
+	c := &collector{}
+	return &serveAuditor{window: window, emit: c.append}, c
+}
+
+func decoyRead(pid int32, exec string) serveRecord {
+	return serveRecord{
+		decoy:  true,
+		reader: readerIdentity{pid: pid, execPath: exec, launchedBy: "Code", identified: true},
+	}
+}
+
+// The property the whole design exists for: agent-history.jsonl and the
+// in-memory ring both evict oldest-first, so a watcher loop re-reading a mount
+// must NOT be able to write one event per read — that would push every real
+// unlock and denial out of the trail it is being added to.
+func TestServeAuditCollapsesAReadStorm(t *testing.T) {
+	a, c := newTestAuditor(time.Minute)
+	start := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < 5000; i++ {
+		a.record(start.Add(time.Duration(i)*time.Millisecond), "/tmp/m.env",
+			serveReason(true, false, true, ""), decoyRead(4321, "/usr/local/bin/node"))
+	}
+	if got := len(c.all()); got != 0 {
+		t.Fatalf("5000 reads inside one window wrote %d events, want 0 until the window closes", got)
+	}
+
+	a.emitAll(a.take(true, start))
+	events := c.all()
+	if len(events) != 1 {
+		t.Fatalf("a read storm produced %d events, want exactly 1 collapsed event", len(events))
+	}
+	if events[0].Count != 5000 {
+		t.Errorf("collapsed event Count = %d, want 5000 — the count is the whole reason the line is interesting", events[0].Count)
+	}
+	if events[0].Kind != agent.KindServe || events[0].Op != agent.OpServeDecoy {
+		t.Errorf("collapsed event = kind %q op %q, want %q/%q", events[0].Kind, events[0].Op, agent.KindServe, agent.OpServeDecoy)
+	}
+}
+
+// Collapsing must never merge two facts an investigation needs apart. The key
+// is (mount, reader, verdict), so a different reader or a different verdict is
+// always its own line even inside one window.
+func TestServeAuditKeepsDistinctFactsApart(t *testing.T) {
+	a, c := newTestAuditor(time.Hour)
+	now := time.Unix(1_700_000_000, 0)
+
+	real := serveRecord{reader: readerIdentity{pid: 4321, execPath: "/usr/local/bin/node", identified: true}}
+
+	a.record(now, "/tmp/a.env", "r1", decoyRead(4321, "/usr/local/bin/node"))
+	a.record(now, "/tmp/b.env", "r1", decoyRead(4321, "/usr/local/bin/node")) // other mount
+	a.record(now, "/tmp/a.env", "r1", decoyRead(9999, "/usr/bin/python3"))    // other reader
+	a.record(now, "/tmp/a.env", "r2", real)                                   // other verdict
+
+	a.emitAll(a.take(true, now))
+	if got := len(c.all()); got != 4 {
+		t.Fatalf("4 distinct (mount, reader, verdict) triples collapsed into %d events, want 4", got)
+	}
+}
+
+// An aggregate must be written once its window closes even if the machine goes
+// quiet — a single decoy read on an idle machine is exactly the one most worth
+// seeing, and it must not wait for a lock or a shutdown to appear.
+func TestServeAuditFlushesWhenTheWindowCloses(t *testing.T) {
+	a, c := newTestAuditor(time.Minute)
+	start := time.Unix(1_700_000_000, 0)
+	lookups := 0
+	a.labelFn = func(mount string) string {
+		lookups++
+		if mount == "/tmp/m.env" {
+			return "gcp"
+		}
+		return "aws"
+	}
+
+	a.record(start, "/tmp/m.env", "r", decoyRead(1, "/bin/cat"))
+	if got := len(c.all()); got != 0 {
+		t.Fatalf("wrote %d events immediately, want 0 while the window is open", got)
+	}
+	// A later read of a DIFFERENT mount, past the window: the first aggregate
+	// is now due and must go out.
+	a.record(start.Add(2*time.Minute), "/tmp/other.env", "r", decoyRead(2, "/bin/cat"))
+
+	events := c.all()
+	if len(events) != 1 {
+		t.Fatalf("an expired aggregate wrote %d events, want 1", len(events))
+	}
+	if len(events[0].Labels) == 0 || events[0].Labels[0] != "gcp" {
+		t.Errorf("the expired event = %+v, want the gcp mount's", events[0])
+	}
+	if lookups != 2 {
+		t.Errorf("resolved the mount label %d times, want one per distinct mount", lookups)
+	}
+}
+
+// The label lookup walks jit's global-mount table, so it must be memoized:
+// paying it once per rendezvous is exactly the per-read cost the mount code
+// has twice been bitten by.
+func TestServeAuditMemoizesTheMountLabel(t *testing.T) {
+	a, _ := newTestAuditor(time.Hour)
+	lookups := 0
+	a.labelFn = func(string) string { lookups++; return "gcp" }
+	now := time.Unix(1_700_000_000, 0)
+
+	// Distinct readers, so each gets its own aggregate and every one of them
+	// needs the label — but the mount is the same, so the lookup is not.
+	for i := 0; i < 20; i++ {
+		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), "/bin/sh"))
+	}
+	if lookups != 1 {
+		t.Errorf("resolved the same mount's label %d times, want 1", lookups)
+	}
+}
+
+// The pending map is keyed partly on pid, so a burst of short-lived readers
+// each claim a key. It needs a ceiling that isn't "however many processes the
+// machine can spawn" — and hitting it must flush, never drop.
+func TestServeAuditBoundsPendingAggregates(t *testing.T) {
+	a, c := newTestAuditor(time.Hour)
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < maxPendingServes*3; i++ {
+		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), "/bin/sh"))
+	}
+
+	a.mu.Lock()
+	pending := len(a.pending)
+	a.mu.Unlock()
+	if pending > maxPendingServes {
+		t.Errorf("pending aggregates = %d, want at most %d", pending, maxPendingServes)
+	}
+	if got := len(c.all()); got == 0 {
+		t.Error("hitting the ceiling dropped every aggregate; it must flush them instead")
+	}
+}
+
+// A nil emit is the zero value every test's bare mountManager has. It must be
+// inert rather than a panic, and cost nothing on the serve path.
+func TestServeAuditWithoutASinkIsInert(t *testing.T) {
+	var a serveAuditor
+	a.record(time.Unix(1, 0), "/tmp/m.env", "r", decoyRead(1, "/bin/cat"))
+	a.start()
+	a.stopFlusher()
+	if a.pending != nil {
+		t.Error("an auditor with no sink accumulated state")
+	}
+}
+
+// stopFlusher is the service shutting down: whatever window it was in the
+// middle of must be written, not discarded.
+func TestServeAuditStopFlusherWritesPending(t *testing.T) {
+	a, c := newTestAuditor(time.Hour)
+	a.start()
+	a.record(time.Unix(1_700_000_000, 0), "/tmp/m.env", "r", decoyRead(7, "/bin/cat"))
+	a.stopFlusher()
+
+	if got := len(c.all()); got != 1 {
+		t.Fatalf("shutdown wrote %d events, want the 1 still pending", got)
+	}
+}
+
+// Every mount has its own Serve goroutine, so record() is called concurrently
+// while the background flusher walks the same map. Under -race this is the
+// test that matters: no read of a credential mount may ever be lost to, or
+// corrupted by, the bookkeeping that records it.
+func TestServeAuditIsConcurrencySafe(t *testing.T) {
+	a, c := newTestAuditor(time.Millisecond)
+	a.start()
+	defer a.stopFlusher()
+
+	var wg sync.WaitGroup
+	for m := 0; m < 8; m++ {
+		wg.Add(1)
+		go func(m int) {
+			defer wg.Done()
+			mount := "/tmp/mount" + string(rune('a'+m)) + ".env"
+			for i := 0; i < 200; i++ {
+				a.record(time.Now(), mount, "r", decoyRead(int32(m+1), "/bin/sh"))
+			}
+		}(m)
+	}
+	wg.Wait()
+	a.stopFlusher()
+
+	// Every read is accounted for: collapsed into some number of events, but
+	// never dropped.
+	var total int64
+	for _, e := range c.all() {
+		total += e.Count
+	}
+	if total != 8*200 {
+		t.Errorf("recorded %d reads across the collapsed events, want %d", total, 8*200)
+	}
+}
+
+// The reason is the durable answer to "why is my app reading decoys", which
+// before this existed lived only as prose in the service's own log.
+func TestServeReasonNamesTheCause(t *testing.T) {
+	cases := []struct {
+		name                     string
+		decoy, grant, hadReal    bool
+		resolveErr, wantFragment string
+	}{
+		{name: "granted", decoy: false, grant: true, wantFragment: "jit run grant"},
+		{name: "consent", decoy: false, grant: false, wantFragment: "consent prompt"},
+		{name: "ungranted", decoy: true, hadReal: true, wantFragment: "no jit run grant or consent"},
+		{name: "locked", decoy: true, hadReal: false, wantFragment: "session is locked"},
+		{name: "resolve failed", decoy: true, hadReal: false, resolveErr: "keychain said no", wantFragment: "keychain said no"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := serveReason(tc.decoy, tc.grant, tc.hadReal, tc.resolveErr)
+			if !strings.Contains(got, tc.wantFragment) {
+				t.Errorf("serveReason = %q, want it to mention %q", got, tc.wantFragment)
+			}
+		})
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -634,6 +634,13 @@ func printStatusText(w io.Writer, r statusResult) {
 	// tool, an editor) or exactly the "my dev server is failing and
 	// nothing says why" case — and only the user can tell which, so say
 	// it happened and point at the command with the who/when detail.
+	//
+	// That command is `jit audit --status decoy`, not `jit service status`:
+	// this note is driven by each mount's in-memory LastServe, which holds
+	// only the newest read and is empty after a restart, whereas the audit
+	// trail has every collapsed serve, the reader, and the REASON — so the
+	// question the note provokes is now fully answerable, and answerable
+	// about yesterday.
 	decoyReads := 0
 	for _, m := range r.Agent.Mounts {
 		if m.LastServe != nil && m.LastServe.Decoy {
@@ -643,7 +650,7 @@ func printStatusText(w io.Writer, r statusResult) {
 	if decoyReads > 0 {
 		printStatusWarnNote(w, "%s most recently served decoy values to a reader.",
 			countWord(decoyReads, "mount", "mounts"))
-		printStatusAction(w, "`jit service status` to see which reader, and when")
+		printStatusAction(w, "`jit audit --status decoy` to see which reader, when, and why")
 	}
 }
 

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -222,6 +222,14 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 		} else {
 			fmt.Fprintf(out, "Exported the %s from the tool's own keyring, copied into the vault at %s.\n", entry.Doc, vaultPath)
 		}
+	} else if wrapSecretAlreadyVaulted(vaultPath) {
+		// Nothing on disk to discover, but the vault already holds the
+		// secret — the docs for every no-source tool say to `jit vault set`
+		// it first, so this is the EXPECTED state for those, and "store it
+		// first" here told a user who had just followed the instructions
+		// that they hadn't (a real run surfaced it: set, wrap, and the wrap
+		// answered as if the set never happened).
+		fmt.Fprintf(out, "Using the %s already in the vault at %s.\n", entry.Doc, vaultPath)
 	} else {
 		wrapBody(out, 0, "", hlCmds(fmt.Sprintf("No %s found on this machine, store it first: `jit vault set %s`, "+
 			"then re-run `jit wrap %s`. Installing the shim and profile now anyway.",
@@ -273,6 +281,21 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 		fmt.Fprint(out, hlCmds(fmt.Sprintf("Check it: open a new shell and run `%s`.\n", entry.VerifyHint)))
 	}
 	return nil
+}
+
+// wrapSecretAlreadyVaulted reports whether the vault already stores a secret
+// at path — on a bare read-only Vault, deliberately: Exists is one os.Stat,
+// so this check never dials the agent, never prompts, and never writes the
+// device-id file as a side effect (the same never-mutate-on-read reasoning
+// `jit vault list` documents). Any error reads as "not stored", which falls
+// back to the store-it-first message — the pre-check behavior.
+func wrapSecretAlreadyVaulted(path string) bool {
+	root, err := vaultRootDir()
+	if err != nil {
+		return false
+	}
+	stored, err := (&vault.Vault{Root: root}).Exists(path)
+	return err == nil && stored
 }
 
 var wrapAddEnv []string

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -28,6 +28,62 @@ func execWrap(t *testing.T, args ...string) (stdout string, err error) {
 	return buf.String(), err
 }
 
+// putToolOnPath plants an executable stub named tool in a temp dir and
+// prepends that dir to PATH, so the wrap flow's is-it-installed check
+// passes without the real tool.
+func putToolOnPath(t *testing.T, tool string) {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, tool)
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { // #nosec G306 -- a test stub must be executable
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// A no-source tool whose secret is ALREADY in the vault must not be told to
+// "store it first" — the docs for every such tool say to `jit vault set`
+// before wrapping, so that message told a user who had just followed the
+// instructions that they hadn't (observed on a real wrap 2026-08-09). The
+// check must also never prompt: it runs on a bare read-only Vault, one
+// os.Stat, no agent.
+func TestWrapUsesTheSecretAlreadyInTheVault(t *testing.T) {
+	home := withFixtureHome(t)
+	putToolOnPath(t, "openai")
+	plantVaultSecret(t, home, "wrap-openai/OPENAI_API_KEY")
+
+	out, err := execWrap(t, "openai")
+	if err != nil {
+		t.Fatalf("jit wrap openai: %v", err)
+	}
+	if strings.Contains(out, "store it first") {
+		t.Errorf("wrap told the user to store a secret the vault already holds:\n%s", out)
+	}
+	if !strings.Contains(out, "already in the vault at wrap-openai/OPENAI_API_KEY") {
+		t.Errorf("wrap didn't acknowledge the existing secret:\n%s", out)
+	}
+	if !strings.Contains(out, "Wrapped openai") {
+		t.Errorf("wrap didn't install the shim:\n%s", out)
+	}
+}
+
+// With nothing on disk AND nothing in the vault, the store-it-first guidance
+// is exactly right and must stay.
+func TestWrapStillAsksWhenNothingIsVaulted(t *testing.T) {
+	withFixtureHome(t)
+	putToolOnPath(t, "openai")
+
+	out, err := execWrap(t, "openai")
+	if err != nil {
+		t.Fatalf("jit wrap openai: %v", err)
+	}
+	// Two substrings, not one: wrapBody may line-wrap between the command
+	// and its argument at narrow test widths.
+	if !strings.Contains(out, "store it first") || !strings.Contains(out, "wrap-openai/OPENAI_API_KEY") {
+		t.Errorf("empty-vault wrap lost the store-it-first guidance:\n%s", out)
+	}
+}
+
 func TestWrapAddListUndoRoundTrip(t *testing.T) {
 	home := withFixtureHome(t)
 

--- a/internal/wrap/catalog_data.go
+++ b/internal/wrap/catalog_data.go
@@ -349,8 +349,8 @@ var catalog = map[string]CatalogEntry{
 		Doc:     "Kiro CLI API key",
 		EnvVars: map[string]string{"KIRO_API_KEY": "KIRO_API_KEY"},
 		Order:   []string{"KIRO_API_KEY"},
-		// No Sources. Kiro's interactive login is subscription OAuth (AWS
-		// Builder ID / Identity Center) and stores no API key; KIRO_API_KEY
+		// No Sources. Kiro's interactive login is subscription OAuth (a
+		// browser sign-in) and stores no API key; KIRO_API_KEY
 		// is the CLI's documented headless credential, minted in the Kiro
 		// dashboard (kiro.dev/docs/cli/headless, checked 2026-08-09 — note
 		// API keys are only available on paid plans). Wrap needs

--- a/internal/wrap/catalog_data.go
+++ b/internal/wrap/catalog_data.go
@@ -259,6 +259,104 @@ var catalog = map[string]CatalogEntry{
 		},
 		VerifyHint: `codex exec "say hi"`,
 	},
+	"cursor-agent": {
+		Tool:    "cursor-agent",
+		Kind:    KindShim,
+		Doc:     "Cursor CLI API key",
+		EnvVars: map[string]string{"CURSOR_API_KEY": "CURSOR_API_KEY"},
+		Order:   []string{"CURSOR_API_KEY"},
+		// No Sources. `agent login` (browser OAuth) stores a session, not an
+		// API key; the API key this wraps comes from the Cursor dashboard and
+		// lives wherever the user exported it — migrate's territory if that's
+		// a shell rc. CURSOR_API_KEY is the CLI's documented env credential
+		// for automation (checked against cursor.com/docs/cli 2026-08-09).
+		// Note the install script symlinks the SAME binary as both `agent`
+		// (primary) and `cursor-agent` (legacy); this entry shims the
+		// unambiguous name. A user who types `agent` can wrap that name by
+		// hand with `jit wrap add` — the catalog doesn't claim a name that
+		// generic. Wrap needs `jit vault set wrap-cursor-agent/CURSOR_API_KEY`
+		// first.
+		VerifyHint: "cursor-agent status",
+	},
+	"copilot": {
+		Tool:    "copilot",
+		Kind:    KindShim,
+		Doc:     "GitHub PAT for Copilot CLI",
+		EnvVars: map[string]string{"COPILOT_GITHUB_TOKEN": "COPILOT_GITHUB_TOKEN"}, // #nosec G101 -- env var name, not a credential
+		Order:   []string{"COPILOT_GITHUB_TOKEN"},
+		// No Sources. The interactive `/login` stores an OAuth session, not
+		// the PAT; a PAT (fine-grained, "Copilot Requests" permission) lives
+		// wherever the user exported it. The shim injects
+		// COPILOT_GITHUB_TOKEN, deliberately NOT GH_TOKEN or GITHUB_TOKEN
+		// even though copilot reads all three (in that precedence order, per
+		// docs.github.com, checked 2026-08-09): copilot runs the user's
+		// commands as children, and GH_TOKEN/GITHUB_TOKEN in that inherited
+		// environment would authenticate gh and every git credential flow in
+		// every child — the same blast-radius reasoning as codex's
+		// CODEX_API_KEY. COPILOT_GITHUB_TOKEN is read by copilot alone.
+		// Wrap needs `jit vault set wrap-copilot/COPILOT_GITHUB_TOKEN` first.
+		VerifyHint: `copilot -p "say hi"`,
+	},
+	"cline": {
+		Tool:    "cline",
+		Kind:    KindShim,
+		Doc:     "Anthropic API key for the Cline CLI",
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "ANTHROPIC_API_KEY"},
+		Order:   []string{"ANTHROPIC_API_KEY"},
+		Sources: []TokenSource{
+			// Verified by running the tool, 2026-08-09: `cline auth -p
+			// anthropic -k <key>` writes exactly this nested shape, and with
+			// the file's key absent cline sends ANTHROPIC_API_KEY from the
+			// environment to the API (observed on the wire via the invalid-key
+			// rejection). Scrubbing removes the "apiKey" line; the pretty-
+			// printed JSON stays valid and the provider entry survives.
+			//
+			// Cline is multi-provider: this covers the Anthropic API-key
+			// setup (`-P anthropic`). The default hosted "cline" provider
+			// signs in with OAuth and stores no API key here — nothing to
+			// wrap. And like the claude entry, the injected variable is
+			// inherited by the child processes cline itself spawns; unlike
+			// codex there is no scoped per-tool variable to prefer.
+			{Path: "~/.cline/settings/providers.json", Format: "json", Selector: "providers/anthropic/settings/apiKey"},
+		},
+		VerifyHint: `cline -P anthropic "say hi"`,
+	},
+	"opencode": {
+		Tool:    "opencode",
+		Kind:    KindShim,
+		Doc:     "Anthropic API key for OpenCode",
+		EnvVars: map[string]string{"ANTHROPIC_API_KEY": "ANTHROPIC_API_KEY"},
+		Order:   []string{"ANTHROPIC_API_KEY"},
+		Sources: []TokenSource{
+			// Verified by running the tool, 2026-08-09: `/connect`-stored
+			// credentials land in auth.json keyed by provider — {"anthropic":
+			// {"type": "api", "key": ...}} — written pretty-printed (observed
+			// by making `opencode auth logout` rewrite the file), so the
+			// line-oriented scrub removes only the "key" line and every OTHER
+			// provider's credential in the same file survives. With the file
+			// entry gone, opencode reads ANTHROPIC_API_KEY from the
+			// environment (observed on the wire via the invalid-key
+			// rejection). An OAuth (Claude subscription) login stores no
+			// "key" field, so there is nothing to extract and it is never
+			// touched — codex's exact stance.
+			{Path: "~/.local/share/opencode/auth.json", Format: "json", Selector: "anthropic/key"},
+		},
+		VerifyHint: `opencode run "say hi"`,
+	},
+	"kiro-cli": {
+		Tool:    "kiro-cli",
+		Kind:    KindShim,
+		Doc:     "Kiro CLI API key",
+		EnvVars: map[string]string{"KIRO_API_KEY": "KIRO_API_KEY"},
+		Order:   []string{"KIRO_API_KEY"},
+		// No Sources. Kiro's interactive login is subscription OAuth (AWS
+		// Builder ID / Identity Center) and stores no API key; KIRO_API_KEY
+		// is the CLI's documented headless credential, minted in the Kiro
+		// dashboard (kiro.dev/docs/cli/headless, checked 2026-08-09 — note
+		// API keys are only available on paid plans). Wrap needs
+		// `jit vault set wrap-kiro-cli/KIRO_API_KEY` first.
+		VerifyHint: `kiro-cli chat --no-interactive "say hi"`,
+	},
 	"sentry-cli": {
 		Tool:    "sentry-cli",
 		Kind:    KindShim,

--- a/internal/wrap/catalog_test.go
+++ b/internal/wrap/catalog_test.go
@@ -151,6 +151,11 @@ func TestCatalogSelectorsAgainstFixtures(t *testing.T) {
 		{"gemini", 0, "gemini/env", "FIXTUREgeminiToken0123456789abcdefFIXTURE"},
 		{"gemini", 1, "gemini/home-dotenv", "FIXTUREgeminiHomeFallback0123456789FIXTURE"},
 		{"codex", 0, "codex/auth.json", "sk-FIXTUREcodexToken0123456789abcdefFIXTURE"},
+		{"cline", 0, "cline/providers.json", "sk-ant-FIXTUREclineToken0123456789abcdefFIXTURE"},
+		// The fixture carries an OAuth entry beside the API key, mirroring a
+		// real multi-provider auth.json — the selector must reach only the
+		// anthropic key and never an OAuth token.
+		{"opencode", 0, "opencode/auth.json", "sk-ant-FIXTUREopencodeToken0123456789abcdefFIXTURE"},
 		{"sentry-cli", 0, "sentry-cli/sentryclirc", "FIXTUREsentryToken0123456789abcdefFIXTURE"},
 		{"snyk", 0, "snyk/snyk.json", "FIXTUREsnykToken0123-4567-89ab-cdef"},
 		{"circleci", 0, "circleci/cli.yml", "FIXTUREcircleciToken0123456789abcdef"},

--- a/internal/wrap/testdata/cline/providers.json
+++ b/internal/wrap/testdata/cline/providers.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "lastUsedProvider": "anthropic",
+  "providers": {
+    "anthropic": {
+      "settings": {
+        "provider": "anthropic",
+        "apiKey": "sk-ant-FIXTUREclineToken0123456789abcdefFIXTURE",
+        "model": "claude-sonnet-5"
+      },
+      "updatedAt": "2026-08-09T12:00:00.000Z",
+      "tokenSource": "manual"
+    }
+  }
+}

--- a/internal/wrap/testdata/opencode/auth.json
+++ b/internal/wrap/testdata/opencode/auth.json
@@ -1,0 +1,12 @@
+{
+  "anthropic": {
+    "type": "api",
+    "key": "sk-ant-FIXTUREopencodeToken0123456789abcdefFIXTURE"
+  },
+  "openai": {
+    "type": "oauth",
+    "refresh": "FIXTURErefreshTokenNotAnAPIKey",
+    "access": "FIXTUREaccessTokenNotAnAPIKey",
+    "expires": 1786276943
+  }
+}


### PR DESCRIPTION
Two features and their follow-through, all tested end-to-end on a real machine before this PR.

## Mount reads join the audit trail (`kind=serve`)

Every mount read reaches a content decision jit knows everything about — which mount, decoy or real, why, and (best-effort, via lineage) which process read it. All of it used to live in one in-memory `LastServe` slot per mount, overwritten by the next read and gone at restart. It is now a durable `SessionEvent` in the same trail as unlocks:

- `--status decoy` is the tripwire query ("what read a credential file and got a fake"); `--status real` answers what a grant approval never could — not "was this authorized" but "was it actually read". `--kind serve`; `--parent claude` now reaches mount reads.
- **Collapse is load-bearing, not an optimization**: `agent-history.jsonl` and the ring evict oldest-first, and `serveContent` runs once per reader rendezvous, so an uncollapsed serve event is an eviction primitive against the very trail it writes into — the hazard `recordRejectedClass` documents, reached by accident instead of by attack. Serves aggregate on (mount, reader, verdict) over a 1-hour window (a pinned looping mount costs ~24 rows/day against ~10k retained); a lone read still surfaces once, when its window closes.
- Reader identity keeps lineage's doctrine: named, named-but-inferred (rendered "(likely)", `reader_likely=true`, never asserted), or an honest "an unidentified reader".
- `jit status`'s decoy note now points at `jit audit --status decoy` instead of `jit service status`.

Live-verified: branch build installed over the running service (atomic mv), real reads of a registered mount recorded as `kind=serve status=decoy reader=/usr/bin/head … parent=claude` with the reason, and the fast reader that evaded the scan reported honestly as unidentified.

## Wrap catalog: cursor-agent, copilot, cline, opencode, kiro-cli

The scanner learned eleven AI-agent surfaces in v0.78.0; the catalog knew four — jit could find Cursor's key and then not deliver it. Every fact grounded per the v0.56.0 lesson, two tools interrogated directly on this machine:

- **cline** — `providers.json` shape captured by running `cline auth` in a sandbox; `ANTHROPIC_API_KEY` proven on the wire (the API's invalid-key reply is the proof). Selector `providers/anthropic/settings/apiKey`.
- **opencode** — auth.json shape accepted by the binary; write format proven pretty-printed (which is what makes the line-oriented scrub safe for other providers' OAuth entries in the same file); env var proven on the wire. Selector `anthropic/key`.
- **copilot** — injects `COPILOT_GITHUB_TOKEN`, deliberately not `GH_TOKEN`/`GITHUB_TOKEN` which it also reads: copilot runs your commands as children, and the generic names would authenticate `gh` in every one of them (codex's `CODEX_API_KEY` reasoning).
- **cursor-agent** — `CURSOR_API_KEY` per Cursor's docs; the installer symlinks the same binary as `agent` and `cursor-agent`, and the entry shims the name that can only mean Cursor.
- **kiro-cli** — `KIRO_API_KEY`, the documented headless credential.

Double-report seam: cline/opencode files are also in `ScanAgentStores`' sweep; `dropRedundantExposedSecrets` collapses it (codex precedent), now pinned by a test instead of assumed.

End-to-end on this machine: fake key vaulted → `jit wrap cline` → shim → `jit run --profile wrap-cline` → cline → Anthropic answered "API key is invalid" for exactly that key; audit trail recorded the whole story; `wrap undo` restored everything.

## Follow-through

- **wrap: a secret already vaulted is used, not asked for again** — surfaced by the release test itself: set-then-wrap told a user who had just followed the documented flow that they hadn't. The check is one `os.Stat` on a bare read-only Vault, so discovery-less wraps still open no vault and prompt nothing.
- **docs** — provenance.md gains the seventh event kind with the collapse rationale; why-jit.md and how-it-works.md mention mount reads; one unverified kiro identity-provider claim retracted; command reference regenerated.

Full gate green throughout (gofmt/vet/staticcheck/gosec/govulncheck/tidy/docs-gen, `go test -race ./...`), concurrency test run 3× under `-race`, machine restored to stock after testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DwKSGutnQQeDt9YWxAz7yj