### PR TITLE
audit: a capped report says so, and the long reports page like git

### DIFF
--- a/docs/reference/commands/jit_audit.md
+++ b/docs/reference/commands/jit_audit.md
@@ -78,6 +78,7 @@ jit audit [flags]
       --grep string     only entries whose rendered line matches this regular expression
       --kind strings    only these kinds (comma-separated): cmd, unlock, use, grant, serve, lock, service, error
       --limit int       show at most this many recent matching entries (0 for all) (default 50)
+      --no-pager        print straight to the terminal instead of paging through $PAGER
       --parent string   only entries whose launched-by ancestor contains this (e.g. claude)
       --secret string   only auth events that touched a secret whose name contains this
       --since string    only entries at or after this time: an age (2h, 90m, 3d) or a date ("2026-07-23" or "2026-07-23 09:00")

--- a/docs/reference/commands/jit_scan.md
+++ b/docs/reference/commands/jit_scan.md
@@ -48,6 +48,7 @@ jit scan [path...] [flags]
       --fail-on string   exit 2 when the scan's risk level is at or above this: critical, high, medium, low, or any (default: always exit 0)
       --format string    output format: "text" (default), "markdown"/"md", or "ndjson" (default "text")
       --full             print the full finding inventory (categories, severities, every file and line) instead of the coverage summary
+      --no-pager         print straight to the terminal instead of paging through $PAGER
   -o, --output string    write the report to this file instead of stdout
       --score            print only the exposure score (e.g. "Exposure: 92/100 (CRITICAL)") and exit
       --unfiltered       show findings jit normally judges to be settings, paths, browser-public build variables or unfilled template values; each is tagged [unfiltered] with the rule that hid it, so one run audits what the filters are hiding

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -412,12 +412,17 @@ var auditCmd = &cobra.Command{
 		commands := auditlog.New(root, io.Discard).Load(0)
 		events := newHistoryLog(root, io.Discard).load(1 << 30)
 
+		// Page the snapshot views on a terminal. --follow stays direct: it
+		// streams live, and a pager buffering an endless tail shows nothing.
+		out, donePaging := pageableOutput(cmd)
+		defer donePaging()
+
 		if auditFormat == "json" {
 			keptCmds, keptEvents := filterSources(commands, events, filter, auditLimit)
-			return writeJSON(cmd.OutOrStdout(), auditJSON{Commands: keptCmds, AuthEvents: keptEvents})
+			return writeJSON(out, auditJSON{Commands: keptCmds, AuthEvents: keptEvents})
 		}
 
-		printAuditLog(cmd.OutOrStdout(), commands, events, filter, auditLimit)
+		printAuditLog(out, commands, events, filter, auditLimit)
 		return nil
 	},
 }
@@ -471,6 +476,9 @@ func printAuditLog(w io.Writer, commands []auditlog.Record, events []agent.Sessi
 	// Newest first. Stable so that a command and the unlock it triggered, which
 	// can share a whole-second timestamp, keep the order they were appended in.
 	sort.SliceStable(entries, func(i, j int) bool { return entries[i].t.After(entries[j].t) })
+	// Measure the whole match set BEFORE the limit cuts it: the header
+	// describes what the query matched, the cap only decides what prints.
+	scale := auditScaleOf(entries)
 	if limit > 0 && len(entries) > limit {
 		entries = entries[:limit]
 	}
@@ -481,7 +489,7 @@ func printAuditLog(w io.Writer, commands []auditlog.Record, events []agent.Sessi
 		}
 		return
 	}
-	printAuditReport(w, entries, filter.active())
+	printAuditReport(w, entries, filter.active(), scale)
 }
 
 // buildEntries renders every command and event that survives the filter into a
