### PR TITLE
grant: pre-approve a running process to use profiles unattended

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,29 @@ Kicking off something that needs several credentials at once? `jit run --trust
 -- terraform apply` approves that whole run's tools in one gesture. Full details:
 [per-process consent](./docs/service/consent.md).
 
+## Leaving the keyboard? Approve the work before you go
+
+Both gates assume a human is there to answer. An AI agent working overnight, a
+long build, a scheduled job: the screen locks, the session drops, and the run
+stalls on a prompt nobody will see. A **process grant** moves your decision
+earlier instead of removing it - one Touch ID, given while you're still there,
+that names exactly what you're signing:
+
+```console
+$ jit grant --process claude --profile jamf --for 8h
+  Touch ID  ->  let claude use 2 secrets (jamf) unattended for 8h
+✓ granted g-7f3a2c81   claude -> jamf   until 17:42
+```
+
+For the next 8 hours, that running process (and what it launches) gets those
+secrets with no prompts - through screen lock and all. It's a live process
+being named, not a name being trusted: a new program calling itself `claude`
+tomorrow inherits nothing, and the grant ends at its deadline, when the process
+exits, or the moment you type `jit grant revoke` (which needs no fingerprint -
+taking access away is always free). Every serve lands in the audit trail as its
+own event, so the morning after you can read exactly what your agent touched
+while you slept. Full details: [process grants](./docs/service/grants.md).
+
 ## The audit trail: what happened, and who did it
 
 Every jit command and every unlock lands in a durable log you read back with
@@ -273,6 +296,7 @@ The docs live under **[docs/](./docs/index.md)**, organized by task:
 - **[How it works](./docs/getting-started/how-it-works.md)**: the vault, the service, mounts, and shims in one page
 - **[FAQ](./docs/faq.md)**: developer and security questions, answered bluntly
 - **[Per-process consent](./docs/service/consent.md)**: what the per-tool prompts do, and how to tune or turn them off
+- **[Process grants](./docs/service/grants.md)**: pre-approve a running tool to work unattended for a bounded, revocable, audited window
 - **[Audit trail](./docs/reference/commands/jit_audit.md)**: read back every command, unlock, and refusal, filterable and followable
 - **[Command reference](./docs/reference/commands/jit.md)**: every command and flag, generated from the CLI
 - **[Security architecture](./docs/security/architecture.md)**: the threat model and the honest limits

--- a/design/process-grants.md
+++ b/design/process-grants.md
@@ -1,0 +1,174 @@
+# Process grants: pre-approved unattended access
+
+**Status: proposal, being built on branch `process-grants`.**
+
+Today every credential serve ultimately rides a session the human opened with
+Touch ID, and the session dies on idle, on an 8h ceiling, on screen lock, on
+sleep. That is the right default and it stays the default. The gap is the
+unattended case: an AI agent working overnight, a long build, a launchd job.
+The human is not at the keyboard, the screen locks, the session drops, and the
+run stalls on a prompt nobody will answer.
+
+A **process grant** moves the human decision earlier instead of removing it:
+while present, the user approves with one disclosed Touch ID that a specific
+**running process tree** may use the secrets of one or more named **profiles**
+for a bounded **TTL**, unattended. Between creation and expiry, serves to that
+tree succeed without prompts, even across screen lock. Everything else keeps
+today's behavior.
+
+    jit grant --process claude --profile jamf --profile aws-ci --for 8h
+
+## What a grant is (and is not)
+
+A grant is `(root process, secret set, expiry)`:
+
+- **Root process** -- a live pid plus its fork-time stamp
+  (`lineage.ProcessStartTime`), exactly the anchoring `trustRoots` and the
+  run-scoped mount attachments already use. Membership is decided by
+  `lineage.AncestryContainsPID`, fail-closed. The grant names a *process that
+  exists right now*; it is never a name-pattern. A new process claiming the
+  same name tomorrow matches nothing.
+- **Secret set** -- the union of the named profiles' vault paths, resolved at
+  creation time (project profile first, then global, same as `jit run`). One
+  or many profiles; the grant stores concrete paths, not profile names, so a
+  later profile edit does not silently widen a standing grant.
+- **Expiry** -- absolute deadline, `now + --for`, hard-capped at
+  `maxGrantTTL = 7d`. Checked at serve time against the record, never baked
+  into key material, so revoke and expiry act immediately.
+
+A grant is **not** a policy. It cannot match future processes, it does not
+survive the agent process (v1), and it never covers secrets outside its
+resolved set. Identity still never decides anything the human did not
+explicitly approve: the doctrine "caller identity explains and audits, never
+decides" is preserved because the *decision* is the disclosed Touch ID at
+creation, bound to a kernel-vouched pid; descent-from-root afterwards is the
+same fail-closed mechanism `--trust` already relies on.
+
+## Mechanics: a scoped DEK cache, not a weaker vault
+
+The enabling fact: the agent is a DEK-unwrapping oracle. `OpUnwrap` receives
+the envelope's wrapped data key and returns the plaintext DEK; payload
+decryption happens in the client. The MEK never leaves the agent, and Touch ID
+is application-level (`LAContext`), not a keychain ACL.
+
+So a grant needs no on-disk re-wrap and no new keychain item class:
+
+1. **Creation.** The CLI resolves the profiles to vault paths and reads each
+   envelope's wrapped DEK bytes and AAD-bound class (a plain file read, no
+   auth). It sends `OpGrantCreate{TargetPID, profiles, entries[]{path,
+   wrapped, class}}` to the agent.
+2. The agent derives the process description from `TargetPID` via lineage
+   (never from caller-supplied text) and runs one disclosed challenge:
+   *"allow claude to use 3 secrets (jamf, aws-ci) unattended for 8h"*. The
+   challenge fetches a fresh MEK, which -- unlike `discloseChallenge` today --
+   is used in place to unwrap the entry DEKs (each with its class as AAD, so a
+   lied-about class fails cryptographically), then wiped. Session state is
+   untouched: creating a grant does not open a session.
+3. The grant record holds `hash(wrapped bytes) -> DEK` in mlocked memory,
+   plus metadata (id, root pid+fork-time, paths, profile names, created,
+   expiry, serve count).
+4. **Serve.** `OpUnwrap` checks grants before consent and before
+   `ensureUnlocked`: caller descends from a live, unexpired grant root AND
+   `hash(req.Data)` is in that grant's map -> return the cached DEK. No
+   session needed, no consent prompt (the human approved this exact
+   tool-and-secret pairing at creation), full audit record. Any miss -- wrong
+   tree, expired, rotated secret, uncovered path -- falls through to today's
+   path unchanged.
+
+Scope of compromise while a grant is live: the granted secrets, for the
+granted window, to the granted tree. Not the MEK, not the vault.
+
+### The re-lock invariant, amended deliberately
+
+Today nothing in the agent's authorization state survives `lock()`: MEK,
+consent cache, trust roots, run attachments all drop. Process grants are a
+new, explicitly carved-out persistence class: **grant records and their DEKs
+survive re-lock by design**, because surviving the screen lock is the entire
+feature. The carve-out is safe to state because a grant is strictly narrower
+than the session it replaces (specific secrets, specific tree, absolute
+deadline, revocable), and it is what the human approved in so many words.
+Grants do NOT survive agent restart or reboot in v1 -- and cannot
+meaningfully, since the root process tree dies with the boot anyway.
+
+### End of life
+
+A grant ends by whichever comes first; all endings wipe the cached DEKs and
+emit an audit event with the cause:
+
+- **expiry** -- lazy check at serve plus a timer so the record does not
+  linger,
+- **revoke** -- `jit grant revoke <id>`, no auth required (reducing access is
+  always free),
+- **root exit** -- fork-time re-verification fails, grant is pruned lazily on
+  the next serve/list/status touch,
+- **agent exit** -- memory gone.
+
+`jit grant extend <id> --for <d>` re-runs the disclosed challenge (more time
+is a new decision); shortening via `revoke` + re-create, or a later
+`--shorten`, needs none.
+
+## CLI surface
+
+`jit grant` is a command group whose bare form creates:
+
+    jit grant --process <name>|--pid <pid> --profile <p> [--profile <p>...] --for <dur>
+    jit grant list [--format json]
+    jit grant revoke <id>
+    jit grant extend <id> --for <dur>
+
+- `--process` resolves the name against the **currently running** processes
+  (libproc listing, same-user only, `lineage.Process.Name()` normalization).
+  Ambiguity (two claudes) is an error listing candidates with pids; `--pid`
+  disambiguates. Nothing running under that name is an error, not a stored
+  pattern.
+- `--profile` repeats; each resolves through the normal project-then-global
+  chain. `--for` accepts the `jit audit --since` duration grammar (`45m`,
+  `8h`, `3d`), capped at 7d.
+- Shell completion for `--process` harvests recent callers from the two audit
+  trails (`audit.jsonl` Parent/LaunchedBy, `agent-history.jsonl` By/
+  LaunchedBy, last 24h), deduped, annotated running/not-running, rendered as
+  cobra `name\tdescription` pairs. Read-only, no agent RPC, no prompt, no
+  state mutation, NoFileComp.
+- Output follows the house style: `[Grants] N` header, `●` live rows with
+  expiry countdown and serve counts, `!` nudge plus a `→ jit grant revoke`
+  hint for a grant that is long-lived and unused. A preview script exists in
+  the session scratchpad and the rendering will be re-previewed before the
+  final polish.
+
+## Protocol and audit
+
+New ops `grant_create`, `grant_list`, `grant_revoke`, `grant_extend` join the
+existing one-request-per-connection protocol; `Response` gains a
+`Grants []GrantStatus`. All four verify the peer as every op does; `create`
+and `extend` additionally require the disclosed challenge; a nil caller is
+rejected on `create` (a grant must be traceable to a requesting human
+context).
+
+Audit trail (both files already merged by `jit audit`):
+
+- creation and extension -> `KindApproved` with the exact prompt wording as
+  `Cause` (renders today as `kind=grant status=approved`),
+- serves under a grant -> aggregated `KindUse` with op `grant-use`, labels
+  carrying the vault paths, collapse-per-caller like session uses,
+- endings -> new `KindGrantEnd` with `Cause` = `expired` | `revoked` |
+  `process-exit`, rendered by `jit audit` and aliased under `--kind grant`.
+
+## Limits, stated plainly
+
+- **Env injection is still up-front.** A `jit run` that already injected env
+  vars gave the tree those values with no further serves; grants change
+  nothing there. Grants shine for pull-at-use paths: credential helpers,
+  capture shims, repeated `jit run` invocations by an agent.
+- **FIFO mounts are out of scope in v1.** The best-effort reader-scan path
+  keeps its own consent gating; extending grants to mounts is a later,
+  separate decision.
+- **Rotation invalidates silently but safely.** Rotating a covered secret
+  changes its wrapped DEK; the grant simply stops matching and the serve
+  falls back to prompting.
+- **Agent restart drops grants.** `jit grant list` after a restart is empty;
+  the audit trail still shows what existed. Acceptable for v1; a persisted
+  (metadata-only) ledger is a possible v2, but the DEKs themselves should
+  never touch disk.
+- **v2 candidates, not now:** binding by code-signing identity (survives
+  restarts, murky for interpreter-run tools), grants offered directly from
+  the consent prompt ("allow once / 1h / 8h"), `jit status` surfacing.

--- a/docs/index.md
+++ b/docs/index.md
@@ -96,6 +96,7 @@ then **[Install](./getting-started/install.md)** →
 
 - [Unlock once, not per command](./service/index.md) - always-on, TTL, lock/unlock
 - [Per-process credential consent](./service/consent.md) - a Touch ID the first time each tool reaches for a credential, naming who is asking
+- [Process grants](./service/grants.md) - pre-approve a running tool to work unattended for a bounded time, revocable and fully audited
 - [Provenance](./service/provenance.md) - why every prompt names its caller, `status` and `audit`
 
 ## Reference

--- a/docs/reference/commands/jit.md
+++ b/docs/reference/commands/jit.md
@@ -28,6 +28,7 @@ jit [flags]
 * [jit doctor](jit_doctor.md)	 - One-shot health check: profiles, secrets, service, backup, and wrap shims
 * [jit export](jit_export.md)	 - Print shell export statements for a profile's secrets
 * [jit git-credential](jit_git-credential.md)	 - Implement git's credential-helper protocol for migrated HTTPS logins
+* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
 * [jit guard](jit_guard.md)	 - Prevention hooks that keep credentials from being recorded in the first place
 * [jit k8s-exec-credential](jit_k8s-exec-credential.md)	 - Print a Kubernetes ExecCredential JSON for a migrated profile
 * [jit lock](jit_lock.md)	 - Lock jit's session immediately, without waiting for the TTL

--- a/docs/reference/commands/jit_grant.md
+++ b/docs/reference/commands/jit_grant.md
@@ -1,0 +1,61 @@
+## jit grant
+
+Pre-approve a running process to use profiles unattended
+
+### Synopsis
+
+Create a process grant: with one Touch ID now, allow a process that is
+already running (and everything it launches) to use the named profiles'
+secrets without further prompts, until the grant expires — including while
+the screen is locked or you are away.
+
+The grant is anchored to the live process you name, not to its name: a new
+process called the same thing tomorrow inherits nothing. It covers exactly
+the secrets the named profiles resolve to at creation time, ends at its
+deadline (or when the process exits, or on 'jit grant revoke'), and every
+serve under it is recorded in 'jit audit'.
+
+Grants live in the service's memory: they survive screen lock by design,
+and do not survive a service restart or reboot.
+
+```
+jit grant --process NAME --profile NAME --for DURATION [flags]
+```
+
+### Examples
+
+```
+  # let the running claude session use the jamf profile for 8 hours
+  jit grant --process claude --profile jamf --for 8h
+
+  # several profiles in one grant, anchored by pid when the name is ambiguous
+  jit grant --pid 4211 --profile jamf --profile aws-ci --for 1d
+
+  # see, shorten, or end what is open
+  jit grant list
+  jit grant revoke g-7f3a
+  jit grant extend g-7f3a --for 24h
+```
+
+### Options
+
+```
+      --for string            how long the grant lasts (45m, 8h, 3d - max 7d)
+      --pid int32             running process the grant anchors to, by pid (when --process is ambiguous)
+      --process string        running program the grant anchors to, by name (tab-completes from recent callers)
+      --profile stringArray   profile whose secrets the grant covers (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit](jit.md)	 - Local-first developer secret runtime
+* [jit grant extend](jit_grant_extend.md)	 - Give an existing grant more time (re-prompts Touch ID)
+* [jit grant list](jit_grant_list.md)	 - Show the active process grants
+* [jit grant revoke](jit_grant_revoke.md)	 - End a process grant now
+

--- a/docs/reference/commands/jit_grant_extend.md
+++ b/docs/reference/commands/jit_grant_extend.md
@@ -1,0 +1,31 @@
+## jit grant extend
+
+Give an existing grant more time (re-prompts Touch ID)
+
+### Synopsis
+
+Move a grant's deadline to now plus the new duration. More time is a new
+decision, so this puts the same disclosed prompt in front of you that
+creating the grant did. Shortening needs no command of its own: revoke and
+re-create, and neither step re-asks for what you already have.
+
+```
+jit grant extend ID --for DURATION [flags]
+```
+
+### Options
+
+```
+      --for string   new lifetime from now (45m, 8h, 3d - max 7d)
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+

