### PR TITLE
grant: completion surfaces the create path and explains empty results

### DIFF
--- a/docs/reference/commands/jit_grant.md
+++ b/docs/reference/commands/jit_grant.md
@@ -6,7 +6,7 @@ Pre-approve a running process to use profiles unattended
 
 Create a process grant: with one Touch ID now, allow a process that is
 already running (and everything it launches) to use the named profiles'
-secrets without further prompts, until the grant expires — including while
+secrets without further prompts, until the grant expires - including while
 the screen is locked or you are away.
 
 The grant is anchored to the live process you name, not to its name: a new

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -45,7 +46,7 @@ var grantCmd = &cobra.Command{
 	Short:   "Pre-approve a running process to use profiles unattended",
 	Long: `Create a process grant: with one Touch ID now, allow a process that is
 already running (and everything it launches) to use the named profiles'
-secrets without further prompts, until the grant expires — including while
+secrets without further prompts, until the grant expires - including while
 the screen is locked or you are away.
 
 The grant is anchored to the live process you name, not to its name: a new
@@ -132,12 +133,25 @@ func requireGrantID(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// grantCreateUsage is the one-line shape of a create, quoted wherever a user
+// lands without it: the bare command, an empty completion, a missing flag.
+const grantCreateUsage = "jit grant --process <name> --profile <profile> --for <duration>"
+
 func runGrantCreate(out io.Writer) error {
+	// A bare `jit grant` is someone discovering the command, not someone who
+	// forgot one flag: answer with the whole shape, not the first missing
+	// piece of it.
+	if grantProcess == "" && grantPIDFlag == 0 && len(grantProfileNames) == 0 && grantFor == "" {
+		return fmt.Errorf("create a grant with %s\n(list / revoke / extend manage existing grants - see `jit grant --help`)", grantCreateUsage)
+	}
+	if grantProcess == "" && grantPIDFlag == 0 {
+		return fmt.Errorf("--process is required (the running program to grant to; tab-completes from recent callers)")
+	}
 	if len(grantProfileNames) == 0 {
 		return fmt.Errorf("--profile is required (repeat it for several: --profile jamf --profile aws-ci)")
 	}
 	if grantFor == "" {
-		return fmt.Errorf("--for is required (how long the grant lasts, like 45m, 8h, 3d — max %s)", formatFlexDuration(agent.MaxGrantTTL))
+		return fmt.Errorf("--for is required (how long the grant lasts, like 45m, 8h, 3d - max %s)", formatFlexDuration(agent.MaxGrantTTL))
 	}
 	ttl, err := parseGrantFor(grantFor)
 	if err != nil {
@@ -200,7 +214,7 @@ func resolveGrantTarget() (lineage.Process, error) {
 	procs := lineage.ProcessesNamed(grantProcess)
 	switch len(procs) {
 	case 0:
-		return lineage.Process{}, fmt.Errorf("nothing named %q is running — a grant anchors to a live process, start it first", grantProcess)
+		return lineage.Process{}, fmt.Errorf("nothing named %q is running - a grant anchors to a live process, start it first", grantProcess)
 	case 1:
 		return procs[0], nil
 	}
@@ -529,20 +543,54 @@ func grantAgo(d time.Duration) string {
 	}
 }
 
+// completeGrantCreateEntry rides the parent command's positional completion:
+// cobra offers the subcommands (list/revoke/extend) on its own, and without
+// this the CREATE form - the whole point of the command - was invisible at
+// exactly the moment a user double-tabs to discover it. Offering the
+// --process flag as a candidate plus an active-help line puts the create
+// shape on the same screen as the subcommands.
+func completeGrantCreateEntry(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	comps := []string{"--process\tcreate: grant a running program (then --profile, --for)"}
+	comps = cobra.AppendActiveHelp(comps, "create a grant: "+grantCreateUsage)
+	return comps, cobra.ShellCompDirectiveNoFileComp
+}
+
+// completeGrantFor offers --for values: common picks up to the 7d cap, with
+// an active-help line saying the grammar is free-form - a fixed list alone
+// read as "these four are the only options", which a real user reported.
+func completeGrantFor(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	comps := []string{"1h", "8h", "24h", "3d", "7d"}
+	comps = cobra.AppendActiveHelp(comps,
+		fmt.Sprintf("any duration up to %s works: 45m, 12h, 5d, ...", formatFlexDuration(agent.MaxGrantTTL)))
+	return comps, cobra.ShellCompDirectiveNoFileComp
+}
+
 // completeGrantIDs offers live grant ids for revoke/extend. It does ask the
-// service (grant_list is prompt-free and instant); an unreachable service
-// completes to nothing rather than an error mid-keystroke.
+// service (grant_list is prompt-free and instant); an unreachable service or
+// an empty grant set completes to an active-help line naming the way forward
+// rather than to dead silence - a tab that produces nothing, explains
+// nothing, and leaves the user stuck was a real report.
 func completeGrantIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
 	ac, err := agentClient()
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		return cobra.AppendActiveHelp(nil, "the jit service is not reachable"), cobra.ShellCompDirectiveNoFileComp
 	}
 	grants, err := ac.GrantList()
 	if err != nil {
-		return nil, cobra.ShellCompDirectiveNoFileComp
+		msg := "could not list grants (is the service on an older jit?)"
+		if errors.Is(err, agent.ErrNotRunning) {
+			msg = "the jit service is not running"
+		}
+		return cobra.AppendActiveHelp(nil, msg), cobra.ShellCompDirectiveNoFileComp
+	}
+	if len(grants) == 0 {
+		return cobra.AppendActiveHelp(nil, "no active grants - create one: "+grantCreateUsage), cobra.ShellCompDirectiveNoFileComp
 	}
 	out := make([]string, 0, len(grants))
 	for _, g := range grants {
@@ -559,11 +607,12 @@ func init() {
 	grantCmd.Flags().StringVar(&grantFor, "for", "", "how long the grant lasts (45m, 8h, 3d - max 7d)")
 	_ = grantCmd.RegisterFlagCompletionFunc("process", completeGrantProcessNames)
 	_ = grantCmd.RegisterFlagCompletionFunc("profile", completeProfileNames)
-	_ = grantCmd.RegisterFlagCompletionFunc("for", cobra.FixedCompletions([]string{"1h", "8h", "24h", "3d"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = grantCmd.RegisterFlagCompletionFunc("for", completeGrantFor)
+	grantCmd.ValidArgsFunction = completeGrantCreateEntry
 
 	grantListCmd.Flags().StringVar(&grantListFormat, "format", "text", "output format: text or json")
 	grantExtendCmd.Flags().StringVar(&grantExtendFor, "for", "", "new lifetime from now (45m, 8h, 3d - max 7d)")
-	_ = grantExtendCmd.RegisterFlagCompletionFunc("for", cobra.FixedCompletions([]string{"1h", "8h", "24h", "3d"}, cobra.ShellCompDirectiveNoFileComp))
+	_ = grantExtendCmd.RegisterFlagCompletionFunc("for", completeGrantFor)
 
 	grantCmd.AddCommand(grantListCmd, grantRevokeCmd, grantExtendCmd)
 	rootCmd.AddCommand(grantCmd)

--- a/internal/cli/grant_test.go
+++ b/internal/cli/grant_test.go
@@ -184,6 +184,54 @@ func TestGrantListRendering(t *testing.T) {
 	}
 }
 
+// Double-tab on the bare command must surface the CREATE path next to the
+// subcommands, and an id completion with nothing to offer must say why and
+// what to do - both were real user reports: create was invisible at the
+// moment of discovery, and `extend <Tab>` with no grants was dead silence.
+func TestGrantCompletionSurfacesCreatePath(t *testing.T) {
+	comps, _ := completeGrantCreateEntry(nil, nil, "")
+	joined := strings.Join(comps, "\n")
+	if !strings.Contains(joined, "--process\t") {
+		t.Errorf("bare-command completion does not offer --process:\n%s", joined)
+	}
+	if !strings.Contains(joined, grantCreateUsage) {
+		t.Errorf("bare-command completion lacks the create usage line:\n%s", joined)
+	}
+	if got, _ := completeGrantCreateEntry(nil, []string{"list"}, ""); got != nil {
+		t.Errorf("completion after an argument = %v, want nothing", got)
+	}
+}
+
+func TestGrantForCompletionSaysFreeForm(t *testing.T) {
+	comps, _ := completeGrantFor(nil, nil, "")
+	joined := strings.Join(comps, "\n")
+	if !strings.Contains(joined, "7d") {
+		t.Errorf("--for completion omits the 7d maximum:\n%s", joined)
+	}
+	if !strings.Contains(joined, "any duration up to 7d") {
+		t.Errorf("--for completion reads as a closed list, missing the free-form hint:\n%s", joined)
+	}
+}
+
+func TestGrantIDCompletionExplainsAnUnreachableService(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no service socket under this root
+	comps, _ := completeGrantIDs(nil, nil, "")
+	joined := strings.Join(comps, "\n")
+	if !strings.Contains(joined, "service is not running") {
+		t.Errorf("id completion with no service = %q, want an active-help explanation", joined)
+	}
+}
+
+// A bare `jit grant` is discovery, not a forgotten flag: the error must show
+// the whole create shape, not just the first missing piece.
+func TestBareGrantErrorShowsTheWholeShape(t *testing.T) {
+	grantProcess, grantPIDFlag, grantProfileNames, grantFor = "", 0, nil, ""
+	err := runGrantCreate(io.Discard)
+	if err == nil || !strings.Contains(err.Error(), grantCreateUsage) {
+		t.Errorf("bare grant error = %v, want it to quote %q", err, grantCreateUsage)
+	}
+}
+
 func TestGrantClockAxes(t *testing.T) {
 	now := time.Now()
 	if now.Hour() >= 22 { // near midnight the "same day" fixture isn't; skip the ambiguity


### PR DESCRIPTION
Two first-use reports:

1. `jit grant <Tab><Tab>` showed only `extend/list/revoke` - the create form, the command's whole point, was invisible at exactly the moment of discovery. The parent command's positional completion now offers `--process` beside the subcommands, with an active-help line carrying the full create shape.
2. `jit grant extend <Tab>` with no grants completed to dead silence. Empty id completion now says why ("no active grants - create one: ...", or "the jit service is not running") via cobra active-help instead of leaving the user stuck.

Also: `--for` completion adds `7d` and an active-help line saying any duration up to the cap works (`45m`, `12h`, `5d`, ...), so the fixed picks stop reading as a closed list; a bare `jit grant` errors with the whole create shape instead of the first missing flag; and the command's user-facing strings drop their em dashes per house style.

What double-tab shows now:

```
extend     -- Give an existing grant more time (re-prompts Touch ID)
list       -- Show the active process grants
revoke     -- End a process grant now
--process  -- create: grant a running program (then --profile, --for)
create a grant: jit grant --process <name> --profile <profile> --for <duration>
```

Deliberately NOT a `create`/`process` subcommand: `jit grant --process X --profile Y --for 8h` is the shipped grammar, and a second spelling of the same act would leave two ways to say one thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ohVY5hGoQdx57zHP3z6VE