@@ -1136,6 +1144,7 @@ func init() {
 	auditCmd.Flags().StringVar(&auditParent, "parent", "", "only entries whose launched-by ancestor contains this (e.g. claude)")
 	auditCmd.Flags().StringVar(&auditSecret, "secret", "", "only auth events that touched a secret whose name contains this")
 	auditCmd.Flags().StringVar(&auditGrep, "grep", "", "only entries whose rendered line matches this regular expression")
+	registerPagerFlag(auditCmd)
 
 	// `jit audit` is the one filterable surface, and every filter is a flag:
 	// tab offered a directory listing for all eleven of them, and nothing at

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -287,7 +287,7 @@ func TestAuditHeaderCountsDecoyRowsNotReads(t *testing.T) {
 		{t: time.Unix(5000, 0), kind: "serve", status: "decoy", subject: "decoy served to node ×34"},
 		{t: time.Unix(4000, 0), kind: "serve", status: "real", subject: "real value served to terraform"},
 	}
-	writeAuditHeader(&buf, entries)
+	writeAuditHeader(&buf, entries, auditScaleOf(entries))
 	if got := buf.String(); !strings.Contains(got, "1 decoy read") {
 		t.Errorf("header = %q, want it to count 1 decoy row (not 34 reads)", got)
 	}

--- a/internal/cli/auditreport.go
+++ b/internal/cli/auditreport.go
@@ -46,13 +46,15 @@ const (
 var auditHangIndent = strings.Repeat(" ", auditRowLead)
 
 // printAuditReport renders the merged trail as the human report. Entries
-// arrive newest-first and already filtered and limited.
-func printAuditReport(w io.Writer, entries []auditEntry, filtered bool) {
+// arrive newest-first and already filtered and limited; scale describes the
+// full match set they were cut from, so the header and footer can speak for
+// the whole query even when --limit capped what prints.
+func printAuditReport(w io.Writer, entries []auditEntry, filtered bool, scale auditScale) {
 	if len(entries) == 0 {
 		printAuditEmpty(w, filtered)
 		return
 	}
-	writeAuditHeader(w, entries)
+	writeAuditHeader(w, entries, scale)
 	groups := groupAuditEntries(entries)
 	cols := auditColumns(groups)
 
@@ -71,14 +73,25 @@ func printAuditReport(w io.Writer, entries []auditEntry, filtered bool) {
 	fmt.Fprintln(w)
 	fmt.Fprint(w, "  ")
 	_, _ = cPath.Fprint(w, glyphAction+" ")
-	// Point at the most useful next filter. When any unlock was refused, name
-	// --status denied too, since it is now a distinct count in the header above.
-	hint := cPath.Sprint("jit audit --status failed") +
-		"   only what went wrong"
-	if _, denied := auditOutcomeCounts(entries); denied > 0 {
+	// Point at the most useful next step. When --limit cut the view, that is
+	// seeing the rest — a capped report once read as "history deleted" to a
+	// reader who asked for three days and got one afternoon back. Otherwise
+	// lead with the sharpest filter. Either way the conditional hints are
+	// judged against the FULL match set, so a denial or decoy that --limit
+	// pushed off the page still earns its filter a mention.
+	var hint string
+	if scale.total > len(entries) {
+		hint = cPath.Sprint("jit audit --limit 0") +
+			fmt.Sprintf("   all %d events", scale.total) +
+			" · " + cPath.Sprint("--status failed") + " for what went wrong"
+	} else {
+		hint = cPath.Sprint("jit audit --status failed") +
+			"   only what went wrong"
+	}
+	if scale.denied > 0 {
 		hint += " · " + cPath.Sprint("--status denied") + " for refusals"
 	}
-	if auditDecoyRows(entries) > 0 {
+	if scale.decoy > 0 {
 		hint += " · " + cPath.Sprint("--status decoy") + " for reads that got decoys"
 	}
 	hint += " · --format logfmt for the machine form"
@@ -96,33 +109,61 @@ func printAuditEmpty(w io.Writer, filtered bool) {
 	fmt.Fprintln(w, hlCmds("No audit log yet. It fills in as you run jit commands; if the service has never run, there are no unlocks to show either."))
 }
 
-// writeAuditHeader states the scale of what follows: how many events, over
-// what span, and how many of them failed. The logfmt view had no summary at
-// all, so "did anything go wrong today?" meant reading every line.
-func writeAuditHeader(w io.Writer, entries []auditEntry) {
+// auditScale describes the FULL match set a report was drawn from, measured
+// before --limit cut it down to a page. The header renders these numbers, not
+// the printed slice's: a header that tallied only the visible rows described
+// its own page while appearing to describe the query — `--since 3d` answered
+// with one afternoon's span and no hint that 164 matches were cut, which a
+// reasonable reader took as "the older history is gone".
+type auditScale struct {
+	total          int
+	oldest, newest time.Time
+	failed, denied int
+	decoy          int
+}
+
+// auditScaleOf measures the full match set. Entries arrive newest-first.
+func auditScaleOf(entries []auditEntry) auditScale {
+	s := auditScale{total: len(entries)}
+	if s.total == 0 {
+		return s
+	}
+	s.newest, s.oldest = entries[0].t, entries[len(entries)-1].t
+	s.failed, s.denied = auditOutcomeCounts(entries)
+	s.decoy = auditDecoyRows(entries)
+	return s
+}
+
+// writeAuditHeader states the scale of what the query MATCHED: how many
+// events, over what span, and how many of them failed — with a "50 of 214"
+// count when --limit means the rows below are only the newest page of it.
+// The logfmt view had no summary at all, so "did anything go wrong today?"
+// meant reading every line.
+func writeAuditHeader(w io.Writer, entries []auditEntry, scale auditScale) {
+	count := countWord(scale.total, "event", "events")
+	if scale.total > len(entries) {
+		count = fmt.Sprintf("%d of %d events", len(entries), scale.total)
+	}
+	span := fmt.Sprintf("%s–%s", scale.oldest.Format("15:04"), scale.newest.Format("15:04"))
+	if !sameDay(scale.oldest, scale.newest) {
+		span = fmt.Sprintf("%s – %s", auditDayLabel(scale.oldest), auditDayLabel(scale.newest))
+	}
+	head := fmt.Sprintf("jit audit — %s · %s", count, span)
 	// Count the two bad outcomes separately: they are distinct statuses a reader
 	// can filter on (--status failed vs --status denied), so collapsing them
 	// into one "failed" made the header disagree with the filter it points at.
-	failed, denied := auditOutcomeCounts(entries)
-	// Entries are newest-first.
-	newest, oldest := entries[0].t, entries[len(entries)-1].t
-	span := fmt.Sprintf("%s–%s", oldest.Format("15:04"), newest.Format("15:04"))
-	if !sameDay(oldest, newest) {
-		span = fmt.Sprintf("%s – %s", auditDayLabel(oldest), auditDayLabel(newest))
+	if scale.failed > 0 {
+		head += fmt.Sprintf(" · %d failed", scale.failed)
 	}
-	head := fmt.Sprintf("jit audit — %s · %s", countWord(len(entries), "event", "events"), span)
-	if failed > 0 {
-		head += fmt.Sprintf(" · %d failed", failed)
-	}
-	if denied > 0 {
-		head += fmt.Sprintf(" · %d denied", denied)
+	if scale.denied > 0 {
+		head += fmt.Sprintf(" · %d denied", scale.denied)
 	}
 	// Decoy reads are counted in ROWS, not in the collapsed Count each row
 	// carries: the header's job is "how much of what follows is this", and a
 	// single looping watcher would otherwise report thousands and read like a
 	// breach.
-	if decoy := auditDecoyRows(entries); decoy > 0 {
-		head += fmt.Sprintf(" · %s", countWord(decoy, "decoy read", "decoy reads"))
+	if scale.decoy > 0 {
+		head += fmt.Sprintf(" · %s", countWord(scale.decoy, "decoy read", "decoy reads"))
 	}
 	_, _ = fmt.Fprintln(w, head)
 	fmt.Fprintln(w)

--- a/internal/cli/auditreport_test.go
+++ b/internal/cli/auditreport_test.go
@@ -18,7 +18,7 @@ func reportEntry(t time.Time, subject, parent, status string) auditEntry {
 
 func renderReport(entries []auditEntry) string {
 	var buf bytes.Buffer
-	printAuditReport(&buf, entries, false)
+	printAuditReport(&buf, entries, false, auditScaleOf(entries))
 	return buf.String()
 }
 
@@ -199,8 +199,8 @@ func TestAuditReportMarksALockAsAStateNotAFailure(t *testing.T) {
 
 func TestAuditReportEmptyStates(t *testing.T) {
 	var filtered, fresh bytes.Buffer
-	printAuditReport(&filtered, nil, true)
-	printAuditReport(&fresh, nil, false)
+	printAuditReport(&filtered, nil, true, auditScale{})
+	printAuditReport(&fresh, nil, false, auditScale{})
 	if !strings.Contains(filtered.String(), "match those filters") {
 		t.Errorf("filtered empty state: %q", filtered.String())
 	}
@@ -235,5 +235,62 @@ func TestAuditReportRowsFitTheWindow(t *testing.T) {
 		if n := len([]rune(line)); n > 80 {
 			t.Errorf("row is %d columns, want <= 80: %q", n, line)
 		}
+	}
+}
+
+// A capped report must say so. The header describes the full match set (its
+// count, span, and outcome tallies), never the printed page alone — a header
+// that reported 50 events over one afternoon against a --since 3d query read
+// as "the older history was deleted".
+func TestAuditReportCappedHeaderSpeaksForTheFullMatchSet(t *testing.T) {
+	base := time.Date(2026, 8, 12, 17, 0, 0, 0, time.Local)
+	full := []auditEntry{
+		reportEntry(base, "jit status", "iTerm", "ok"),
+		reportEntry(base.Add(-time.Hour), "jit run -- true", "claude", "failed"),
+		{t: base.Add(-2 * time.Hour), kind: "serve", status: "decoy", subject: "decoy served to node"},
+		reportEntry(base.Add(-72*time.Hour), "jit vault list", "iTerm", "ok"),
+	}
+	scale := auditScaleOf(full)
+
+	var buf bytes.Buffer
+	printAuditReport(&buf, full[:2], false, scale)
+	out := buf.String()
+
+	if !strings.Contains(out, "2 of 4 events") {
+		t.Errorf("capped header must count shown-of-matched:\n%s", out)
+	}
+	// The span covers the whole match set (multi-day), not the printed page's
+	// single afternoon.
+	if !strings.Contains(out, " – ") {
+		t.Errorf("capped header must span the full match set's days:\n%s", out)
+	}
+	// The failed command is on the page, the decoy row is not — both still
+	// belong to the header's tallies.
+	if !strings.Contains(out, "1 failed") || !strings.Contains(out, "1 decoy read") {
+		t.Errorf("header tallies must cover rows the cap cut:\n%s", out)
+	}
+	// And the way out is named: the trailer leads with --limit 0 and carries
+	// the full count, plus the decoy filter the cut row earns.
+	if !strings.Contains(out, "--limit 0") || !strings.Contains(out, "all 4 events") {
+		t.Errorf("capped trailer must point at --limit 0:\n%s", out)
+	}
+	if !strings.Contains(out, "--status decoy") {
+		t.Errorf("a decoy the cap cut must still earn its filter hint:\n%s", out)
+	}
+}
+
+// An uncapped report keeps today's exact shape: a plain count, no
+// shown-of-matched, no --limit hint.
+func TestAuditReportUncappedHeaderUnchanged(t *testing.T) {
+	now := time.Now()
+	out := renderReport([]auditEntry{
+		reportEntry(now, "jit status", "iTerm", "ok"),
+		reportEntry(now.Add(-time.Minute), "jit vault list", "iTerm", "ok"),
+	})
+	if !strings.Contains(out, "2 events") || strings.Contains(out, " of ") {
+		t.Errorf("uncapped header must stay a plain count:\n%s", out)
+	}
+	if strings.Contains(out, "--limit") {
+		t.Errorf("uncapped trailer must not hint at --limit:\n%s", out)
 	}
 }

--- a/internal/cli/pager.go
+++ b/internal/cli/pager.go
@@ -1,0 +1,187 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/term"
+)
+
+// jit pages its long reports (`jit audit`, `jit scan`) through the user's
+// pager, git-style: only when stdout is the real terminal, resolved from
+// $JIT_PAGER then $PAGER then less, with -F so output that fits one screen
+// prints inline as if no pager existed. Everything else about the report is
+// deliberately untouched — the pager writer wraps only the command's output
+// stream, never os.Stdout itself, so fatih/color still sees a terminal (color
+// survives into `less -R`) and termtext.Width() still reads the real window
+// (no collapse to the 80-column pipe fallback).
+//
+// The pager is spawned LAZILY, on the first byte of report output. `jit scan`
+// runs a progress trail on stderr for many seconds before its report starts;
+// a pager started up front would sit as a blank alternate screen over that
+// trail the whole time.
+
+// pagerOff is --no-pager on the commands that page. One var shared by both
+// registrations: only one command runs per process, and a shared var is what
+// keeps the flag's meaning identical everywhere it appears.
+var pagerOff bool
+
+// registerPagerFlag adds --no-pager to a command that pages its output.
+func registerPagerFlag(cmd *cobra.Command) {
+	cmd.Flags().BoolVar(&pagerOff, "no-pager", false, "print straight to the terminal instead of paging through $PAGER")
+}
+
+// resolvePager picks the pager command line: $JIT_PAGER wins, then $PAGER,
+// then less. A variable set to the empty string or to "cat" disables paging —
+// the same convention git honors, and the escape hatch for a shell where
+// --no-pager can't be typed (an alias, a wrapper script).
+func resolvePager() string {
+	for _, k := range []string{"JIT_PAGER", "PAGER"} {
+		if v, ok := os.LookupEnv(k); ok {
+			v = strings.TrimSpace(v)
+			if v == "cat" {
+				return ""
+			}
+			return v
+		}
+	}
+	return "less"
+}
+
+// pageableOutput returns the writer a long report should print to, plus a
+// done func the caller must invoke (defer is fine) after the last write —
+// it closes the pager's stdin and waits for the user to quit it, so the
+// command's exit still marks "the user is finished reading".
+//
+// Paging engages only when every one of these holds: the command's output is
+// the process's real stdout (tests substitute buffers, and a future caller
+// may substitute a file), that stdout is a terminal (piping to grep or
+// redirecting to a file must behave exactly as before), --no-pager wasn't
+// given, and the resolved pager is non-empty. Otherwise the caller's writer
+// comes back unchanged with a no-op done.
+func pageableOutput(cmd *cobra.Command) (io.Writer, func()) {
+	out := cmd.OutOrStdout()
+	if pagerOff {
+		return out, func() {}
+	}
+	stdout, ok := out.(*os.File)
+	if !ok || stdout != os.Stdout || !term.IsTerminal(int(stdout.Fd())) {
+		return out, func() {}
+	}
+	pager := resolvePager()
+	if pager == "" {
+		return out, func() {}
+	}
+	p := &pagerWriter{cmdline: pager, dst: stdout}
+	return p, p.close
+}
+
+// pagerWriter lazily spawns the pager on the first write and streams into
+// its stdin. If the spawn fails (pager not installed, /bin/sh missing) it
+// degrades silently to writing straight through — a missing pager must never
+// cost the report itself.
+type pagerWriter struct {
+	cmdline string
+	dst     *os.File
+
+	started bool
+	proc    *exec.Cmd
+	pipe    io.WriteCloser
+}
+
+func (p *pagerWriter) Write(b []byte) (int, error) {
+	if !p.started {
+		p.started = true
+		p.start()
+	}
+	if p.pipe == nil {
+		return p.dst.Write(b)
+	}
+	if _, err := p.pipe.Write(b); err != nil {
+		// The user quit the pager before the report finished streaming.
+		// That is them saying "seen enough", not a failure: claim the write
+		// succeeded so the report code upstream never surfaces an EPIPE for
+		// a deliberate q keystroke.
+		return len(b), nil
+	}
+	return len(b), nil
+}
+
+func (p *pagerWriter) start() {
+	// Catch a typo'd $PAGER before the shell does: sh itself starts fine,
+	// dies with "command not found", and every report byte would then vanish
+	// into the broken pipe. Only checkable when the value is a plain command
+	// (possibly with flags) — anything with shell syntax is the shell's to
+	// judge.
+	if name, ok := simplePagerName(p.cmdline); ok {
+		if _, err := exec.LookPath(name); err != nil {
+			fmt.Fprintf(os.Stderr, "jit: pager %q not found; printing without it\n", name)
+			return
+		}
+	}
+	// Through the shell, so PAGER="less -S" and any other value a user's
+	// dotfiles export works verbatim. The command line comes from the user's
+	// own environment and runs as them, with their terminal — the exact
+	// contract $PAGER has had since forever.
+	cmd := exec.Command("/bin/sh", "-c", p.cmdline) // #nosec G204 -- $PAGER/$JIT_PAGER is the user's own choice of program, the flag's entire purpose
+	cmd.Stdout = p.dst
+	cmd.Stderr = os.Stderr
+	env := os.Environ()
+	// Defaults for a bare `less`, only when the user hasn't set their own:
+	// -F quit inline if it fits one screen, -R pass color through, -X skip
+	// the alternate screen so short output stays in scrollback. Env rather
+	// than argv so a user's exported LESS wins wholesale, exactly as git
+	// does it.
+	if _, ok := os.LookupEnv("LESS"); !ok {
+		env = append(env, "LESS=FRX")
+	}
+	cmd.Env = env
+	pipe, err := cmd.StdinPipe()
+	if err != nil {
+		return
+	}
+	if err := cmd.Start(); err != nil {
+		_ = pipe.Close()
+		return
+	}
+	// While the pager owns the terminal, ctrl-C belongs to it (less uses it
+	// to interrupt a search). The keyboard SIGINT goes to the whole
+	// foreground process group, so without this jit would die and orphan the
+	// pager mid-display. Restored in close.
+	signal.Ignore(syscall.SIGINT)
+	p.proc, p.pipe = cmd, pipe
+}
+
+// simplePagerName returns the command a pager value names, when the value is
+// a bare command with optional flags ("less", "less -S", "more"). A value
+// carrying shell syntax — a pipeline, a variable, quoting — reports !ok and
+// is left for the shell to interpret.
+func simplePagerName(cmdline string) (string, bool) {
+	if strings.ContainsAny(cmdline, "|&;<>()$`\\\"'*?[]{}~#") {
+		return "", false
+	}
+	fields := strings.Fields(cmdline)
+	if len(fields) == 0 {
+		return "", false
+	}
+	return fields[0], true
+}
+
+func (p *pagerWriter) close() {
+	if p.pipe != nil {
+		_ = p.pipe.Close()
+	}
+	if p.proc != nil {
+		_ = p.proc.Wait()
+		signal.Reset(syscall.SIGINT)
+	}
+}

--- a/internal/cli/pager_test.go
+++ b/internal/cli/pager_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestResolvePagerPrecedence(t *testing.T) {
+	cases := []struct {
+		name, jitPager, pager string
+		setJit, setPager      bool
+		want                  string
+	}{
+		{name: "default is less", want: "less"},
+		{name: "PAGER honored", setPager: true, pager: "more", want: "more"},
+		{name: "JIT_PAGER wins", setJit: true, jitPager: "bat", setPager: true, pager: "more", want: "bat"},
+		{name: "cat disables", setPager: true, pager: "cat", want: ""},
+		{name: "empty disables", setJit: true, jitPager: "", want: ""},
+		{name: "value with flags kept verbatim", setPager: true, pager: "less -S", want: "less -S"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Unset both first: the test process inherits the developer's own
+			// PAGER, and t.Setenv restores whatever was there afterwards.
+			for _, k := range []string{"JIT_PAGER", "PAGER"} {
+				t.Setenv(k, "")
+				os.Unsetenv(k)
+			}
+			if tc.setJit {
+				t.Setenv("JIT_PAGER", tc.jitPager)
+			}
+			if tc.setPager {
+				t.Setenv("PAGER", tc.pager)
+			}
+			if got := resolvePager(); got != tc.want {
+				t.Errorf("resolvePager() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A command whose output was substituted (every test, and any caller writing
+// to a buffer or file) must get its writer back untouched: the pager only
+// ever fronts the process's real terminal.
+func TestPageableOutputPassesNonStdoutThrough(t *testing.T) {
+	cmd := &cobra.Command{}
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	out, done := pageableOutput(cmd)
+	done()
+	if out != &buf {
+		t.Fatalf("pageableOutput substituted a writer for a non-stdout output")
+	}
+}
+
+func TestSimplePagerName(t *testing.T) {
+	for cmdline, want := range map[string]string{
+		"less":            "less",
+		"less -S -+F":     "less",
+		"more":            "more",
+		"col -b | less":   "", // pipeline: the shell's business
+		"$HOME/bin/pager": "", // variable: ditto
+		"  ":              "",
+	} {
+		name, ok := simplePagerName(cmdline)
+		if ok != (want != "") || name != want {
+			t.Errorf("simplePagerName(%q) = %q, %v; want %q", cmdline, name, ok, want)
+		}
+	}
+}
+
+// A pager that spawns streams the report and delivers it whole once closed.
+func TestPagerWriterStreamsThroughARealPager(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "paged")
+	dst, err := os.Create(path) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+
+	p := &pagerWriter{cmdline: "cat", dst: dst}
+	if _, err := p.Write([]byte("first line\n")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := p.Write([]byte("second line\n")); err != nil {
+		t.Fatal(err)
+	}
+	p.close()
+
+	got, err := os.ReadFile(path) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "first line\nsecond line\n" {
+		t.Errorf("paged output = %q", got)
+	}
+}
+
+// A pager that doesn't exist must cost nothing but a stderr note: the report
+// itself falls through to the terminal.
+func TestPagerWriterFallsBackWhenPagerMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "direct")
+	dst, err := os.Create(path) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+
+	p := &pagerWriter{cmdline: "definitely-not-a-pager-jit-test", dst: dst}
+	if _, err := p.Write([]byte("the report\n")); err != nil {
+		t.Fatal(err)
+	}
+	p.close()
+
+	got, err := os.ReadFile(path) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "the report\n" {
+		t.Errorf("fallback output = %q, want the report delivered directly", got)
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -239,7 +239,7 @@ var scanCmd = &cobra.Command{
 			return failOnResult(scanFailOn, summary.RiskLevel, summary.ExposureScore, len(summary.DegradedScanners))
 		}
 
-		out := cmd.OutOrStdout()
+		var out io.Writer
 		home, _ := os.UserHomeDir() // display-only "~"-shortening; "" (no shortening) if unresolvable
 		var outFile *os.File
 		if scanOutput != "" {
@@ -260,6 +260,13 @@ var scanCmd = &cobra.Command{
 			// later, often by a tool that can't expand "~" — keep the
 			// absolute file:line locations a terminal reader doesn't need.
 			home = ""
+		} else {
+			// On a terminal, page the report: a machine-wide scan runs well
+			// past one screen. Lazy spawn (see pageableOutput) keeps the
+			// progress trail above visible while the scan itself runs.
+			var donePaging func()
+			out, donePaging = pageableOutput(cmd)
+			defer donePaging()
 		}
 
 		// The triage view is the default for a machine-wide text scan: the
@@ -357,6 +364,7 @@ func init() {
 	scanCmd.Flags().BoolVar(&scanScore, "score", false, `print only the exposure score (e.g. "Exposure: 92/100 (CRITICAL)") and exit`)
 	scanCmd.Flags().BoolVar(&scanFull, "full", false, "print the full finding inventory (categories, severities, every file and line) instead of the coverage summary")
 	scanCmd.Flags().StringVar(&scanFailOn, "fail-on", "", "exit 2 when the scan's risk level is at or above this: critical, high, medium, low, or any (default: always exit 0)")
+	registerPagerFlag(scanCmd)
 	_ = scanCmd.RegisterFlagCompletionFunc("fail-on", func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 		return []string{audit.RiskLevelCritical, audit.RiskLevelHigh, audit.RiskLevelMedium, audit.RiskLevelLow, "any"}, cobra.ShellCompDirectiveNoFileComp
 	})


### PR DESCRIPTION
## What

Two halves of one reported complaint: `jit audit --since 3d` printed `50 events · 15:06–17:34`, and the reader reasonably concluded three days of history had been deleted by an upgrade. Nothing was deleted — the default `--limit 50` had cut the view, and the header then described its own page while appearing to describe the query.

### The header speaks for the query

- The full match set is measured **before** the cap: the header shows `50 of 214 events`, the query's true span, and failed/denied/decoy tallies that include rows the cap cut.
- The trailer's first hint becomes the way out: `jit audit --limit 0   all 214 events`.
- An uncapped report renders **byte-identical** to before (tested).

### The long reports page, git-style

`jit audit` and `jit scan` now page through the user's pager on a terminal: `$JIT_PAGER` → `$PAGER` → `less`, with `LESS=FRX` set only when unset (color through, one-screen output prints inline and stays in scrollback). `--no-pager` or `PAGER=cat` opt out.

Design points:

- The pager writer fronts **only the command's output stream** — `os.Stdout` is untouched, so fatih/color still sees a terminal and `termtext.Width()` still reads the real window. Color and full-width layout survive into `less -R` for free.
- Spawned **lazily on the first report byte**, so scan's stderr progress trail stays visible instead of a blank pager screen.
- A typo'd `$PAGER` warns on stderr and prints straight through — the report must never vanish into a broken pipe.
- Piped or redirected output is byte-identical to before: the pager engages only on a real tty. `--follow` stays direct (a pager buffering an endless tail shows nothing).
- ctrl-C belongs to the pager while it owns the terminal (less uses it to interrupt a search), restored on close.

## Testing

- New tests: capped/uncapped header contract, pager resolution precedence, stream-through via a real spawned pager, missing-pager fallback.
- Full `go test -race ./...`, gofmt, vet, staticcheck, gosec, `go mod verify`/`tidy` clean; docs regenerated.
- Exercised live under a pty: pager engages on a tty, `--no-pager` overrides, pipes never spawn it, missing pager falls back with a warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TXiT8qiEHcUyKDbSkofwT5