--- a/docs/reference/commands/jit_grant_list.md
+++ b/docs/reference/commands/jit_grant_list.md
@@ -1,0 +1,30 @@
+## jit grant list
+
+Show the active process grants
+
+### Synopsis
+
+List every live process grant: who holds it, which profiles it covers,
+when it expires, and how many serves have ridden it. Reading this never
+prompts.
+
+```
+jit grant list [flags]
+```
+
+### Options
+
+```
+      --format string   output format: text or json (default "text")
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+

--- a/docs/reference/commands/jit_grant_revoke.md
+++ b/docs/reference/commands/jit_grant_revoke.md
@@ -1,0 +1,24 @@
+## jit grant revoke
+
+End a process grant now
+
+### Synopsis
+
+End a grant immediately. No authentication: reducing access is always
+free, and the kill switch is deliberately the easiest command in the
+feature. The ending is recorded in 'jit audit'.
+
+```
+jit grant revoke ID
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -120,6 +120,20 @@ machine still cannot read, dump, or destroy the vault without a live human
 gesture. Only `list`/`history` (names and version timestamps, never a value)
 are prompt-free.
 
+**One state deliberately survives a re-lock:** a
+[process grant](../service/grants.md). Everything else the service holds -
+the session key, consent decisions, `--trust` roots, run attachments - drops
+the moment the session ends, because those all ride an approval whose scope
+was "this session". A grant's approval said something different, out loud:
+*unattended, until a deadline*, for named secrets and one live process tree
+(anchored by pid and kernel fork-time, so a recycled pid inherits nothing).
+It is strictly narrower than the session it stands in for: never the master
+key, only the covered secrets' data keys, in service memory only, ended by
+its deadline, its process exiting, a restart, or an unauthenticated
+`jit grant revoke`. The decision point is unchanged - a human on a disclosed
+prompt - it just happens before the absence instead of during it, and every
+serve under it is a distinct [`jit audit`](../service/provenance.md) event.
+
 **Refusing has to stay cheap.** A consent prompt cannot cache a refusal as a
 lasting "no" - the prompt cannot tell a human's decline from a keychain
 failure, and treating either as permanent would lock a credential out with no

--- a/docs/service/grants.md
+++ b/docs/service/grants.md
@@ -1,0 +1,98 @@
+---
+title: Process grants
+description: Pre-approve a running tool to use profiles unattended for a bounded time - one Touch ID now, no prompts while you are away, everything on the audit trail.
+---
+
+# Process grants - approve now, run unattended
+
+Everything jit serves normally rides a session you opened with Touch ID, and
+that session ends when you walk away: idle timeout, screen lock, sleep. That
+is the right default, and it has one honest gap - work that runs while you
+are *not* there. An AI agent working overnight, a long build, a scheduled
+job: the session drops, the next credential read stops on a prompt nobody
+will answer.
+
+A **process grant** moves your decision earlier instead of removing it. While
+you are at the keyboard, one disclosed Touch ID approves that a specific
+**running process** (and everything it launches) may use the secrets of one
+or more profiles until a deadline you set:
+
+```sh
+jit grant --process claude --profile jamf --profile aws-ci --for 8h
+```
+
+The prompt says exactly what you are signing:
+
+> jit is trying to **let claude use 3 secrets (jamf, aws-ci) unattended for 8h**.
+
+From then until it expires, credential reads from that process tree succeed
+with no prompts - including while the screen is locked. Everything else
+keeps today's behavior: other processes still prompt, other secrets still
+prompt, and the vault's management commands still take a fresh gesture.
+
+## What a grant anchors to
+
+A grant names a process that **exists right now** - resolved to a live pid
+(and its kernel fork-time stamp), never stored as a name pattern. A new
+process that calls itself `claude` tomorrow inherits nothing. If two
+processes share the name, jit lists them and makes you pick with `--pid`;
+it never guesses.
+
+The covered secrets are resolved from the profiles **at creation time**, by
+the service itself, through the same project-then-global profile lookup
+`jit run` uses. Editing a profile later never silently widens a standing
+grant, and the prompt can never describe a different set than the grant
+covers.
+
+## What ends it
+
+Whichever comes first, and each ending lands in `jit audit`:
+
+- **its deadline** - `--for` takes `45m`, `8h`, `3d`, capped at 7 days;
+- **the process exiting** - the grant dies with the tree it named;
+- **`jit grant revoke <id>`** - immediate, and deliberately needs no
+  authentication: reducing access is always free, so the kill switch is the
+  easiest command in the feature;
+- **a service restart or reboot** - grants live in the service's memory,
+  never on disk.
+
+Wanting *more* time is a new decision, so `jit grant extend <id> --for 24h`
+puts the same disclosed prompt in front of you that creating it did.
+
+```sh
+jit grant list             # what is open: who, which profiles, time left, serves
+jit grant revoke g-7f3a2c81
+jit grant extend g-7f3a2c81 --for 24h
+```
+
+## The audit trail tells the whole story
+
+A standing, unattended credential channel is only acceptable if you can read
+back everything it did. Each stage is a durable
+[`jit audit`](./provenance.md) event:
+
+```
+$ jit audit --kind grant
+time=... kind=grant status=approved reason="let claude use 2 secrets (jamf) unattended for 8h"
+time=... kind=grant status=ended grant=g-7f3a2c81 reason="claude's grant expired"
+$ jit audit --kind use
+time=... kind=use op="read a secret via grant" count=2 parent=claude secrets="jamf/api-user, jamf/api-pass"
+```
+
+Serves under a grant carry their own op (`read a secret via grant`), so
+"rode an unlock you gave moments ago" and "rode a standing grant from this
+morning" are never the same line.
+
+## The honest limits
+
+- A grant covers **pull-at-use** delivery: credential hooks, wrap shims, and
+  `jit run` invocations made under the granted tree. Environment variables a
+  `jit run` already injected were handed over up front, grant or no grant.
+- Live file mounts keep their own [consent gating](./consent.md); grants do
+  not cover FIFO reads.
+- Rotating a covered secret changes its key material; the grant simply stops
+  matching it and that read falls back to prompting.
+- The grant's process match is the anchor for a decision **you** made on a
+  Touch ID naming that process; as everywhere in jit, kernel-derived
+  identity explains and audits, it never decides on its own (see
+  [Security architecture](../security/architecture.md)).

--- a/docs/service/index.md
+++ b/docs/service/index.md
@@ -20,7 +20,11 @@ The shared session covers the high-frequency paths - native credential
 hooks (`aws`, `kubectl`) and `jit run`. On top of it,
 [per-process consent](./consent.md) (on by default) still prompts a Touch ID
 the first time each tool reaches for a real credential, naming who is asking,
-so an unlocked session is never a blank cheque. It deliberately does **not**
+so an unlocked session is never a blank cheque. And for the opposite
+situation - work that must keep running while you are *away* from the
+keyboard - a [process grant](./grants.md) lets you pre-approve one running
+tool for named profiles and a bounded time, with one Touch ID given while
+you are still there. It deliberately does **not**
 cover the sensitive [`jit vault`](../vault/index.md) management commands
 (`get`/`set`/`rm`/`import`/`restore`/`clean`/`prune`/`delete`/`export`):
 those always require a fresh Touch ID/passcode on every run, unlocked or

--- a/docs/service/provenance.md
+++ b/docs/service/provenance.md
@@ -47,7 +47,7 @@ is not authenticating one, and jit doesn't pretend otherwise (see
   time=2026-07-22 13:18:02 level=warn kind=unlock status=denied method=touchid-or-passcode reason="local authentication failed: the user canceled" cmd="~/some-script.sh" parent=Code
   ```
 
-Among the auth events, seven kinds appear:
+Among the auth events, eight kinds appear:
 
 - **unlock (status=ok)** - a Touch ID/passcode prompt the human approved, with
   the command that triggered it and what launched that command.
@@ -61,17 +61,28 @@ Among the auth events, seven kinds appear:
   how many times it has already been refused.
 - **grant (status=approved)** - a *disclosed* prompt the human approved: a
   `jit run --with` grant of a machine-global credential, a per-process consent
-  approval, or a `jit run --trust` registration. These sit on top of the
-  session rather than opening one, so they are their own kind rather than an
-  unlock, and `reason` is the exact sentence that was on the dialog. Without
+  approval, a `jit run --trust` registration, or a
+  [process grant](./grants.md)'s creation or extension. These sit on top of
+  the session rather than opening one, so they are their own kind rather than
+  an unlock, and `reason` is the exact sentence that was on the dialog. Without
   this entry the trail could show every prompt you *refused* and none that you
   allowed, which is the wrong half to be able to prove.
+- **grant (status=ended)** - a [process grant](./grants.md) ending, with the
+  reason (`expired`, `revoked` - carrying the revoker's provenance - or the
+  anchored process exiting), the grant id, and the vault paths it covered.
+  Recorded because a standing approval's *end* is the fact an investigation
+  needs: "was the grant still live at the time?" is unanswerable from a trail
+  that only records beginnings. `--kind grant` shows a grant's whole life.
 - **use** - what flowed through the already-open session *between* the
   prompts: reads, stores, and grants that rode the cached unlock,
   collapsed per caller (a profile resolve's burst of reads is one entry,
   not ten). The secret names are what the calling jit process reported
   about itself - useful for audit, labeled `caller-reported` because,
   unlike everything else on these lines, they don't come from the kernel.
+  A read served by a live process grant instead of the session renders as
+  its own op, `read a secret via grant`, with the covered path named by the
+  service itself rather than caller-reported - so unattended serves are
+  never mistaken for session activity.
 - **serve** - a reader opened a live mount, and what it got: the decoy
   (`status=decoy`) or the real value (`status=real`), why that verdict, and -
   best-effort, from the kernel - which program read it and what launched that

--- a/internal/agent/caller.go
+++ b/internal/agent/caller.go
@@ -234,6 +234,8 @@ func DescribeUse(op string) string {
 		return "extended the session"
 	case opServeMounts:
 		return "served mounted files"
+	case opGrantUse:
+		return "read a secret via grant"
 	default:
 		return op
 	}

--- a/internal/agent/caller.go
+++ b/internal/agent/caller.go
@@ -234,7 +234,7 @@ func DescribeUse(op string) string {
 		return "extended the session"
 	case opServeMounts:
 		return "served mounted files"
-	case opGrantUse:
+	case OpGrantUse:
 		return "read a secret via grant"
 	default:
 		return op

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -318,6 +318,59 @@ func (c *Client) GrantGlobalForPID(mounts []RunMount, pid int32) error {
 	return err
 }
 
+// GrantCreate asks the agent to create a process grant: after one disclosed
+// challenge (agent-worded, like every prompt), pid's process tree may unwrap
+// the named profiles' secrets until now+ttl, unattended, across re-locks.
+// The client sends profile NAMES and its project root only — the agent
+// resolves them to concrete secrets itself, so the prompt and the granted
+// set cannot disagree (see Server.OnResolveGrant). Returns the created
+// grant's status for rendering.
+func (c *Client) GrantCreate(pid int32, profiles []string, projectRoot string, ttl time.Duration) (GrantStatus, error) {
+	resp, err := c.call(Request{
+		Op:            OpGrantCreate,
+		TargetPID:     pid,
+		GrantProfiles: profiles,
+		ProjectRoot:   projectRoot,
+		TTLSeconds:    int64(ttl / time.Second),
+	})
+	if err != nil {
+		return GrantStatus{}, err
+	}
+	if len(resp.Grants) != 1 {
+		return GrantStatus{}, fmt.Errorf("agent: grant created but not reported back")
+	}
+	return resp.Grants[0], nil
+}
+
+// GrantList reads the live process grants — prompt-free, like History.
+func (c *Client) GrantList() ([]GrantStatus, error) {
+	resp, err := c.call(Request{Op: OpGrantList})
+	if err != nil {
+		return nil, err
+	}
+	return resp.Grants, nil
+}
+
+// GrantRevoke ends a grant now. No challenge, by design: reducing access is
+// always free, and the kill switch must be the easiest thing in the feature.
+func (c *Client) GrantRevoke(id string) error {
+	_, err := c.call(Request{Op: OpGrantRevoke, GrantID: id})
+	return err
+}
+
+// GrantExtend moves a grant's deadline to now+ttl, behind a fresh disclosed
+// challenge — more time is a new decision.
+func (c *Client) GrantExtend(id string, ttl time.Duration) (GrantStatus, error) {
+	resp, err := c.call(Request{Op: OpGrantExtend, GrantID: id, TTLSeconds: int64(ttl / time.Second)})
+	if err != nil {
+		return GrantStatus{}, err
+	}
+	if len(resp.Grants) != 1 {
+		return GrantStatus{}, fmt.Errorf("agent: grant extended but not reported back")
+	}
+	return resp.Grants[0], nil
+}
+
 // RunMounts labels each of paths with a single mode — the common shape when
 // every mount in a group shares one treatment (all grants, or all swaps).
 // One helper so the paths->[]RunMount transform lives in exactly one place.

--- a/internal/agent/grant.go
+++ b/internal/agent/grant.go
@@ -135,11 +135,6 @@ const (
 	grantEndExited  = "process exited"
 )
 
-// opGrantUse labels a KindUse event served from a grant's DEK cache instead
-// of the session — the audit distinction between "rode an unlock you gave
-// moments ago" and "rode a standing grant you gave this morning".
-const opGrantUse = "grant_use"
-
 // newGrantID mints a short, non-guessable grant id ("g-3f9a2c81"). Random
 // rather than sequential so an id never encodes how many grants exist, and
 // short enough to type into `jit grant revoke`.

--- a/internal/agent/grant.go
+++ b/internal/agent/grant.go
@@ -1,0 +1,554 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package agent
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jitpass/jit/internal/lineage"
+)
+
+// This file is the process-grant store (design/process-grants.md): the one
+// piece of authorization state that deliberately SURVIVES a re-lock.
+//
+// A process grant is a human decision moved earlier: while present, the user
+// approves with one disclosed challenge that a specific running process tree
+// may unwrap the secrets of named profiles until an absolute deadline —
+// unattended, across screen lock. Mechanically it is a scoped DEK cache: at
+// creation, while the challenge's MEK is in hand, the covered envelopes' DEKs
+// are unwrapped and held (mlocked) keyed by a digest of their wrapped bytes;
+// a later OpUnwrap whose caller descends from the grant's root and whose
+// wrapped bytes match is answered from that cache, with no session, no
+// consent prompt, and a full audit record. Everything else — wrong tree,
+// expired, rotated secret, uncovered path — falls through to the ordinary
+// path unchanged.
+//
+// The anchoring is trustRoots' exactly: pid plus fork-time stamp, descent by
+// lineage.AncestryContainsPID, every uncertainty failing closed. The doctrine
+// "identity explains, never decides" holds because the DECISION was the
+// disclosed Touch ID at creation, bound to a kernel-vouched pid; descent
+// afterwards only routes to a decision the human already made — the same
+// footing as `jit run --trust`, narrowed from "everything, this session" to
+// "these secrets, until this deadline".
+
+// MaxGrantTTL caps a grant's lifetime, creation and extension alike. A week
+// is deliberately generous (a machine left working over a long weekend) while
+// still bounding a typo: `--for 30d` must fail loudly, not quietly mint a
+// month of unattended access.
+const MaxGrantTTL = 7 * 24 * time.Hour
+
+// minGrantTTL rejects grants too short to mean anything: a sub-minute grant
+// is either a typo or a caller trying to use grants as a session substitute.
+const minGrantTTL = time.Minute
+
+// GrantSecret is one secret a grant should cover, as resolved by the agent's
+// own CLI wiring (Server.OnResolveGrant): the vault path, the envelope's
+// wrapped DEK bytes, and its AAD-bound class. The class is what keeps the
+// resolution honest end-to-end: creation unwraps each entry with the class as
+// AAD, so an entry whose class was misreported fails the auth tag and the
+// whole create fails — nothing is ever granted that the prompt didn't
+// truthfully describe.
+type GrantSecret struct {
+	Path    string
+	Wrapped []byte
+	Class   string
+}
+
+// grantSecret is one covered secret inside a stored grant: its vault path
+// (agent-verified at creation, unlike Request.Label) and its plaintext DEK.
+type grantSecret struct {
+	path string
+	dek  []byte
+}
+
+// processGrant is one live grant. Immutable after creation except expires,
+// serves and lastServe, all mutated under Server.grantMu.
+type processGrant struct {
+	id        string
+	rootPID   int32
+	rootStart int64 // fork-time stamp — the anti-pid-recycling anchor
+	name      string
+	command   string
+	profiles  []string
+	// deks maps hex(sha256(wrapped bytes)) -> the covered secret. Keyed on
+	// the wrapped bytes themselves so the serve path needs no vault access
+	// at all: the client already sends exactly those bytes on every unwrap.
+	deks      map[string]grantSecret
+	created   time.Time
+	expires   time.Time
+	serves    int64
+	lastServe time.Time
+}
+
+// paths lists the covered vault paths, sorted for stable display and events.
+func (g *processGrant) secretPaths() []string {
+	out := make([]string, 0, len(g.deks))
+	for _, s := range g.deks {
+		out = append(out, s.path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// status snapshots a grant for the wire. rootAlive is the caller's answer —
+// liveness needs a sysctl the caller has usually just done.
+func (g *processGrant) status(rootAlive bool) GrantStatus {
+	st := GrantStatus{
+		ID:          g.id,
+		PID:         g.rootPID,
+		Name:        g.name,
+		Command:     g.command,
+		Profiles:    append([]string(nil), g.profiles...),
+		Secrets:     g.secretPaths(),
+		CreatedUnix: g.created.Unix(),
+		ExpiresUnix: g.expires.Unix(),
+		Serves:      g.serves,
+		RootAlive:   rootAlive,
+	}
+	if !g.lastServe.IsZero() {
+		st.LastServeUnix = g.lastServe.Unix()
+	}
+	return st
+}
+
+// wipeDEKs zeroes and munlocks every cached DEK. Caller must hold grantMu (or
+// own the grant exclusively, as a failed create does).
+func (g *processGrant) wipeDEKs() {
+	for k, s := range g.deks {
+		wipe(s.dek)
+		unlockMemory(s.dek)
+		delete(g.deks, k)
+	}
+}
+
+// grantEndCause values — the vocabulary KindGrantEnd.Cause draws from.
+const (
+	grantEndExpired = "expired"
+	grantEndRevoked = "revoked"
+	grantEndExited  = "process exited"
+)
+
+// opGrantUse labels a KindUse event served from a grant's DEK cache instead
+// of the session — the audit distinction between "rode an unlock you gave
+// moments ago" and "rode a standing grant you gave this morning".
+const opGrantUse = "grant_use"
+
+// newGrantID mints a short, non-guessable grant id ("g-3f9a2c81"). Random
+// rather than sequential so an id never encodes how many grants exist, and
+// short enough to type into `jit grant revoke`.
+func newGrantID() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("minting grant id: %w", err)
+	}
+	return "g-" + hex.EncodeToString(b[:]), nil
+}
+
+// wrappedDigest keys a grant's DEK cache: a digest of the wrapped bytes, so
+// the map never holds the wrapped form and the plaintext side by side.
+func wrappedDigest(wrapped []byte) string {
+	sum := sha256.Sum256(wrapped)
+	return hex.EncodeToString(sum[:])
+}
+
+// createGrant validates, prompts (one disclosed challenge), unwraps and
+// stores a grant. It is OpGrantCreate's whole body, kept here so server.go's
+// dispatch stays a switch.
+func (s *Server) createGrant(req Request, c *caller) Response {
+	if c == nil {
+		return Response{OK: false, Error: "grant_create: caller could not be identified"}
+	}
+	if req.TargetPID <= 0 {
+		return Response{OK: false, Error: "grant_create: missing target_pid"}
+	}
+	if len(req.GrantProfiles) == 0 {
+		return Response{OK: false, Error: "grant_create: missing grant_profiles"}
+	}
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	if ttl < minGrantTTL || ttl > MaxGrantTTL {
+		return Response{OK: false, Error: fmt.Sprintf("grant_create: ttl must be between %s and %s", minGrantTTL, MaxGrantTTL)}
+	}
+	if s.OnResolveGrant == nil {
+		return Response{OK: false, Error: "grant_create: this agent has no grant resolver wired"}
+	}
+
+	// The target is described by the KERNEL, from the pid alone — the name on
+	// the prompt is never a string the requesting process typed. The fork-time
+	// stamp is taken BEFORE the (up to ~120s) challenge and re-verified after,
+	// so a target that dies and gets its pid recycled mid-prompt cannot
+	// inherit the approval.
+	target, ok := lineage.Describe(req.TargetPID)
+	if !ok {
+		return Response{OK: false, Error: fmt.Sprintf("grant_create: no such process (pid %d)", req.TargetPID)}
+	}
+	rootStart, ok := lineage.ProcessStartTime(req.TargetPID)
+	if !ok {
+		return Response{OK: false, Error: fmt.Sprintf("grant_create: process %d cannot be anchored (already exiting?)", req.TargetPID)}
+	}
+
+	// Resolution happens BEFORE the prompt (same ordering as OnCanGrant): an
+	// unresolvable profile fails without burning a Touch ID, and the human
+	// approves the whole named set or none of it.
+	secrets, err := s.OnResolveGrant(req.GrantProfiles, req.ProjectRoot)
+	if err != nil {
+		return Response{OK: false, Error: fmt.Sprintf("grant_create: %s", err)}
+	}
+	if len(secrets) == 0 {
+		return Response{OK: false, Error: "grant_create: the named profiles resolve to no secrets"}
+	}
+
+	reason := grantCreateReason(target.Name(), req.GrantProfiles, len(secrets), ttl)
+	event, mek, err := s.discloseChallengeOp(reason, OpGrantCreate, c)
+	if s.OnSessionEvent != nil {
+		s.OnSessionEvent(*event)
+	}
+	if err != nil {
+		return Response{OK: false, Error: err.Error()}
+	}
+	defer wipe(mek)
+
+	id, err := newGrantID()
+	if err != nil {
+		return Response{OK: false, Error: err.Error()}
+	}
+	g := &processGrant{
+		id:        id,
+		rootPID:   req.TargetPID,
+		rootStart: rootStart,
+		name:      target.Name(),
+		command:   target.Command(),
+		profiles:  append([]string(nil), req.GrantProfiles...),
+		deks:      make(map[string]grantSecret, len(secrets)),
+		created:   time.Now(),
+		expires:   time.Now().Add(ttl),
+	}
+	for _, sec := range secrets {
+		dek, err := open(mek, sec.Wrapped, []byte(sec.Class))
+		if err != nil {
+			// One bad entry fails the whole create: the human approved a
+			// specific count, and a grant quietly covering fewer secrets than
+			// its prompt named is a prompt that lied by omission.
+			g.wipeDEKs()
+			return Response{OK: false, Error: fmt.Sprintf("grant_create: %s cannot be unwrapped (%s), no grant created", sec.Path, err)}
+		}
+		lockMemory(dek)
+		g.deks[wrappedDigest(sec.Wrapped)] = grantSecret{path: sec.Path, dek: dek}
+	}
+
+	// The prompt has been answered; make sure the process it named is still
+	// the process the grant will serve.
+	if cur, ok := lineage.ProcessStartTime(req.TargetPID); !ok || cur != rootStart {
+		g.wipeDEKs()
+		return Response{OK: false, Error: fmt.Sprintf("grant_create: process %d exited while the prompt was up, no grant created", req.TargetPID)}
+	}
+
+	s.grantMu.Lock()
+	if s.grants == nil {
+		s.grants = map[string]*processGrant{}
+	}
+	s.grants[id] = g
+	st := g.status(true)
+	s.grantMu.Unlock()
+	s.armGrantExpiry(g.id, g.expires)
+
+	return Response{OK: true, Grants: []GrantStatus{st}}
+}
+
+// grantCreateReason words the creation prompt. Everything in it is
+// agent-derived or abort-verified: the name comes from the kernel via the
+// target pid, the count and duration ARE the grant's scope, and the profile
+// names were resolved by the agent itself to exactly the secrets being
+// granted (OnResolveGrant), never echoed from free text. The scope statement
+// ("unattended, until ...") is the half that must never be the truncated
+// half, same budget discipline as trustReason.
+func grantCreateReason(name string, profiles []string, count int, ttl time.Duration) string {
+	who := truncate(name, maxTrustWhoLen)
+	if who == "" {
+		who = "this process"
+	}
+	noun := "secrets"
+	if count == 1 {
+		noun = "secret"
+	}
+	// The name and profile budgets are sized so the whole sentence fits
+	// maxReasonLen with room to spare: the trailing scope statement
+	// ("unattended for …") is the half that changes the decision, so it must
+	// never be the half a long tool name pushes off the prompt. The outer
+	// truncate is a belt only.
+	return truncate(fmt.Sprintf("let %s use %d %s (%s) unattended for %s",
+		who, count, noun, truncate(strings.Join(profiles, ", "), 20), formatGrantTTL(ttl)), maxReasonLen)
+}
+
+// formatGrantTTL renders a duration the way a human typed it: "8h", "45m",
+// "3d" — never time.Duration's "8h0m0s", which reads like a countdown.
+func formatGrantTTL(d time.Duration) string {
+	d = d.Round(time.Minute)
+	if d >= 24*time.Hour && d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
+	}
+	if d >= time.Hour && d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", d/time.Hour)
+	}
+	if d >= time.Hour {
+		return fmt.Sprintf("%dh%02dm", d/time.Hour, (d%time.Hour)/time.Minute)
+	}
+	return fmt.Sprintf("%dm", d/time.Minute)
+}
+
+// grantUnwrap answers an OpUnwrap from the grant store, or returns ok=false
+// to send the request down the ordinary session path. On a hit it returns a
+// COPY of the cached DEK (mekCopy's reasoning: the store wipes independently
+// of the response being written) and the agent-verified vault path for the
+// audit record.
+//
+// Fail-closed at every step, trustRoots-style: expired grants and dead roots
+// are ended (with their KindGrantEnd event) rather than skipped, the root's
+// fork-time is re-verified before descent, and any unreadable ancestry
+// answers "no grant". A miss never errors — the ordinary path decides.
+func (s *Server) grantUnwrap(c *caller, wrapped []byte) (dek []byte, path string, ok bool) {
+	if c == nil {
+		return nil, "", false
+	}
+	s.grantMu.Lock()
+	if len(s.grants) == 0 {
+		s.grantMu.Unlock()
+		return nil, "", false
+	}
+	digest := wrappedDigest(wrapped)
+	// Snapshot the candidates that cover these wrapped bytes, then verify
+	// descent OUTSIDE grantMu — AncestryContainsPID walks sysctls, and list/
+	// revoke must not queue behind it (trustRoots' exact discipline).
+	type candidate struct {
+		id        string
+		rootPID   int32
+		rootStart int64
+	}
+	var cands []candidate
+	for _, g := range s.grants {
+		if _, covered := g.deks[digest]; covered {
+			cands = append(cands, candidate{id: g.id, rootPID: g.rootPID, rootStart: g.rootStart})
+		}
+	}
+	s.grantMu.Unlock()
+	if len(cands) == 0 {
+		s.pruneGrants(time.Now())
+		return nil, "", false
+	}
+
+	now := time.Now()
+	for _, cand := range cands {
+		if cur, alive := lineage.ProcessStartTime(cand.rootPID); !alive || cur != cand.rootStart {
+			s.endGrant(cand.id, grantEndExited)
+			continue
+		}
+		if !lineage.AncestryContainsPID(c.pid, cand.rootPID) {
+			continue
+		}
+		s.grantMu.Lock()
+		g := s.grants[cand.id] // re-check: a revoke may have won the race
+		if g == nil {
+			s.grantMu.Unlock()
+			continue
+		}
+		if now.After(g.expires) {
+			s.grantMu.Unlock()
+			s.endGrant(cand.id, grantEndExpired)
+			continue
+		}
+		sec, covered := g.deks[digest]
+		if !covered {
+			s.grantMu.Unlock()
+			continue
+		}
+		out := make([]byte, len(sec.dek))
+		copy(out, sec.dek)
+		g.serves++
+		g.lastServe = now
+		s.grantMu.Unlock()
+		return out, sec.path, true
+	}
+	return nil, "", false
+}
+
+// listGrants prunes, then snapshots every live grant for the wire, newest
+// first. Prompt-free by design (OpHistory's reasoning: reading what standing
+// access exists must never itself cost an authentication).
+func (s *Server) listGrants() []GrantStatus {
+	s.pruneGrants(time.Now())
+	s.grantMu.Lock()
+	grants := make([]*processGrant, 0, len(s.grants))
+	for _, g := range s.grants {
+		grants = append(grants, g)
+	}
+	s.grantMu.Unlock()
+
+	sort.Slice(grants, func(i, j int) bool { return grants[i].created.After(grants[j].created) })
+	out := make([]GrantStatus, 0, len(grants))
+	for _, g := range grants {
+		cur, alive := lineage.ProcessStartTime(g.rootPID)
+		s.grantMu.Lock()
+		st := g.status(alive && cur == g.rootStart)
+		s.grantMu.Unlock()
+		out = append(out, st)
+	}
+	return out
+}
+
+// revokeGrant ends a grant by id, attributing the revoker. Deliberately NO
+// challenge: reducing access is always free, and revocation must be the
+// easiest operation in the feature — an auth gate on the kill switch only
+// ever delays the person pulling it.
+func (s *Server) revokeGrant(id string, c *caller) Response {
+	s.grantMu.Lock()
+	_, exists := s.grants[id]
+	s.grantMu.Unlock()
+	if !exists {
+		return Response{OK: false, Error: fmt.Sprintf("grant_revoke: no grant %q (it may have already expired — `jit grant list` shows what is live)", id)}
+	}
+	s.endGrantBy(id, grantEndRevoked, c)
+	return Response{OK: true}
+}
+
+// extendGrant re-prompts (more time is a NEW decision — the original approval
+// bounded exactly the window being widened) and moves a grant's deadline to
+// now+ttl.
+func (s *Server) extendGrant(req Request, c *caller) Response {
+	if c == nil {
+		return Response{OK: false, Error: "grant_extend: caller could not be identified"}
+	}
+	ttl := time.Duration(req.TTLSeconds) * time.Second
+	if ttl < minGrantTTL || ttl > MaxGrantTTL {
+		return Response{OK: false, Error: fmt.Sprintf("grant_extend: ttl must be between %s and %s", minGrantTTL, MaxGrantTTL)}
+	}
+	s.grantMu.Lock()
+	g := s.grants[req.GrantID]
+	var name string
+	var count int
+	var profiles []string
+	if g != nil {
+		name, count, profiles = g.name, len(g.deks), g.profiles
+	}
+	s.grantMu.Unlock()
+	if g == nil {
+		return Response{OK: false, Error: fmt.Sprintf("grant_extend: no grant %q (it may have expired — extend cannot resurrect one, create it again)", req.GrantID)}
+	}
+
+	// grantCreateReason already words the full scope; re-lead it as an
+	// extension so the prompt says what is actually happening.
+	reason := truncate("extend: "+grantCreateReason(name, profiles, count, ttl), maxReasonLen)
+	event, mek, err := s.discloseChallengeOp(reason, OpGrantExtend, c)
+	if s.OnSessionEvent != nil {
+		s.OnSessionEvent(*event)
+	}
+	if err != nil {
+		return Response{OK: false, Error: err.Error()}
+	}
+	wipe(mek)
+
+	s.grantMu.Lock()
+	g = s.grants[req.GrantID] // re-check: it may have ended during the prompt
+	if g == nil {
+		s.grantMu.Unlock()
+		return Response{OK: false, Error: fmt.Sprintf("grant_extend: grant %q ended while the prompt was up", req.GrantID)}
+	}
+	g.expires = time.Now().Add(ttl)
+	st := g.status(true)
+	expires := g.expires
+	s.grantMu.Unlock()
+	s.armGrantExpiry(req.GrantID, expires)
+	return Response{OK: true, Grants: []GrantStatus{st}}
+}
+
+// endGrant ends one grant with a cause, wiping its DEKs and emitting the
+// KindGrantEnd event. Idempotent: a grant already gone is a no-op, so the
+// lazy prune, the expiry timer and an explicit revoke can all race safely.
+func (s *Server) endGrant(id, cause string) {
+	s.endGrantBy(id, cause, nil)
+}
+
+func (s *Server) endGrantBy(id, cause string, c *caller) {
+	s.grantMu.Lock()
+	g := s.grants[id]
+	if g == nil {
+		s.grantMu.Unlock()
+		return
+	}
+	delete(s.grants, id)
+	paths := g.secretPaths()
+	name := g.name
+	g.wipeDEKs()
+	s.grantMu.Unlock()
+
+	event := SessionEvent{
+		UnixTime: time.Now().Unix(),
+		Kind:     KindGrantEnd,
+		Op:       id,
+		Cause:    fmt.Sprintf("%s's grant %s", name, cause),
+		Labels:   paths,
+	}
+	if c != nil {
+		event.By = c.command()
+		event.ByPID = c.pid
+		event.LaunchedBy = c.launchedBy()
+	}
+	s.mu.Lock()
+	s.recordEvent(event)
+	s.mu.Unlock()
+	if s.OnSessionEvent != nil {
+		s.OnSessionEvent(event)
+	}
+}
+
+// pruneGrants ends every grant that is past its deadline or whose root no
+// longer exists (fork-time mismatch included). Called lazily from the serve
+// and list paths and by each grant's own expiry timer, so an ended grant's
+// DEKs never linger much past the moment they stopped being authorized.
+func (s *Server) pruneGrants(now time.Time) {
+	s.grantMu.Lock()
+	type check struct {
+		id        string
+		rootPID   int32
+		rootStart int64
+		expired   bool
+	}
+	var checks []check
+	for _, g := range s.grants {
+		checks = append(checks, check{id: g.id, rootPID: g.rootPID, rootStart: g.rootStart, expired: now.After(g.expires)})
+	}
+	s.grantMu.Unlock()
+
+	for _, ch := range checks {
+		if ch.expired {
+			s.endGrant(ch.id, grantEndExpired)
+			continue
+		}
+		if cur, alive := lineage.ProcessStartTime(ch.rootPID); !alive || cur != ch.rootStart {
+			s.endGrant(ch.id, grantEndExited)
+		}
+	}
+}
+
+// armGrantExpiry schedules the expiry sweep for one grant. The timer fires a
+// prune rather than ending the id unconditionally — an extend that moved the
+// deadline re-arms, and the stale timer's prune then finds nothing expired
+// (the same reason armLockTimer carries a generation; here the prune's own
+// deadline re-check is the guard).
+func (s *Server) armGrantExpiry(id string, expires time.Time) {
+	delay := time.Until(expires) + time.Second
+	time.AfterFunc(delay, func() {
+		s.grantMu.Lock()
+		g := s.grants[id]
+		expired := g != nil && time.Now().After(g.expires)
+		s.grantMu.Unlock()
+		if expired {
+			s.endGrant(id, grantEndExpired)
+		}
+	})
+}

--- a/internal/agent/grant_test.go
+++ b/internal/agent/grant_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -388,6 +389,69 @@ func TestFormatGrantTTL(t *testing.T) {
 			t.Errorf("formatGrantTTL(%s) = %q, want %q", tc.d, got, tc.want)
 		}
 	}
+}
+
+// TestGrantEventsReachTheDurableSink pins the audit contract: every stage of
+// a grant's life must reach OnSessionEvent, because that callback IS the
+// durable trail — the CLI wires it straight to agent-history.jsonl, which is
+// the only thing `jit audit` reads. An event that stays in the in-memory ring
+// but never fires the sink would render fine in tests that read history()
+// and still be invisible to the one command users audit with.
+func TestGrantEventsReachTheDurableSink(t *testing.T) {
+	s, socketPath, cleanup := startTestServer(t, time.Minute, nil)
+	defer cleanup()
+
+	var mu sync.Mutex
+	var sunk []SessionEvent
+	s.OnSessionEvent = func(e SessionEvent) {
+		mu.Lock()
+		sunk = append(sunk, e)
+		mu.Unlock()
+	}
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled: %v", err)
+	}
+	// A serve pends in the collapse window; a history read is one of the
+	// moments that must flush it to the sink.
+	_ = s.history()
+	if err := c.GrantRevoke(st.ID); err != nil {
+		t.Fatalf("GrantRevoke: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	find := func(want string, match func(SessionEvent) bool) {
+		t.Helper()
+		for _, e := range sunk {
+			if match(e) {
+				return
+			}
+		}
+		var kinds []string
+		for _, e := range sunk {
+			kinds = append(kinds, fmt.Sprintf("%s/%s(%s)", e.Kind, e.Op, e.Cause))
+		}
+		t.Errorf("sink never received %s; got: %s", want, strings.Join(kinds, ", "))
+	}
+	find("the creation approval (KindApproved, op grant_create, unattended wording)", func(e SessionEvent) bool {
+		return e.Kind == KindApproved && e.Op == OpGrantCreate && strings.Contains(e.Cause, "unattended for")
+	})
+	find("the grant serve (KindUse, op grant_use, path in labels)", func(e SessionEvent) bool {
+		return e.Kind == KindUse && e.Op == OpGrantUse && containsString(e.Labels, "jamf/api-pass")
+	})
+	find("the ending (KindGrantEnd, revoked, paths in labels)", func(e SessionEvent) bool {
+		return e.Kind == KindGrantEnd && strings.Contains(e.Cause, grantEndRevoked) && containsString(e.Labels, "jamf/api-pass")
+	})
 }
 
 // assertGrantEndEvent asserts history carries a KindGrantEnd whose cause

--- a/internal/agent/grant_test.go
+++ b/internal/agent/grant_test.go
@@ -1,0 +1,414 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package agent
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// grantTestMEK matches fakeFetcher's key so tests can pre-seal wrapped DEKs
+// the way real envelopes carry them.
+var grantTestMEK = bytes.Repeat([]byte{0x42}, 32)
+
+// sealGrantSecret builds one resolver entry: a DEK sealed under the test MEK
+// with the class as AAD, exactly what vault.WrappedDEK would hand the real
+// resolver.
+func sealGrantSecret(t *testing.T, path, class string, dek []byte) GrantSecret {
+	t.Helper()
+	wrapped, err := seal(grantTestMEK, dek, []byte(class))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	return GrantSecret{Path: path, Wrapped: wrapped, Class: class}
+}
+
+// wireGrantResolver points OnResolveGrant at a fixed secret set and returns
+// the entries, so a test controls exactly what the profiles resolve to.
+func wireGrantResolver(s *Server, secrets ...GrantSecret) {
+	s.OnResolveGrant = func(profiles []string, projectRoot string) ([]GrantSecret, error) {
+		return secrets, nil
+	}
+}
+
+func TestGrantServesAcrossLockWithoutPrompting(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("grant creation challenged %d times, want exactly 1 (one disclosed prompt)", got)
+	}
+	if len(st.Secrets) != 1 || st.Secrets[0] != "jamf/api-pass" {
+		t.Errorf("GrantStatus.Secrets = %v, want [jamf/api-pass]", st.Secrets)
+	}
+	if !st.RootAlive {
+		t.Error("GrantStatus.RootAlive = false for a live root")
+	}
+
+	// A disclosed challenge is a confirmation, not an unlock: no session may
+	// exist after creation.
+	if unlocked, _ := s.status(); unlocked {
+		t.Fatal("grant creation opened a session; a disclosed challenge must not")
+	}
+
+	// The feature itself: the covered unwrap is served with the agent locked,
+	// and no human is prompted.
+	got, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp")
+	if err != nil {
+		t.Fatalf("UnwrapKeyLabeled under grant: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Errorf("grant served %x, want %x", got, dek)
+	}
+	if err := c.Lock(); err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled after explicit lock: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("grant-covered unwraps challenged the human (%d fetches, want 1): the unattended case is the feature", got)
+	}
+
+	// The serves are on the record.
+	grants, err := c.GrantList()
+	if err != nil {
+		t.Fatalf("GrantList: %v", err)
+	}
+	if len(grants) != 1 || grants[0].Serves != 2 {
+		t.Errorf("GrantList = %+v, want one grant with 2 serves", grants)
+	}
+}
+
+func TestGrantMissFallsThroughToOrdinaryUnlock(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	covered := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, covered)
+
+	c := NewClient(socketPath)
+	if _, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
+		t.Fatalf("GrantCreate: %v", err)
+	}
+
+	// An UNCOVERED secret must ride the ordinary session path: fresh
+	// challenge, session opened.
+	other, err := seal(grantTestMEK, bytes.Repeat([]byte{0x08}, 32), []byte("aws"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	if _, err := c.UnwrapKeyLabeled(other, "aws/key", "aws"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled (uncovered): %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("uncovered unwrap fetched %d times total, want 2 (grant prompt + ordinary unlock)", got)
+	}
+}
+
+func TestGrantDoesNotServeAForeignProcessTree(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	// Anchor the grant to a process the TEST connection does not descend
+	// from: a child we spawn. The client (this test process) is the child's
+	// PARENT, and descent runs child-up, so the caller is outside the tree.
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting child: %v", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+	}()
+
+	c := NewClient(socketPath)
+	if _, err := c.GrantCreate(int32(child.Process.Pid), []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
+		t.Fatalf("GrantCreate: %v", err)
+	}
+
+	// The covered bytes, from OUTSIDE the granted tree: must not be served
+	// from the grant — the fetcher firing again is the proof it took the
+	// ordinary challenge path instead.
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("foreign-tree unwrap fetched %d times total, want 2 (grant prompt + ordinary unlock, never the grant cache)", got)
+	}
+
+	grants, err := c.GrantList()
+	if err != nil {
+		t.Fatalf("GrantList: %v", err)
+	}
+	if len(grants) != 1 || grants[0].Serves != 0 {
+		t.Errorf("GrantList = %+v, want the grant intact with 0 serves", grants)
+	}
+}
+
+func TestGrantEndsWhenRootExits(t *testing.T) {
+	s, socketPath, cleanup := startTestServer(t, time.Minute, nil)
+	defer cleanup()
+
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x07}, 32))
+	wireGrantResolver(s, sec)
+
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting child: %v", err)
+	}
+	pid := int32(child.Process.Pid) // #nosec G115 -- test pid
+
+	c := NewClient(socketPath)
+	if _, err := c.GrantCreate(pid, []string{"jamf"}, "", time.Hour); err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	_ = child.Process.Kill()
+	_, _ = child.Process.Wait()
+
+	grants, err := c.GrantList()
+	if err != nil {
+		t.Fatalf("GrantList: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("GrantList after root exit = %+v, want the grant pruned", grants)
+	}
+	assertGrantEndEvent(t, s, grantEndExited)
+}
+
+func TestGrantExpiryEndsTheGrant(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	// The RPC floor is a minute; expire it by hand — the serve path re-checks
+	// the record's own deadline, which is the contract (expiry is enforced at
+	// serve time, never baked into key material).
+	s.grantMu.Lock()
+	s.grants[st.ID].expires = time.Now().Add(-time.Second)
+	s.grantMu.Unlock()
+
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled after expiry: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expired grant answered without a fresh challenge (%d fetches, want 2)", got)
+	}
+	grants, err := c.GrantList()
+	if err != nil {
+		t.Fatalf("GrantList: %v", err)
+	}
+	if len(grants) != 0 {
+		t.Fatalf("GrantList after expiry = %+v, want empty", grants)
+	}
+	assertGrantEndEvent(t, s, grantEndExpired)
+}
+
+func TestGrantRevokeIsImmediateAndUnauthenticated(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	if err := c.GrantRevoke(st.ID); err != nil {
+		t.Fatalf("GrantRevoke: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("revoke fetched the MEK (%d fetches, want 1): the kill switch must never require auth", got)
+	}
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled after revoke: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("revoked grant still answered without a challenge (%d fetches, want 2)", got)
+	}
+	assertGrantEndEvent(t, s, grantEndRevoked)
+
+	if err := c.GrantRevoke(st.ID); err == nil || !strings.Contains(err.Error(), "no grant") {
+		t.Errorf("revoking twice = %v, want a no-such-grant error", err)
+	}
+}
+
+func TestGrantExtendReprompts(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x07}, 32))
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	ext, err := c.GrantExtend(st.ID, 2*time.Hour)
+	if err != nil {
+		t.Fatalf("GrantExtend: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("extend fetched %d times total, want 2: more time is a new decision and must re-prompt", got)
+	}
+	if ext.ExpiresUnix <= st.ExpiresUnix {
+		t.Errorf("extend moved expiry %d -> %d, want later", st.ExpiresUnix, ext.ExpiresUnix)
+	}
+}
+
+func TestGrantCreateFailsClosedOnClassMismatch(t *testing.T) {
+	s, socketPath, cleanup := startTestServer(t, time.Minute, nil)
+	defer cleanup()
+
+	// The wrapped bytes are sealed under "aws"; the resolver claims "docker".
+	// The AAD check must fail the WHOLE create — the prompt described a set
+	// the grant could not truthfully cover.
+	wrapped, err := seal(grantTestMEK, bytes.Repeat([]byte{0x07}, 32), []byte("aws"))
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	good := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x09}, 32))
+	wireGrantResolver(s, good, GrantSecret{Path: "aws/key", Wrapped: wrapped, Class: "docker"})
+
+	c := NewClient(socketPath)
+	_, err = c.GrantCreate(int32(os.Getpid()), []string{"jamf", "aws"}, "", time.Hour) // #nosec G115 -- test pid
+	if err == nil || !strings.Contains(err.Error(), "no grant created") {
+		t.Fatalf("GrantCreate with a lying class = %v, want a no-grant-created failure", err)
+	}
+	grants, lerr := c.GrantList()
+	if lerr != nil {
+		t.Fatalf("GrantList: %v", lerr)
+	}
+	if len(grants) != 0 {
+		t.Errorf("GrantList = %+v, want empty: a partial grant is a prompt that lied by omission", grants)
+	}
+}
+
+func TestGrantCreateValidatesBeforePrompting(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+	wireGrantResolver(s) // resolves to nothing
+	_ = socketPath
+
+	cases := []struct {
+		name string
+		req  Request
+	}{
+		{"no target", Request{Op: OpGrantCreate, GrantProfiles: []string{"jamf"}, TTLSeconds: 3600}},
+		{"no profiles", Request{Op: OpGrantCreate, TargetPID: int32(os.Getpid()), TTLSeconds: 3600}},                                            // #nosec G115 -- test pid
+		{"ttl too long", Request{Op: OpGrantCreate, TargetPID: int32(os.Getpid()), GrantProfiles: []string{"jamf"}, TTLSeconds: 8 * 24 * 3600}}, // #nosec G115 -- test pid
+		{"ttl too short", Request{Op: OpGrantCreate, TargetPID: int32(os.Getpid()), GrantProfiles: []string{"jamf"}, TTLSeconds: 30}},           // #nosec G115 -- test pid
+		{"dead target", Request{Op: OpGrantCreate, TargetPID: 999999999, GrantProfiles: []string{"jamf"}, TTLSeconds: 3600}},                    //
+		{"empty resolution", Request{Op: OpGrantCreate, TargetPID: int32(os.Getpid()), GrantProfiles: []string{"jamf"}, TTLSeconds: 3600}},      // #nosec G115 -- test pid
+	}
+	for _, tc := range cases {
+		resp := s.handle(tc.req, &caller{pid: int32(os.Getpid())}) // #nosec G115 -- test pid
+		if resp.OK {
+			t.Errorf("%s: handle succeeded, want failure", tc.name)
+		}
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("invalid grant requests reached the prompt %d times, want 0: validation runs before any Touch ID", got)
+	}
+}
+
+func TestGrantCreateReasonWording(t *testing.T) {
+	got := grantCreateReason("claude", []string{"jamf", "aws-ci"}, 3, 8*time.Hour)
+	want := "let claude use 3 secrets (jamf, aws-ci) unattended for 8h"
+	if got != want {
+		t.Errorf("grantCreateReason = %q, want %q", got, want)
+	}
+	if r := grantCreateReason("", []string{"p"}, 1, time.Minute); !strings.Contains(r, "this process") {
+		t.Errorf("nameless reason = %q, want a 'this process' fallback", r)
+	}
+	long := grantCreateReason(strings.Repeat("x", 100), []string{strings.Repeat("y", 100)}, 12, 3*24*time.Hour)
+	if len([]rune(long)) > maxReasonLen {
+		t.Errorf("reason is %d runes, must fit the %d-rune prompt budget", len([]rune(long)), maxReasonLen)
+	}
+	if !strings.Contains(long, "unattended for 3d") {
+		t.Errorf("truncated reason = %q, lost the scope statement — the half that changes the decision", long)
+	}
+}
+
+func TestFormatGrantTTL(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{45 * time.Minute, "45m"},
+		{8 * time.Hour, "8h"},
+		{90 * time.Minute, "1h30m"},
+		{24 * time.Hour, "1d"},
+		{3 * 24 * time.Hour, "3d"},
+	}
+	for _, tc := range cases {
+		if got := formatGrantTTL(tc.d); got != tc.want {
+			t.Errorf("formatGrantTTL(%s) = %q, want %q", tc.d, got, tc.want)
+		}
+	}
+}
+
+// assertGrantEndEvent asserts history carries a KindGrantEnd whose cause
+// names how the grant ended.
+func assertGrantEndEvent(t *testing.T, s *Server, cause string) {
+	t.Helper()
+	for _, e := range s.history() {
+		if e.Kind == KindGrantEnd && strings.Contains(e.Cause, cause) {
+			if len(e.Labels) == 0 {
+				t.Errorf("grant_end event carries no secret paths: %+v", e)
+			}
+			return
+		}
+	}
+	t.Errorf("no grant_end event with cause %q in history: %s", cause, historyKinds(s))
+}
+
+func historyKinds(s *Server) string {
+	var kinds []string
+	for _, e := range s.history() {
+		kinds = append(kinds, fmt.Sprintf("%s(%s)", e.Kind, e.Cause))
+	}
+	return strings.Join(kinds, ", ")
+}

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -68,6 +68,24 @@ type Request struct {
 	// the agent gate consent on it without a caller being able to lie its way
 	// around the gate. Empty for legacy (v1/v2) secrets with no provenance.
 	Class string `json:"class,omitempty"`
+	// GrantProfiles ("grant_create") names the profiles a process grant should
+	// cover. NAMES only, deliberately: the agent resolves them to concrete
+	// secrets itself (Server.OnResolveGrant, through jit's own profile store
+	// and vault envelopes), so the Touch ID prompt and the granted secret set
+	// derive from the same agent-resolved facts — a caller cannot name one
+	// profile on the prompt and smuggle a different secret set into the grant,
+	// the same reasoning that moved reveal_pid's wording to OnDescribeGrant.
+	GrantProfiles []string `json:"grant_profiles,omitempty"`
+	// ProjectRoot ("grant_create") is the directory whose project profiles
+	// should shadow the global ones during that resolution — the caller's cwd,
+	// exactly the layering `jit run` applies. Empty means global-only.
+	ProjectRoot string `json:"project_root,omitempty"`
+	// GrantID ("grant_revoke"/"grant_extend") names the grant to act on.
+	GrantID string `json:"grant_id,omitempty"`
+	// TTLSeconds ("grant_create"/"grant_extend") is the requested lifetime.
+	// The server clamps and validates; a client cannot mint a longer grant
+	// than MaxGrantTTL by inflating this field.
+	TTLSeconds int64 `json:"ttl_seconds,omitempty"`
 }
 
 // RunMount is one mount's requested run-scoped treatment in a reveal_pid
@@ -108,6 +126,18 @@ const (
 	// so a recycled pid can't inherit a dead run's trust; the grant is dropped
 	// on the next re-lock.
 	OpTrust = "trust"
+	// OpGrantCreate creates a process grant (`jit grant`): after one disclosed
+	// challenge, TargetPID's process tree may unwrap the covered profiles'
+	// secrets until the grant expires — without further prompts, and across
+	// re-locks (the one authorization state that deliberately survives them;
+	// see Server's grant fields). OpGrantExtend re-prompts for more time on an
+	// existing grant; OpGrantRevoke ends one with no prompt at all (reducing
+	// access is always free); OpGrantList reads the current set, prompt-free
+	// for the same reason OpHistory is.
+	OpGrantCreate = "grant_create"
+	OpGrantList   = "grant_list"
+	OpGrantRevoke = "grant_revoke"
+	OpGrantExtend = "grant_extend"
 )
 
 // SessionEvent.Kind values.
@@ -182,6 +212,17 @@ const (
 	// the same hazard recordRejectedClass defends against, arrived at from
 	// the other direction.
 	KindServe = "serve"
+	// KindGrantEnd marks a process grant ending, with Cause naming which way:
+	// "expired" (its TTL ran out), "revoked" (jit grant revoke, with the
+	// revoker's provenance on By/LaunchedBy), or "process exited" (the root
+	// process the grant was anchored to is gone). Its creation needs no kind
+	// of its own — a grant is born as a KindApproved event, like every other
+	// disclosed challenge — but its END is the moment unattended access
+	// stopped, and a trail that records when standing access began and not
+	// when it ceased can't answer "was the grant still live at the time?",
+	// which is the first question an incident asks. Labels carries the
+	// covered vault paths; Op carries the grant id.
+	KindGrantEnd = "grant_end"
 )
 
 // The Op values a KindServe event carries: which content the reader got.
@@ -265,6 +306,39 @@ type Response struct {
 	// Empty when talking to an agent older than this field, which callers
 	// must render as unknown rather than as agreement.
 	ExecutablePath string `json:"executable_path,omitempty"`
+	// Grants answers "grant_list" (and "grant_create"/"grant_extend" echo the
+	// affected grant back the same way, so a client can render the result
+	// without a second round trip). Empty on every other Op. In-memory state:
+	// a process grant never survives the agent process, by design.
+	Grants []GrantStatus `json:"grants,omitempty"`
+}
+
+// GrantStatus is one process grant as the agent reports it — deliberately
+// plain strings/ints like every other wire type here. Name and Command are
+// kernel-derived at grant creation (internal/lineage), never caller-reported,
+// matching MountGrantStatus's convention.
+type GrantStatus struct {
+	ID  string `json:"id"`
+	PID int32  `json:"pid"`
+	// Name is the root process's display name ("claude"); Command its full
+	// invocation for a wide terminal.
+	Name    string `json:"name,omitempty"`
+	Command string `json:"command,omitempty"`
+	// Profiles are the profile names the grant was created from; Secrets the
+	// concrete vault paths it actually covers (resolved at creation — a later
+	// profile edit never widens a standing grant).
+	Profiles []string `json:"profiles"`
+	Secrets  []string `json:"secrets"`
+	// CreatedUnix/ExpiresUnix bound the grant's life; Serves counts unwraps
+	// served under it and LastServeUnix stamps the newest (zero when unused).
+	CreatedUnix   int64 `json:"created_unix"`
+	ExpiresUnix   int64 `json:"expires_unix"`
+	Serves        int64 `json:"serves,omitempty"`
+	LastServeUnix int64 `json:"last_serve_unix,omitempty"`
+	// RootAlive reports whether the anchored process (pid + fork time) still
+	// exists at the time of the status read. A dead root is pruned lazily, so
+	// a listing can catch one mid-flight; render it as ending, not live.
+	RootAlive bool `json:"root_alive"`
 }
 
 // SessionEvent is one transition of the agent's session — an unlock or a

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -233,6 +233,14 @@ const (
 	OpServeReal  = "real"
 )
 
+// OpGrantUse is the Op a KindUse event carries when the unwrap was answered
+// from a process grant's DEK cache instead of the session — the audit
+// distinction between "rode an unlock you gave moments ago" and "rode a
+// standing grant you gave this morning". Exported like the serve ops above:
+// it is part of the trail's vocabulary, and the CLI renderer must name it
+// without restating the string.
+const OpGrantUse = "grant_use"
+
 // Response answers a Request.
 type Response struct {
 	OK    bool   `json:"ok"`

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -226,6 +226,30 @@ type Server struct {
 	trustMu    sync.Mutex
 	trustRoots map[int32]int64
 
+	// grants are the live process grants (design/process-grants.md, grant.go):
+	// scoped DEK caches a disclosed challenge pre-authorized for one process
+	// tree until an absolute deadline. Guarded by grantMu for trustMu's exact
+	// reason (descent checks walk sysctls). Deliberately NOT dropped on
+	// re-lock — surviving the screen lock is the feature the human approved in
+	// so many words — which makes this the one carve-out from "a re-lock
+	// clears every authorization state"; it earns that by being strictly
+	// narrower than the session it stands in for (named secrets, one tree, an
+	// absolute deadline, revocable, and never the MEK). Memory-only: a grant
+	// never survives the agent process.
+	grantMu sync.Mutex
+	grants  map[string]*processGrant
+
+	// OnResolveGrant, if set, resolves grant_create's profile NAMES to the
+	// concrete secrets they cover — vault path, wrapped DEK bytes, AAD-bound
+	// class — through jit's own profile store and vault envelopes (the CLI
+	// layer wires it; Server never imports internal/vault or internal/profile).
+	// It is OnDescribeGrant's reasoning applied to scope instead of wording:
+	// because the agent resolves the names itself, the prompt and the granted
+	// set derive from the same facts, and a caller cannot put one profile on
+	// the prompt and a different secret set in the grant. Nil disables
+	// grant_create entirely.
+	OnResolveGrant func(profiles []string, projectRoot string) ([]GrantSecret, error)
+
 	// AuthMethodFn, if set, returns a best-effort description of how the local
 	// auth challenge asked the user ("Touch ID or device passcode" vs. "device
 	// passcode"), stamped onto the unlock/denied event a fresh challenge
@@ -700,7 +724,37 @@ func (s *Server) handle(req Request, c *caller) Response {
 			return Response{OK: false, Error: err.Error()}
 		}
 		return Response{OK: true, Data: wrapped}
+	case OpGrantCreate:
+		return s.createGrant(req, c)
+	case OpGrantList:
+		// Deliberately no ensureUnlocked, OpHistory's reasoning: reading what
+		// standing access exists must never itself cost an authentication.
+		return Response{OK: true, Grants: s.listGrants()}
+	case OpGrantRevoke:
+		if req.GrantID == "" {
+			return Response{OK: false, Error: "grant_revoke: missing grant_id"}
+		}
+		return s.revokeGrant(req.GrantID, c)
+	case OpGrantExtend:
+		if req.GrantID == "" {
+			return Response{OK: false, Error: "grant_extend: missing grant_id"}
+		}
+		return s.extendGrant(req, c)
 	case OpUnwrap:
+		// A live process grant answers first: the human already approved this
+		// exact tree reaching these exact secrets (one disclosed challenge,
+		// bounded by a deadline), so a covered unwrap needs no session, no
+		// consent gate, and no class re-verification — the class was
+		// AEAD-verified against these same wrapped bytes when the grant was
+		// created, and the DEK below is keyed to the bytes themselves, so a
+		// caller lying about Class now changes nothing it receives. Recorded
+		// as its own use op (grant_use): riding a standing grant and riding a
+		// minutes-old unlock are different facts in an audit. Any miss falls
+		// through to the ordinary path unchanged.
+		if dek, path, ok := s.grantUnwrap(c, req.Data); ok {
+			s.recordAggregated(KindUse, opGrantUse, c.command(), c, path)
+			return Response{OK: true, Data: dek}
+		}
 		// Nothing has verified req.Class yet. It is AEAD-bound into the wrap,
 		// but that binding is only checked by open() further down, so until
 		// then the class is simply a string the caller sent — and it is the
@@ -868,7 +922,8 @@ func (s *Server) verifyClassBinding(data []byte, class string, c *caller) error 
 // user refused and none for any they accepted, so the trail could prove what
 // you blocked and never what you allowed.
 func (s *Server) forceDisclosedChallenge(reason string, c *caller) error {
-	event, err := s.discloseChallenge(reason, c)
+	event, mek, err := s.discloseChallengeOp(reason, OpRevealPID, c)
+	wipe(mek)
 	// Outside challengeMu — see ensureUnlockedNotify for what happens when a
 	// callback runs under it.
 	if s.OnSessionEvent != nil {
@@ -877,15 +932,25 @@ func (s *Server) forceDisclosedChallenge(reason string, c *caller) error {
 	return err
 }
 
-// discloseChallenge is forceDisclosedChallenge's serialized half: it holds
-// challengeMu across the prompt (so a disclosed challenge queues behind an
-// in-flight one rather than stacking a second dialog) and returns the event
-// for the caller to notify on, outside the lock. The event is never nil.
-func (s *Server) discloseChallenge(reason string, c *caller) (*SessionEvent, error) {
+// discloseChallengeOp is the serialized half every disclosed challenge shares:
+// it holds challengeMu across the prompt (so a disclosed challenge queues
+// behind an in-flight one rather than stacking a second dialog) and returns
+// the event for the caller to notify on, outside the lock. The event is never
+// nil; op stamps it, so a grant creation's approval and a reveal's approval
+// stay distinguishable in history.
+//
+// On approval it also returns the challenge's MEK instead of discarding it.
+// Session state is still never touched — a disclosed challenge remains a
+// confirmation, not an unlock — but grant creation needs the key for exactly
+// as long as it takes to unwrap the covered DEKs (grant.go), and fetching it
+// twice would mean two prompts for one decision. Callers that only wanted the
+// confirmation wipe it immediately (forceDisclosedChallenge); every caller
+// must wipe it. Nil on any failure.
+func (s *Server) discloseChallengeOp(reason, op string, c *caller) (*SessionEvent, []byte, error) {
 	s.challengeMu.Lock()
 	defer s.challengeMu.Unlock()
 
-	pending := unlockEvent(OpRevealPID, c)
+	pending := unlockEvent(op, c)
 	pending.Cause = reason
 	s.mu.Lock()
 	s.pendingChallenge = pending
@@ -893,13 +958,13 @@ func (s *Server) discloseChallenge(reason string, c *caller) (*SessionEvent, err
 
 	fetcher := s.newFetcher()
 	mek, err := fetcher.FetchMEK(reason)
-	// This MEK is discarded below — a disclosed challenge is a confirmation,
-	// not an unlock — so the fetcher's cache is pure residue. Closing it here
-	// matters more than on the unlock path: every consent prompt comes through
-	// here, so this is the site that leaked a MEK copy per prompt.
+	// The fetcher's own cache is pure residue once FetchMEK has returned its
+	// copy. Closing it here matters more than on the unlock path: every
+	// consent prompt comes through here, so this is the site that leaked a
+	// MEK copy per prompt.
 	closeFetcher(fetcher)
 
-	event := unlockEvent(OpRevealPID, c)
+	event := unlockEvent(op, c)
 	event.AuthMethod = s.authMethod()
 	if err != nil {
 		event.Kind = KindDenied
@@ -915,10 +980,9 @@ func (s *Server) discloseChallenge(reason string, c *caller) (*SessionEvent, err
 	s.mu.Unlock()
 
 	if err != nil {
-		return event, fmt.Errorf("disclosed grant declined: %w", err)
+		return event, nil, fmt.Errorf("disclosed grant declined: %w", err)
 	}
-	wipe(mek)
-	return event, nil
+	return event, mek, nil
 }
 
 func (s *Server) ensureUnlockedNotify(onFresh func(), op string, c *caller, label string) ([]byte, error) {
@@ -1301,6 +1365,14 @@ func (s *Server) lockIfGen(cause string, gen uint64) {
 	// Consent decisions ride the unlock session: clear them when it ends, so a
 	// re-lock forces a fresh prompt rather than honoring an approval you gave
 	// before you stepped away. Cheap and idempotent when there's nothing to drop.
+	//
+	// Process grants (s.grants) are deliberately NOT cleared here — the single
+	// carve-out from "a re-lock drops every authorization state". Surviving the
+	// screen lock is the feature: the human's disclosed challenge approved
+	// "unattended, until <deadline>" in so many words, for named secrets and
+	// one process tree, and a grant that died with the lock would just be a
+	// session. They end by their own deadline, their root exiting, or an
+	// explicit revoke (grant.go).
 	if s.Consent != nil {
 		s.Consent.Clear()
 	}

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -752,7 +752,7 @@ func (s *Server) handle(req Request, c *caller) Response {
 		// minutes-old unlock are different facts in an audit. Any miss falls
 		// through to the ordinary path unchanged.
 		if dek, path, ok := s.grantUnwrap(c, req.Data); ok {
-			s.recordAggregated(KindUse, opGrantUse, c.command(), c, path)
+			s.recordAggregated(KindUse, OpGrantUse, c.command(), c, path)
 			return Response{OK: true, Data: dek}
 		}
 		// Nothing has verified req.Class yet. It is AEAD-bound into the wrap,

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -168,6 +168,11 @@ var agentRunCmd = &cobra.Command{
 		server.OnDescribeGrant = mounts.describeGrant
 		server.OnStopMount = mounts.stopMount
 		server.OnMountStatus = mounts.mountRevealStatuses
+		// Process grants (design/process-grants.md): the service resolves a
+		// grant's profile names to concrete secrets itself, through the same
+		// stores `jit run` reads — see resolveGrantSecrets for why that
+		// agent-side resolution is what makes the grant prompt trustworthy.
+		server.OnResolveGrant = resolveGrantSecrets(root)
 		// Best-effort "how were you asked" for the audit trail: probe once per
 		// fresh challenge whether Touch ID is currently usable, so a denial or
 		// unlock records "Touch ID or device passcode" on a Mac with biometry

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -72,6 +72,8 @@ var auditKindAliases = map[string]string{
 	"grant":    "grant",
 	"approve":  "grant",
 	"approved": "grant",
+	"revoked":  "grant",
+	"ended":    "grant",
 	"serve":    "serve",
 	"read":     "serve",
 	"mount":    "serve",
@@ -878,6 +880,24 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 		if e.Cause != "" {
 			pairs = append(pairs, kv{"reason", e.Cause})
 		}
+	case agent.KindGrantEnd:
+		// A process grant ending — expiry, revoke, or its root process
+		// exiting. Same kind token as the approval that created it, so
+		// `--kind grant` shows a grant's whole life; status carries which
+		// ending it was. Op is the grant id, Labels the covered vault paths.
+		kind, status = "grant", "ended"
+		pairs = append(pairs, kv{"level", "info"}, kv{"kind", "grant"}, kv{"status", "ended"})
+		subject = "grant ended"
+		if e.Cause != "" {
+			subject = e.Cause
+		}
+		if e.Op != "" {
+			pairs = append(pairs, kv{"grant", e.Op})
+		}
+		if e.Cause != "" {
+			pairs = append(pairs, kv{"reason", e.Cause})
+		}
+		pairs = appendAuthContext(pairs, home, e)
 	case agent.KindError:
 		// A socket-boundary failure the service refused or hit: a rejected
 		// peer, a malformed request, the accept loop dying. op names which and

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -73,6 +73,86 @@ func seedServeFixtures(t *testing.T, home string) {
 	})
 }
 
+// seedGrantFixtures plants a process grant's whole life in the durable trail,
+// exactly as the agent emits it (grant.go): the disclosed approval that
+// created it, a collapsed grant-served use, and the ending.
+func seedGrantFixtures(t *testing.T, home string) {
+	t.Helper()
+	root := filepath.Join(home, "Library", "Application Support", "jitpass")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	h := newHistoryLog(root, nil)
+	h.append(agent.SessionEvent{
+		UnixTime: 7000, Kind: agent.KindApproved, Op: agent.OpGrantCreate,
+		By: "jit grant --process claude --profile jamf --for 8h", ByPID: 4242,
+		Cause:      "let claude use 2 secrets (jamf) unattended for 8h",
+		AuthMethod: "Touch ID or device passcode",
+	})
+	h.append(agent.SessionEvent{
+		UnixTime: 7100, Kind: agent.KindUse, Op: agent.OpGrantUse,
+		By: "jit run --profile jamf -- terraform plan", ByPID: 4300, LaunchedBy: "claude",
+		Labels: []string{"jamf/api-user", "jamf/api-pass"}, Count: 2,
+	})
+	h.append(agent.SessionEvent{
+		UnixTime: 7200, Kind: agent.KindGrantEnd, Op: "g-1234abcd",
+		Cause:  "claude's grant expired",
+		Labels: []string{"jamf/api-user", "jamf/api-pass"},
+	})
+}
+
+// TestAuditCapturesGrantLifecycle drives the REAL command over a grant's
+// whole recorded life: the approval and the ending must both surface under
+// --kind grant (one filter shows a grant's full story), and the grant-served
+// use must render distinguishably from an ordinary session use. This is the
+// contract that makes the feature auditable at all — a standing, unattended
+// credential channel whose serves or endings vanished from `jit audit` would
+// be exactly the "trust feature that becomes an incident write-up" the
+// design doc warns about.
+func TestAuditCapturesGrantLifecycle(t *testing.T) {
+	home := withFixtureHome(t)
+	seedGrantFixtures(t, home)
+
+	out, err := execAuditLogfmt(t, "--kind", "grant")
+	if err != nil {
+		t.Fatalf("jit audit --kind grant: %v", err)
+	}
+	for _, want := range []string{
+		"status=approved",
+		`reason="let claude use 2 secrets (jamf) unattended for 8h"`,
+		"status=ended",
+		"grant=g-1234abcd",
+		`reason="claude's grant expired"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--kind grant missing %q, got:\n%s", want, out)
+		}
+	}
+
+	out, err = execAuditLogfmt(t, "--kind", "use")
+	if err != nil {
+		t.Fatalf("jit audit --kind use: %v", err)
+	}
+	for _, want := range []string{
+		`op="read a secret via grant"`, // OpGrantUse through agent.DescribeUse — not an ordinary session use
+		"count=2",
+		"parent=claude",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("--kind use missing %q for the grant-served use, got:\n%s", want, out)
+		}
+	}
+
+	// The secret filter must reach a grant serve's labels like any other use.
+	out, err = execAuditLogfmt(t, "--secret", "jamf/api-pass")
+	if err != nil {
+		t.Fatalf("jit audit --secret: %v", err)
+	}
+	if !strings.Contains(out, `op="read a secret via grant"`) || !strings.Contains(out, "status=ended") {
+		t.Errorf("--secret jamf/api-pass should match both the grant serve and the ending, got:\n%s", out)
+	}
+}
+
 // A decoy read is the honeytoken-shaped signal the mount design produces on
 // every read and, before this, discarded: it must render as its own kind, name
 // the reader and its launcher, and say why that reader got a fake.

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -1,0 +1,570 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/auditlog"
+	"github.com/jitpass/jit/internal/lineage"
+	"github.com/jitpass/jit/internal/profile"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// jit grant — process grants (design/process-grants.md): pre-approve a
+// RUNNING process tree to use one or more profiles' secrets unattended, for
+// a bounded time, with one Touch ID given while you are still at the
+// keyboard. The bare command creates; list/revoke/extend manage what exists.
+// All state lives in the service's memory — the CLI here is a thin client
+// over the grant_* RPCs, plus the name-to-pid resolution and completion
+// that need a terminal-side view.
+
+var (
+	grantProcess      string
+	grantPIDFlag      int32
+	grantProfileNames []string
+	grantFor          string
+	grantListFormat   string
+	grantExtendFor    string
+)
+
+var grantCmd = &cobra.Command{
+	Use:     "grant --process NAME --profile NAME --for DURATION",
+	GroupID: groupSecrets,
+	Short:   "Pre-approve a running process to use profiles unattended",
+	Long: `Create a process grant: with one Touch ID now, allow a process that is
+already running (and everything it launches) to use the named profiles'
+secrets without further prompts, until the grant expires — including while
+the screen is locked or you are away.
+
+The grant is anchored to the live process you name, not to its name: a new
+process called the same thing tomorrow inherits nothing. It covers exactly
+the secrets the named profiles resolve to at creation time, ends at its
+deadline (or when the process exits, or on 'jit grant revoke'), and every
+serve under it is recorded in 'jit audit'.
+
+Grants live in the service's memory: they survive screen lock by design,
+and do not survive a service restart or reboot.`,
+	Example: `  # let the running claude session use the jamf profile for 8 hours
+  jit grant --process claude --profile jamf --for 8h
+
+  # several profiles in one grant, anchored by pid when the name is ambiguous
+  jit grant --pid 4211 --profile jamf --profile aws-ci --for 1d
+
+  # see, shorten, or end what is open
+  jit grant list
+  jit grant revoke g-7f3a
+  jit grant extend g-7f3a --for 24h`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGrantCreate(cmd.OutOrStdout()); err != nil {
+			return fmt.Errorf("jit grant: %w", err)
+		}
+		return nil
+	},
+}
+
+var grantListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "Show the active process grants",
+	Long: `List every live process grant: who holds it, which profiles it covers,
+when it expires, and how many serves have ridden it. Reading this never
+prompts.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGrantList(cmd.OutOrStdout()); err != nil {
+			return fmt.Errorf("jit grant list: %w", err)
+		}
+		return nil
+	},
+}
+
+var grantRevokeCmd = &cobra.Command{
+	Use:   "revoke ID",
+	Short: "End a process grant now",
+	Long: `End a grant immediately. No authentication: reducing access is always
+free, and the kill switch is deliberately the easiest command in the
+feature. The ending is recorded in 'jit audit'.`,
+	Args:              requireGrantID,
+	ValidArgsFunction: completeGrantIDs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGrantRevoke(cmd.OutOrStdout(), args[0]); err != nil {
+			return fmt.Errorf("jit grant revoke: %w", err)
+		}
+		return nil
+	},
+}
+
+var grantExtendCmd = &cobra.Command{
+	Use:   "extend ID --for DURATION",
+	Short: "Give an existing grant more time (re-prompts Touch ID)",
+	Long: `Move a grant's deadline to now plus the new duration. More time is a new
+decision, so this puts the same disclosed prompt in front of you that
+creating the grant did. Shortening needs no command of its own: revoke and
+re-create, and neither step re-asks for what you already have.`,
+	Args:              requireGrantID,
+	ValidArgsFunction: completeGrantIDs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := runGrantExtend(cmd.OutOrStdout(), args[0]); err != nil {
+			return fmt.Errorf("jit grant extend: %w", err)
+		}
+		return nil
+	},
+}
+
+// requireGrantID is ExactArgs(1) with the argument named in the error, so a
+// bare `jit grant revoke` says what is missing instead of counting.
+func requireGrantID(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("expects a grant id (see `jit grant list`)")
+	}
+	return nil
+}
+
+func runGrantCreate(out io.Writer) error {
+	if len(grantProfileNames) == 0 {
+		return fmt.Errorf("--profile is required (repeat it for several: --profile jamf --profile aws-ci)")
+	}
+	if grantFor == "" {
+		return fmt.Errorf("--for is required (how long the grant lasts, like 45m, 8h, 3d — max %s)", formatFlexDuration(agent.MaxGrantTTL))
+	}
+	ttl, err := parseGrantFor(grantFor)
+	if err != nil {
+		return err
+	}
+
+	// Validate the profiles HERE, where the error can name the files checked —
+	// the service re-resolves authoritatively, but a typo should fail before
+	// any RPC, let alone a prompt.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+	seen := map[string]bool{}
+	for _, name := range grantProfileNames {
+		if seen[name] {
+			return fmt.Errorf("--profile %s given twice", name)
+		}
+		seen[name] = true
+		if _, err := profile.Load(cwd, name); err != nil {
+			return err
+		}
+	}
+
+	target, err := resolveGrantTarget()
+	if err != nil {
+		return err
+	}
+
+	ac, err := agentClient()
+	if err != nil {
+		return err
+	}
+	st, err := ac.GrantCreate(target.PID, grantProfileNames, cwd, ttl)
+	if err != nil {
+		return notRunningHint(err)
+	}
+	printGrantCreated(out, st)
+	return nil
+}
+
+// resolveGrantTarget turns --process/--pid into the live process the grant
+// anchors to. A name that matches several running processes is an error that
+// lists them — the human picks with --pid; jit never guesses which claude
+// they meant.
+func resolveGrantTarget() (lineage.Process, error) {
+	if grantPIDFlag != 0 && grantProcess != "" {
+		return lineage.Process{}, fmt.Errorf("give --process or --pid, not both")
+	}
+	if grantPIDFlag != 0 {
+		p, ok := lineage.Describe(grantPIDFlag)
+		if !ok {
+			return lineage.Process{}, fmt.Errorf("no process with pid %d (it may have exited)", grantPIDFlag)
+		}
+		return p, nil
+	}
+	if grantProcess == "" {
+		return lineage.Process{}, fmt.Errorf("--process is required (the running program to grant to; tab-completes from recent callers)")
+	}
+	procs := lineage.ProcessesNamed(grantProcess)
+	switch len(procs) {
+	case 0:
+		return lineage.Process{}, fmt.Errorf("nothing named %q is running — a grant anchors to a live process, start it first", grantProcess)
+	case 1:
+		return procs[0], nil
+	}
+	lines := make([]string, 0, len(procs))
+	for _, p := range procs {
+		lines = append(lines, fmt.Sprintf("  --pid %-6d %s", p.PID, truncateEnd(p.Command(), 60)))
+	}
+	return lineage.Process{}, fmt.Errorf("%d processes are named %q, pick one with --pid:\n%s",
+		len(procs), grantProcess, strings.Join(lines, "\n"))
+}
+
+func printGrantCreated(out io.Writer, st agent.GrantStatus) {
+	_, _ = cOKBold.Fprint(out, glyphDone+" granted "+st.ID)
+	fmt.Fprintf(out, "   %s %s %s   until %s\n",
+		st.Name, glyphAction, strings.Join(st.Profiles, ", "), grantClock(st.ExpiresUnix))
+	fmt.Fprintf(out, "  %s %s: %s\n", glyphBranch,
+		countWord(len(st.Secrets), "secret", "secrets"), truncateEnd(strings.Join(st.Secrets, ", "), 58))
+	fmt.Fprintf(out, "  %s end it early: %s\n", glyphBranch, cPath.Sprint("jit grant revoke "+st.ID))
+}
+
+func runGrantList(out io.Writer) error {
+	if err := validateOutputFormat(grantListFormat); err != nil {
+		return err
+	}
+	ac, err := agentClient()
+	if err != nil {
+		return err
+	}
+	grants, err := ac.GrantList()
+	if err != nil {
+		return notRunningHint(err)
+	}
+	if grantListFormat == "json" {
+		if grants == nil {
+			grants = []agent.GrantStatus{}
+		}
+		return writeJSON(out, grants)
+	}
+	renderGrantRows(out, grants)
+	return nil
+}
+
+// renderGrantRows is the text half of `jit grant list`: a [Grants] report
+// whose rows carry state in the leading glyph (live ● / ending ✗), the id in
+// bold (it is what revoke/extend take), and everything else plain.
+func renderGrantRows(out io.Writer, grants []agent.GrantStatus) {
+	fmt.Fprintf(out, "[Grants] %d\n", len(grants))
+	if len(grants) == 0 {
+		fmt.Fprintln(out, "  no process grants are active")
+		return
+	}
+	who := make([]string, len(grants))
+	widest := 0
+	for i, g := range grants {
+		who[i] = fmt.Sprintf("%s %s %s", g.Name, glyphAction, strings.Join(g.Profiles, ", "))
+		if len(who[i]) > widest {
+			widest = len(who[i])
+		}
+	}
+	if widest > 34 {
+		widest = 34
+	}
+	for i, g := range grants {
+		glyph, ink := glyphOK, cOK
+		state := fmt.Sprintf("expires %s (%s left)", grantClock(g.ExpiresUnix), grantRemaining(g.ExpiresUnix))
+		if !g.RootAlive {
+			glyph, ink = glyphRisk, cRisk
+			state = "process exited, ending"
+		}
+		serves := "unused"
+		if g.Serves > 0 {
+			serves = countWord(int(g.Serves), "serve", "serves")
+		}
+		fmt.Fprint(out, "  ")
+		_, _ = ink.Fprint(out, glyph)
+		fmt.Fprint(out, " ")
+		_, _ = cBold.Fprint(out, g.ID)
+		fmt.Fprintf(out, "  %-*s  %s · %s\n", widest, truncateEnd(who[i], widest), state, serves)
+	}
+}
+
+func runGrantRevoke(out io.Writer, id string) error {
+	ac, err := agentClient()
+	if err != nil {
+		return err
+	}
+	// Best-effort name lookup first, so the confirmation can say what ended
+	// rather than echoing an opaque id. The revoke itself decides existence.
+	var who string
+	if grants, err := ac.GrantList(); err == nil {
+		for _, g := range grants {
+			if g.ID == id {
+				who = fmt.Sprintf("   %s %s %s", g.Name, glyphAction, strings.Join(g.Profiles, ", "))
+				break
+			}
+		}
+	}
+	if err := ac.GrantRevoke(id); err != nil {
+		return notRunningHint(err)
+	}
+	_, _ = cOKBold.Fprint(out, glyphDone+" revoked "+id)
+	fmt.Fprintln(out, who)
+	return nil
+}
+
+func runGrantExtend(out io.Writer, id string) error {
+	if grantExtendFor == "" {
+		return fmt.Errorf("--for is required (the new lifetime from now, like 8h or 1d)")
+	}
+	ttl, err := parseGrantFor(grantExtendFor)
+	if err != nil {
+		return err
+	}
+	ac, err := agentClient()
+	if err != nil {
+		return err
+	}
+	st, err := ac.GrantExtend(id, ttl)
+	if err != nil {
+		return notRunningHint(err)
+	}
+	_, _ = cOKBold.Fprint(out, glyphDone+" extended "+st.ID)
+	fmt.Fprintf(out, "   %s %s %s   until %s\n",
+		st.Name, glyphAction, strings.Join(st.Profiles, ", "), grantClock(st.ExpiresUnix))
+	return nil
+}
+
+// parseGrantFor reads a --for duration with the audit log's forgiving grammar
+// (45m, 8h, 3d) and bounds it the same way the service will, so the friendly
+// error happens before any RPC.
+func parseGrantFor(s string) (time.Duration, error) {
+	d, ok := parseFlexDuration(s)
+	if !ok {
+		return 0, fmt.Errorf("--for %q is not a duration (like 45m, 8h, 3d)", s)
+	}
+	if d < time.Minute {
+		return 0, fmt.Errorf("--for %s is under the 1m minimum", s)
+	}
+	if d > agent.MaxGrantTTL {
+		return 0, fmt.Errorf("--for %s exceeds the %s maximum for an unattended grant", s, formatFlexDuration(agent.MaxGrantTTL))
+	}
+	return d, nil
+}
+
+// formatFlexDuration renders a duration the way --for reads one ("7d", "8h"),
+// for error messages that quote the limits.
+func formatFlexDuration(d time.Duration) string {
+	if d >= 24*time.Hour && d%(24*time.Hour) == 0 {
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
+	}
+	if d >= time.Hour && d%time.Hour == 0 {
+		return fmt.Sprintf("%dh", d/time.Hour)
+	}
+	return d.String()
+}
+
+// grantClock renders an expiry instant on the axis a human plans by: clock
+// time today, day + clock time within the week the TTL cap allows.
+func grantClock(unix int64) string {
+	t := time.Unix(unix, 0)
+	now := time.Now()
+	if t.YearDay() == now.YearDay() && t.Year() == now.Year() {
+		return t.Format("15:04")
+	}
+	if t.YearDay() == now.AddDate(0, 0, 1).YearDay() && t.Year() == now.AddDate(0, 0, 1).Year() {
+		return t.Format("tomorrow 15:04")
+	}
+	return t.Format("Mon 15:04")
+}
+
+// grantRemaining renders time left in at most two units ("6h12m", "3d2h",
+// "45m"), matching how --for was typed rather than time.Duration's seconds.
+func grantRemaining(expiresUnix int64) string {
+	d := time.Until(time.Unix(expiresUnix, 0))
+	if d <= 0 {
+		return "0m"
+	}
+	d = d.Round(time.Minute)
+	days := d / (24 * time.Hour)
+	hours := (d % (24 * time.Hour)) / time.Hour
+	mins := (d % time.Hour) / time.Minute
+	switch {
+	case days > 0 && hours > 0:
+		return fmt.Sprintf("%dd%dh", days, hours)
+	case days > 0:
+		return fmt.Sprintf("%dd", days)
+	case hours > 0 && mins > 0:
+		return fmt.Sprintf("%dh%02dm", hours, mins)
+	case hours > 0:
+		return fmt.Sprintf("%dh", hours)
+	default:
+		return fmt.Sprintf("%dm", mins)
+	}
+}
+
+// truncateEnd cuts s to max runes with a trailing ellipsis — variable content
+// is truncated rather than wrapped (house rule), and these are process
+// command lines and secret lists, whose tail is the expendable half.
+func truncateEnd(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(r[:max])
+	}
+	return string(r[:max-1]) + "…"
+}
+
+// resolveGrantSecrets is the service-side OnResolveGrant hook (wired in
+// runAgent): profile names in, concrete grant secrets out — vault path,
+// wrapped DEK bytes, AAD-bound class — resolved through jit's OWN profile
+// store and vault envelopes. This being agent-side is what makes the grant
+// prompt trustworthy: the caller sends names, and the set those names cover
+// is decided by the same code path `jit run` resolves them with (project
+// store shadowing global), never by anything the caller listed.
+func resolveGrantSecrets(root string) func(profiles []string, projectRoot string) ([]agent.GrantSecret, error) {
+	return func(profiles []string, projectRoot string) ([]agent.GrantSecret, error) {
+		deviceID, err := vault.EnsureDeviceID(root)
+		if err != nil {
+			return nil, fmt.Errorf("determining device recipient ID: %w", err)
+		}
+		// No KeyWrapper: WrappedDEK reads envelopes without decrypting, so
+		// resolution can never prompt on its own.
+		v := &vault.Vault{Root: root, RecipientID: deviceID}
+		loadRoot := projectRoot
+		if loadRoot == "" {
+			if home, err := profile.GlobalRoot(); err == nil {
+				loadRoot = home
+			}
+		}
+		seen := map[string]bool{}
+		var out []agent.GrantSecret
+		for _, name := range profiles {
+			p, err := profile.Load(loadRoot, name)
+			if err != nil {
+				return nil, err
+			}
+			paths := make([]string, 0, len(p))
+			for _, secretPath := range p {
+				paths = append(paths, secretPath)
+			}
+			sort.Strings(paths)
+			for _, secretPath := range paths {
+				if seen[secretPath] {
+					continue
+				}
+				seen[secretPath] = true
+				wrapped, class, err := v.WrappedDEK(secretPath)
+				if err != nil {
+					return nil, fmt.Errorf("profile %s: %w", name, err)
+				}
+				out = append(out, agent.GrantSecret{Path: secretPath, Wrapped: wrapped, Class: class})
+			}
+		}
+		return out, nil
+	}
+}
+
+// completeGrantProcessNames offers --process candidates from the audit
+// trails: the programs that actually asked for secrets recently, annotated
+// with whether a live process currently carries the name. Reads the two
+// JSONL files directly and scans the process table once — no agent RPC, no
+// prompt, no state mutation (completeVaultPaths' discipline).
+func completeGrantProcessNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	root, err := vaultRootDir()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	cutoff := time.Now().Add(-24 * time.Hour)
+	last := map[string]time.Time{}
+	note := func(name string, t time.Time) {
+		if name == "" || name == "jit" || t.Before(cutoff) {
+			return
+		}
+		if t.After(last[name]) {
+			last[name] = t
+		}
+	}
+	for _, r := range auditlog.New(root, io.Discard).Load(0) {
+		t := time.Unix(0, r.UnixNano)
+		note(r.LaunchedBy, t)
+		note(r.Parent, t)
+	}
+	for _, e := range newHistoryLog(root, io.Discard).load(4096) {
+		note(e.LaunchedBy, time.Unix(e.UnixTime, 0))
+	}
+	if len(last) == 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	running := map[string]int32{}
+	for _, p := range lineage.VisibleProcesses() {
+		if n := p.Name(); n != "" {
+			running[n] = p.PID
+		}
+	}
+
+	names := make([]string, 0, len(last))
+	for n := range last {
+		names = append(names, n)
+	}
+	sort.Slice(names, func(i, j int) bool { return last[names[i]].After(last[names[j]]) })
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		desc := fmt.Sprintf("asked %s ago", grantAgo(time.Since(last[n])))
+		if pid, ok := running[n]; ok {
+			desc += fmt.Sprintf(" · running (pid %d)", pid)
+		} else {
+			desc += " · not running"
+		}
+		out = append(out, n+"\t"+desc)
+	}
+	return out, cobra.ShellCompDirectiveNoFileComp
+}
+
+// grantAgo renders an age in one coarse unit for a completion description.
+func grantAgo(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "moments"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", d/time.Minute)
+	default:
+		return fmt.Sprintf("%dh", d/time.Hour)
+	}
+}
+
+// completeGrantIDs offers live grant ids for revoke/extend. It does ask the
+// service (grant_list is prompt-free and instant); an unreachable service
+// completes to nothing rather than an error mid-keystroke.
+func completeGrantIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	ac, err := agentClient()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	grants, err := ac.GrantList()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	out := make([]string, 0, len(grants))
+	for _, g := range grants {
+		out = append(out, fmt.Sprintf("%s\t%s %s %s · until %s",
+			g.ID, g.Name, glyphAction, strings.Join(g.Profiles, ", "), grantClock(g.ExpiresUnix)))
+	}
+	return out, cobra.ShellCompDirectiveNoFileComp
+}
+
+func init() {
+	grantCmd.Flags().StringVar(&grantProcess, "process", "", "running program the grant anchors to, by name (tab-completes from recent callers)")
+	grantCmd.Flags().Int32Var(&grantPIDFlag, "pid", 0, "running process the grant anchors to, by pid (when --process is ambiguous)")
+	grantCmd.Flags().StringArrayVar(&grantProfileNames, "profile", nil, "profile whose secrets the grant covers (repeatable)")
+	grantCmd.Flags().StringVar(&grantFor, "for", "", "how long the grant lasts (45m, 8h, 3d - max 7d)")
+	_ = grantCmd.RegisterFlagCompletionFunc("process", completeGrantProcessNames)
+	_ = grantCmd.RegisterFlagCompletionFunc("profile", completeProfileNames)
+	_ = grantCmd.RegisterFlagCompletionFunc("for", cobra.FixedCompletions([]string{"1h", "8h", "24h", "3d"}, cobra.ShellCompDirectiveNoFileComp))
+
+	grantListCmd.Flags().StringVar(&grantListFormat, "format", "text", "output format: text or json")
+	grantExtendCmd.Flags().StringVar(&grantExtendFor, "for", "", "new lifetime from now (45m, 8h, 3d - max 7d)")
+	_ = grantExtendCmd.RegisterFlagCompletionFunc("for", cobra.FixedCompletions([]string{"1h", "8h", "24h", "3d"}, cobra.ShellCompDirectiveNoFileComp))
+
+	grantCmd.AddCommand(grantListCmd, grantRevokeCmd, grantExtendCmd)
+	rootCmd.AddCommand(grantCmd)
+}

--- a/internal/cli/grant_test.go
+++ b/internal/cli/grant_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/auditlog"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+func TestParseGrantFor(t *testing.T) {
+	if _, err := parseGrantFor("banana"); err == nil {
+		t.Error("parseGrantFor(banana) succeeded, want an error naming the grammar")
+	}
+	if _, err := parseGrantFor("30s"); err == nil {
+		t.Error("parseGrantFor(30s) succeeded, want the 1m-minimum error")
+	}
+	if _, err := parseGrantFor("30d"); err == nil {
+		t.Error("parseGrantFor(30d) succeeded, want the 7d-maximum error: a typo must fail loudly, not mint a month")
+	}
+	for in, want := range map[string]time.Duration{
+		"45m": 45 * time.Minute,
+		"8h":  8 * time.Hour,
+		"3d":  3 * 24 * time.Hour,
+		"1w":  7 * 24 * time.Hour,
+	} {
+		got, err := parseGrantFor(in)
+		if err != nil || got != want {
+			t.Errorf("parseGrantFor(%s) = %v, %v; want %v", in, got, err, want)
+		}
+	}
+}
+
+func TestGrantRemaining(t *testing.T) {
+	now := time.Now()
+	for want, at := range map[string]time.Time{
+		"45m":   now.Add(45*time.Minute + 30*time.Second),
+		"6h12m": now.Add(6*time.Hour + 12*time.Minute + 20*time.Second),
+		"3d2h":  now.Add(3*24*time.Hour + 2*time.Hour + time.Minute),
+		"0m":    now.Add(-time.Minute),
+	} {
+		if got := grantRemaining(at.Unix()); got != want {
+			t.Errorf("grantRemaining(%s from now) = %q, want %q", time.Until(at).Round(time.Minute), got, want)
+		}
+	}
+}
+
+func TestResolveGrantSecretsResolvesProfilesToWrappedDEKs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, "Library", "Application Support", "jitpass")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// A vault with two secrets and a global profile naming them both — one of
+	// them twice, which must not produce a duplicate grant entry.
+	deviceID, err := vault.EnsureDeviceID(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: grantTestWrapper{}, RecipientID: deviceID}
+	if err := v.SetWithMeta("jamf/api-user", []byte("u"), vault.Meta{Class: vault.ClassMCP}); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.SetWithMeta("jamf/api-pass", []byte("p"), vault.Meta{Class: vault.ClassMCP}); err != nil {
+		t.Fatal(err)
+	}
+	profilesDir := filepath.Join(home, ".jit", "profiles")
+	if err := os.MkdirAll(profilesDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	manifest := "JAMF_USER: jamf/api-user\nJAMF_PASS: jamf/api-pass\nJAMF_AGAIN: jamf/api-pass\n"
+	if err := os.WriteFile(filepath.Join(profilesDir, "jamf.yaml"), []byte(manifest), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveGrantSecrets(root)([]string{"jamf"}, "")
+	if err != nil {
+		t.Fatalf("resolveGrantSecrets: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("resolved %d secrets, want 2 (deduplicated): %+v", len(got), got)
+	}
+	for _, sec := range got {
+		if sec.Class != vault.ClassMCP {
+			t.Errorf("%s: class %q, want %q", sec.Path, sec.Class, vault.ClassMCP)
+		}
+		if len(sec.Wrapped) == 0 {
+			t.Errorf("%s: empty wrapped DEK", sec.Path)
+		}
+	}
+
+	if _, err := resolveGrantSecrets(root)([]string{"nope"}, ""); err == nil {
+		t.Error("unknown profile resolved, want an error naming the files checked")
+	}
+}
+
+// grantTestWrapper is a no-op KeyWrapper: resolveGrantSecrets itself never
+// unwraps (that is the point — resolution cannot prompt), so the test wrapper
+// only has to let SetWithMeta write envelopes.
+type grantTestWrapper struct{}
+
+func (grantTestWrapper) WrapKey(dek []byte) ([]byte, error)       { return append([]byte("w:"), dek...), nil }
+func (grantTestWrapper) UnwrapKey(wrapped []byte) ([]byte, error) { return wrapped[2:], nil }
+
+func TestCompleteGrantProcessNamesReadsAuditTrails(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	root := filepath.Join(home, "Library", "Application Support", "jitpass")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	// One recent caller in each trail, one stale (outside 24h), and jit
+	// itself (excluded always).
+	logger := auditlog.New(root, io.Discard)
+	logger.Append(auditlog.Record{UnixNano: time.Now().UnixNano(), Command: "jit run", LaunchedBy: "claude"})
+	logger.Append(auditlog.Record{UnixNano: time.Now().Add(-30 * time.Hour).UnixNano(), Command: "jit run", LaunchedBy: "ancient-tool"})
+	logger.Append(auditlog.Record{UnixNano: time.Now().UnixNano(), Command: "jit scan", LaunchedBy: "jit"})
+	histLine, err := json.Marshal(agent.SessionEvent{UnixTime: time.Now().Unix(), Kind: agent.KindUse, LaunchedBy: "terraform"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, historyFileName), append(histLine, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	out, directive := completeGrantProcessNames(nil, nil, "")
+	if directive != 4 { // cobra.ShellCompDirectiveNoFileComp
+		t.Errorf("directive = %d, want NoFileComp", directive)
+	}
+	joined := strings.Join(out, "\n")
+	for _, want := range []string{"claude\t", "terraform\t"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("completions missing %q:\n%s", want, joined)
+		}
+	}
+	for _, reject := range []string{"ancient-tool", "jit\t"} {
+		if strings.Contains(joined, reject) {
+			t.Errorf("completions include %q (stale or jit itself):\n%s", reject, joined)
+		}
+	}
+	// This test process is running, so its own name annotates as running —
+	// covered implicitly; here just assert every entry carries a description.
+	for _, entry := range out {
+		if !strings.Contains(entry, "\tasked ") {
+			t.Errorf("completion entry %q lacks a description", entry)
+		}
+	}
+}
+
+func TestGrantListRendering(t *testing.T) {
+	var b strings.Builder
+	// Rendering is exercised through the exported pieces it is made of; the
+	// full command needs a live agent. Two grants: one live, one whose root
+	// died, so both glyph rows exist.
+	grants := []agent.GrantStatus{
+		{ID: "g-7f3a2c81", Name: "claude", Profiles: []string{"jamf"}, Secrets: []string{"a", "b"},
+			ExpiresUnix: time.Now().Add(6 * time.Hour).Unix(), Serves: 4, RootAlive: true},
+		{ID: "g-2c91aa00", Name: "terraform", Profiles: []string{"aws-ci"}, Secrets: []string{"c"},
+			ExpiresUnix: time.Now().Add(24 * time.Hour).Unix(), RootAlive: false},
+	}
+	renderGrantRows(&b, grants)
+	out := b.String()
+	for _, want := range []string{"[Grants] 2", "g-7f3a2c81", "4 serves", "process exited, ending", "unused"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("grant list output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "\t") {
+		t.Error("grant list uses tabs; columns are whitespace-padded in the house style")
+	}
+}
+
+func TestGrantClockAxes(t *testing.T) {
+	now := time.Now()
+	if now.Hour() >= 22 { // near midnight the "same day" fixture isn't; skip the ambiguity
+		t.Skip("too close to midnight for stable same-day fixtures")
+	}
+	if got := grantClock(now.Add(time.Minute).Unix()); len(got) != 5 || !strings.Contains(got, ":") {
+		t.Errorf("same-day expiry = %q, want bare clock time (15:04)", got)
+	}
+	if got := grantClock(now.Add(3 * 24 * time.Hour).Unix()); !strings.Contains(got, " ") {
+		t.Errorf("multi-day expiry = %q, want a day marker before the clock", got)
+	}
+}

--- a/internal/lineage/caller.go
+++ b/internal/lineage/caller.go
@@ -7,6 +7,7 @@ package lineage
 
 import (
 	"encoding/binary"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -213,6 +214,51 @@ func isRelay(name string) bool {
 		return true
 	}
 	return false
+}
+
+// VisibleProcesses describes every process the kernel will let this user
+// read, this process excluded. "Visible" already means same-user in practice:
+// another user's processes fail Describe's kernel reads (EPERM), which is the
+// boundary jit's threat model wants. One pass over the process table, so a
+// caller annotating many names (the --process completion) pays the scan once.
+// Resolution and DISPLAY only, per this package's doctrine: nothing here may
+// gate.
+func VisibleProcesses() []Process {
+	pids, err := listAllPIDs()
+	if err != nil {
+		return nil
+	}
+	self := int32(os.Getpid()) // #nosec G115 -- darwin pids fit int32; same conversion IdentifyFIFOReader has always done
+	out := make([]Process, 0, len(pids))
+	for _, pid := range pids {
+		if pid == self || pid <= 0 {
+			continue
+		}
+		p, ok := Describe(pid)
+		if !ok {
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
+// ProcessesNamed returns every currently-visible process whose display Name()
+// is name — how `jit grant --process <name>` resolves a typed name to the
+// live process a grant will anchor to. The grant's gate is the fork-time
+// stamp and ancestry walk taken from the pid afterwards, never this name
+// match itself.
+func ProcessesNamed(name string) []Process {
+	if name == "" {
+		return nil
+	}
+	var out []Process
+	for _, p := range VisibleProcesses() {
+		if p.Name() == name {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // procArgs reads pid's argv from the kernel via sysctl kern.procargs2,

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -277,6 +277,33 @@ func (v *Vault) Get(path string) ([]byte, error) {
 	return plaintext, nil
 }
 
+// WrappedDEK returns the wrapped data key this device would use to open the
+// secret at path, plus its AAD-bound class — WITHOUT decrypting anything or
+// touching the KeyWrapper, so it never prompts. It is the read the agent's
+// process-grant resolution needs (design/process-grants.md): grant creation
+// pre-unwraps exactly these bytes under the challenge's MEK, and the serve
+// path later recognizes the same bytes arriving in an ordinary unwrap. Same
+// version and recipient rules as Get, verbatim: a grant must never resolve an
+// envelope Get would refuse.
+func (v *Vault) WrappedDEK(path string) (wrapped []byte, class string, err error) {
+	env, err := v.readEnvelope(path)
+	if err != nil {
+		return nil, "", err
+	}
+	if env.Version > envelopeVersion {
+		return nil, "", fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
+	}
+	wrappedHex, err := env.wrappedDEKFor(v.RecipientID, path)
+	if err != nil {
+		return nil, "", err
+	}
+	wrapped, err = hex.DecodeString(wrappedHex)
+	if err != nil {
+		return nil, "", fmt.Errorf("corrupt envelope %s: invalid recipient encoding: %w", path, err)
+	}
+	return wrapped, env.Class, nil
+}
+
 // SecretInfo describes a stored secret without decrypting it — everything
 // the envelope says in plaintext. CreatedUnix/UpdatedUnix are zero for
 // version-1 envelopes, which predate the metadata; callers must render

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -717,3 +717,31 @@ func TestVaultVerify(t *testing.T) {
 		t.Errorf("Verify on a missing secret = %v, want ErrNotFound", err)
 	}
 }
+
+func TestWrappedDEKReadsWithoutDecrypting(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.SetWithMeta("jamf/api-pass", []byte("hunter2"), Meta{Class: ClassMCP}); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+
+	wrapped, class, err := v.WrappedDEK("jamf/api-pass")
+	if err != nil {
+		t.Fatalf("WrappedDEK: %v", err)
+	}
+	if class != ClassMCP {
+		t.Errorf("class = %q, want %q", class, ClassMCP)
+	}
+	// The bytes must be exactly what Get would unwrap: the DEK inside must
+	// open under the same wrapper the vault wrote with.
+	dek, err := v.KeyWrapper.UnwrapKey(wrapped)
+	if err != nil {
+		t.Fatalf("returned wrapped DEK does not unwrap: %v", err)
+	}
+	if len(dek) != dekSize {
+		t.Errorf("unwrapped DEK is %d bytes, want %d", len(dek), dekSize)
+	}
+
+	if _, _, err := v.WrappedDEK("nope/missing"); err != ErrNotFound {
+		t.Errorf("WrappedDEK on missing secret = %v, want ErrNotFound", err)
+	}
+}


### PR DESCRIPTION
## What

`jit grant --process claude --profile jamf --for 8h`: with one disclosed Touch ID given while the user is present, a specific **running** process tree may use the named profiles' secrets until an absolute deadline — unattended, across screen lock. `jit grant list` / `revoke <id>` / `extend <id> --for <d>` manage what exists. Design record: `design/process-grants.md`.

## How

- **A scoped DEK cache, never a weaker vault.** At creation the agent unwraps just the covered envelopes' data keys under the challenge's MEK and holds them mlocked, keyed by a digest of the wrapped bytes; a covered `OpUnwrap` from inside the granted tree is answered from that cache with no session and no consent prompt. Any miss (wrong tree, expired, rotated, uncovered) falls through to today's path unchanged.
- **Anchored like trustRoots**: pid + fork-time stamp, descent via `lineage.AncestryContainsPID`, every uncertainty failing closed. The human decision is the disclosed challenge at creation, bound to a kernel-vouched pid — identity still explains, the human still decides.
- **Prompt and scope cannot disagree**: the agent resolves profile names to secrets itself (`Server.OnResolveGrant`, wired to the profile store + `vault.WrappedDEK`), and each entry's class is AEAD-verified at creation — one bad entry fails the whole create.
- **The one deliberate carve-out from "re-lock clears all authorization state"** (documented at the clear site): grants survive re-lock because surviving the screen lock is what the human approved, in so many words. They end by deadline, root exit, revoke, or agent exit — each ending wipes the DEKs and lands in `jit audit` as a new `grant_end` kind. Serves are `grant_use` events; revoke needs no auth; extend re-prompts.

## Testing

- 13 new tests (all `-race`): promptless serve across lock with exactly one MEK fetch, foreign-tree callers never hit the cache, expiry/revoke cut access at the next request, class mismatch fails creation whole, invalid requests rejected before any prompt.
- Full gate green: suite, gofmt, vet, staticcheck, gosec, govulncheck, docs-gen.
- **Live on a real machine**: created a grant for a running Claude session, dropped the session with a genuine `screen locked` event (screenlock watcher), and `jit run` inside the granted tree received both secrets with no prompt while the service stayed locked; audit shows the full lifecycle (approved wording → `read a secret via grant ×2` → revoked), and the earlier unanswered dialogs were recorded as denials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ohVY5hGoQdx57zHP3z6VE