### PR TITLE
grant: tree-scoped --process covers current and future sessions under your terminal

### DIFF
--- a/design/process-grants.md
+++ b/design/process-grants.md
@@ -1,6 +1,7 @@
 # Process grants: pre-approved unattended access
 
-**Status: proposal, being built on branch `process-grants`.**
+**Status: shipped (v0.86.0); tree-scoped `--process` grants added later —
+see "Tree-scoped grants" below.**
 
 Today every credential serve ultimately rides a session the human opened with
 Touch ID, and the session dies on idle, on an 8h ceiling, on screen lock, on
@@ -36,13 +37,62 @@ A grant is `(root process, secret set, expiry)`:
   `maxGrantTTL = 7d`. Checked at serve time against the record, never baked
   into key material, so revoke and expiry act immediately.
 
-A grant is **not** a policy. It cannot match future processes, it does not
+A grant is **not** a policy. It is never a bare name-pattern, it does not
 survive the agent process (v1), and it never covers secrets outside its
 resolved set. Identity still never decides anything the human did not
 explicitly approve: the doctrine "caller identity explains and audits, never
 decides" is preserved because the *decision* is the disclosed Touch ID at
 creation, bound to a kernel-vouched pid; descent-from-root afterwards is the
 same fail-closed mechanism `--trust` already relies on.
+
+## Tree-scoped grants: covering future processes without a name gate
+
+The exact-pid shape above answered "this running claude" but not the real
+workflow: "every claude I start from this terminal in the next hour", or a
+script that will run in ten minutes. Its UX also collapsed when seven
+processes shared a name (pick a pid from identical rows) and when the target
+was not yet running.
+
+`jit grant --process NAME` is therefore **tree-scoped**: the anchor is the
+creating human's own **session root** — the topmost ancestor below launchd
+of the shell the command is typed in (`lineage.SessionRoot`): the terminal
+app, the tmux server, the IDE process, the SSH connection. Serving requires
+BOTH (`lineage.AncestryNamedWithin`, fail-closed like every walk):
+
+1. the requester's ancestry passes through a process whose display name is
+   NAME, at or below the root, and
+2. the chain then reaches the root itself (same pid + fork-time pin as
+   every anchor).
+
+Condition 2 is a kernel fact no process can arrange for itself; condition 1
+is self-chosen (argv/exec path) and deliberately carries **no security
+weight** — it only NARROWS what the tree admits. A process elsewhere on the
+machine gains nothing by renaming itself claude; a hostile process already
+inside the terminal tree was already inside the human-approved perimeter.
+"Any future NAME anywhere, machine-wide" was considered and rejected: it
+would make the spoofable half the only gate.
+
+Consequences, all deliberate:
+
+- Future processes ARE covered: membership is evaluated per serve against
+  the live tree, never against a pid list frozen at creation. Granting
+  before the target starts is valid ("none running yet" on the
+  confirmation), which is the automation story — grant, walk away, the
+  script fires inside the window.
+- The prompt names both halves: *"let claude under iTerm2 use 1 secret
+  (jamf) unattended for 1h"*. The name is the human's own typed word (their
+  intent, not a process describing itself); the anchor rendering is
+  kernel-derived from the verified root.
+- The agent refuses an anchor that is not the CALLER's own ancestor, and
+  refuses pid 1 outright — "anchored under launchd" would be the machine-
+  wide name grant this design exists to avoid.
+- The grant dies with the terminal app (anchor exit == root exit), at its
+  deadline, or on revoke — whichever is first.
+- Per-anchor is the honest boundary: a claude under VS Code's terminal is
+  a different tree than iTerm2's; each session grants its own.
+
+`--pid` keeps the original exact-one-process semantics, now annotated in
+completion with each candidate's cwd and age (the seven-identical-rows fix).
 
 ## Mechanics: a scoped DEK cache, not a weaker vault
 
@@ -116,11 +166,10 @@ is a new decision); shortening via `revoke` + re-create, or a later
     jit grant revoke <id>
     jit grant extend <id> --for <dur>
 
-- `--process` resolves the name against the **currently running** processes
-  (libproc listing, same-user only, `lineage.Process.Name()` normalization).
-  Ambiguity (two claudes) is an error listing candidates with pids; `--pid`
-  disambiguates. Nothing running under that name is an error, not a stored
-  pattern.
+- `--process` is tree-scoped (see "Tree-scoped grants" above): anchored to
+  the session root of the terminal it is typed in, covering the name's
+  current and future processes under it. No ambiguity error, no
+  must-be-running requirement. `--pid` is the exact-one-process mode.
 - `--profile` repeats; each resolves through the normal project-then-global
   chain. `--for` accepts the `jit audit --since` duration grammar (`45m`,
   `8h`, `3d`), capped at 7d.

--- a/docs/reference/commands/jit.md
+++ b/docs/reference/commands/jit.md
@@ -28,7 +28,7 @@ jit [flags]
 * [jit doctor](jit_doctor.md)	 - One-shot health check: profiles, secrets, service, backup, and wrap shims
 * [jit export](jit_export.md)	 - Print shell export statements for a profile's secrets
 * [jit git-credential](jit_git-credential.md)	 - Implement git's credential-helper protocol for migrated HTTPS logins
-* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+* [jit grant](jit_grant.md)	 - Pre-approve a program to use profiles unattended
 * [jit guard](jit_guard.md)	 - Prevention hooks that keep credentials from being recorded in the first place
 * [jit k8s-exec-credential](jit_k8s-exec-credential.md)	 - Print a Kubernetes ExecCredential JSON for a migrated profile
 * [jit lock](jit_lock.md)	 - Lock jit's session immediately, without waiting for the TTL

--- a/docs/reference/commands/jit_grant.md
+++ b/docs/reference/commands/jit_grant.md
@@ -1,18 +1,23 @@
 ## jit grant
 
-Pre-approve a running process to use profiles unattended
+Pre-approve a program to use profiles unattended
 
 ### Synopsis
 
-Create a process grant: with one Touch ID now, allow a process that is
-already running (and everything it launches) to use the named profiles'
-secrets without further prompts, until the grant expires - including while
-the screen is locked or you are away.
+Create a process grant: with one Touch ID now, allow a program (and
+everything it launches) to use the named profiles' secrets without further
+prompts, until the grant expires - including while the screen is locked or
+you are away.
 
-The grant is anchored to the live process you name, not to its name: a new
-process called the same thing tomorrow inherits nothing. It covers exactly
-the secrets the named profiles resolve to at creation time, ends at its
-deadline (or when the process exits, or on 'jit grant revoke'), and every
+--process NAME is scoped to the terminal you type it in: every NAME under
+this terminal - running now or started later, in any tab - is covered
+until the deadline. The anchor is the terminal app itself, verified
+through kernel ancestry, so a same-named process elsewhere on the machine
+inherits nothing, and the grant ends early if the terminal app quits.
+--pid grants one exact running process instead, and ends when it exits.
+
+A grant covers exactly the secrets the named profiles resolve to at
+creation time, ends at its deadline (or on 'jit grant revoke'), and every
 serve under it is recorded in 'jit audit'.
 
 Grants live in the service's memory: they survive screen lock by design,
@@ -25,10 +30,11 @@ jit grant --process NAME --profile NAME --for DURATION [flags]
 ### Examples
 
 ```
-  # let the running claude session use the jamf profile for 8 hours
+  # let claude use the jamf profile for 8 hours - current sessions and
+  # any started from this terminal within the window
   jit grant --process claude --profile jamf --for 8h
 
-  # several profiles in one grant, anchored by pid when the name is ambiguous
+  # several profiles, for one exact running process only
   jit grant --pid 4211 --profile jamf --profile aws-ci --for 1d
 
   # see, shorten, or end what is open
@@ -41,8 +47,8 @@ jit grant --process NAME --profile NAME --for DURATION [flags]
 
 ```
       --for string            how long the grant lasts (45m, 8h, 3d - max 7d)
-      --pid int32             running process the grant anchors to, by pid (when --process is ambiguous)
-      --process string        running program the grant anchors to, by name (tab-completes from recent callers)
+      --pid int32             one exact running process to grant instead (ends when it exits)
+      --process string        program to cover, by name: every one under this terminal, running or started later
       --profile stringArray   profile whose secrets the grant covers (repeatable)
 ```
 

--- a/docs/reference/commands/jit_grant_extend.md
+++ b/docs/reference/commands/jit_grant_extend.md
@@ -27,5 +27,5 @@ jit grant extend ID --for DURATION [flags]
 
 ### SEE ALSO
 
-* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+* [jit grant](jit_grant.md)	 - Pre-approve a program to use profiles unattended
 

--- a/docs/reference/commands/jit_grant_list.md
+++ b/docs/reference/commands/jit_grant_list.md
@@ -26,5 +26,5 @@ jit grant list [flags]
 
 ### SEE ALSO
 
-* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+* [jit grant](jit_grant.md)	 - Pre-approve a program to use profiles unattended
 

--- a/docs/reference/commands/jit_grant_revoke.md
+++ b/docs/reference/commands/jit_grant_revoke.md
@@ -20,5 +20,5 @@ jit grant revoke ID
 
 ### SEE ALSO
 
-* [jit grant](jit_grant.md)	 - Pre-approve a running process to use profiles unattended
+* [jit grant](jit_grant.md)	 - Pre-approve a program to use profiles unattended
 

--- a/docs/service/grants.md
+++ b/docs/service/grants.md
@@ -1,6 +1,6 @@
 ---
 title: Process grants
-description: Pre-approve a running tool to use profiles unattended for a bounded time - one Touch ID now, no prompts while you are away, everything on the audit trail.
+description: Pre-approve a tool to use profiles unattended for a bounded time - one Touch ID now, no prompts while you are away, everything on the audit trail.
 ---
 
 # Process grants - approve now, run unattended
@@ -13,9 +13,9 @@ job: the session drops, the next credential read stops on a prompt nobody
 will answer.
 
 A **process grant** moves your decision earlier instead of removing it. While
-you are at the keyboard, one disclosed Touch ID approves that a specific
-**running process** (and everything it launches) may use the secrets of one
-or more profiles until a deadline you set:
+you are at the keyboard, one disclosed Touch ID approves that a program (and
+everything it launches) may use the secrets of one or more profiles until a
+deadline you set:
 
 ```sh
 jit grant --process claude --profile jamf --profile aws-ci --for 8h
@@ -23,20 +23,40 @@ jit grant --process claude --profile jamf --profile aws-ci --for 8h
 
 The prompt says exactly what you are signing:
 
-> jit is trying to **let claude use 3 secrets (jamf, aws-ci) unattended for 8h**.
+> jit is trying to **let claude under iTerm2 use 3 secrets (jamf, aws-ci) unattended for 8h**.
 
-From then until it expires, credential reads from that process tree succeed
-with no prompts - including while the screen is locked. Everything else
-keeps today's behavior: other processes still prompt, other secrets still
-prompt, and the vault's management commands still take a fresh gesture.
+From then until it expires, credential reads from claude sessions in this
+terminal succeed with no prompts - including while the screen is locked,
+and **including sessions you start later inside the window**: a new tab, a
+scheduled script, the next `claude` you launch. Everything else keeps
+today's behavior: other processes still prompt, other secrets still prompt,
+and the vault's management commands still take a fresh gesture.
 
 ## What a grant anchors to
 
-A grant names a process that **exists right now** - resolved to a live pid
-(and its kernel fork-time stamp), never stored as a name pattern. A new
-process that calls itself `claude` tomorrow inherits nothing. If two
-processes share the name, jit lists them and makes you pick with `--pid`;
-it never guesses.
+`--process NAME` is scoped to **the terminal you type it in**. The anchor is
+the terminal app itself (iTerm2, Terminal, a tmux server, an IDE's terminal,
+an SSH connection) - verified through kernel process ancestry, pinned by pid
+and fork time. A credential read is served only when the asking process sits
+under that exact terminal AND its chain passes through a process named NAME.
+Two consequences worth spelling out:
+
+- **Future sessions are covered.** Membership is checked per read against
+  the live process tree, not against a list frozen at creation - so you can
+  grant before the program even starts (the confirmation says "none running
+  yet"), and an automation that fires in ten minutes inside that terminal
+  or tmux just works.
+- **The name alone never decides.** A process elsewhere on the machine that
+  renames itself `claude` inherits nothing: it does not descend from your
+  terminal, and no process can fake its place in the kernel's tree. The
+  boundary is the terminal you physically granted from; the name only
+  narrows what is served inside it. The flip side: a claude under a
+  *different* app (say VS Code's terminal) is a different tree - grant
+  there too if you want it covered.
+
+`--pid` grants one exact running process instead (and dies when it exits);
+its tab completion annotates each candidate with its working directory and
+age so same-named processes are tellable apart.
 
 The covered secrets are resolved from the profiles **at creation time**, by
 the service itself, through the same project-then-global profile lookup
@@ -49,7 +69,8 @@ covers.
 Whichever comes first, and each ending lands in `jit audit`:
 
 - **its deadline** - `--for` takes `45m`, `8h`, `3d`, capped at 7 days;
-- **the process exiting** - the grant dies with the tree it named;
+- **its anchor exiting** - quitting the terminal app ends a `--process`
+  grant; a `--pid` grant dies with the process it named;
 - **`jit grant revoke <id>`** - immediate, and deliberately needs no
   authentication: reducing access is always free, so the kill switch is the
   easiest command in the feature;
@@ -80,7 +101,7 @@ back everything it did. Each stage is a durable
 
 ```
 $ jit audit --kind grant
-time=... kind=grant status=approved reason="let claude use 2 secrets (jamf) unattended for 8h"
+time=... kind=grant status=approved reason="let claude under iTerm2 use 2 secrets (jamf) unattended for 8h"
 time=... kind=grant status=ended grant=g-7f3a2c81 reason="claude's grant expired"
 $ jit audit --kind use
 time=... kind=use op="read a secret via grant" count=2 parent=claude secrets="jamf/api-user, jamf/api-pass"

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -321,14 +321,18 @@ func (c *Client) GrantGlobalForPID(mounts []RunMount, pid int32) error {
 // GrantCreate asks the agent to create a process grant: after one disclosed
 // challenge (agent-worded, like every prompt), pid's process tree may unwrap
 // the named profiles' secrets until now+ttl, unattended, across re-locks.
-// The client sends profile NAMES and its project root only — the agent
-// resolves them to concrete secrets itself, so the prompt and the granted
-// set cannot disagree (see Server.OnResolveGrant). Returns the created
-// grant's status for rendering.
-func (c *Client) GrantCreate(pid int32, profiles []string, projectRoot string, ttl time.Duration) (GrantStatus, error) {
+// With name set the grant is tree-scoped: pid must be the caller's own
+// session root (the agent verifies the ancestry) and name narrows which of
+// its descendants — current and future — are served. The client sends
+// profile NAMES and its project root only — the agent resolves them to
+// concrete secrets itself, so the prompt and the granted set cannot disagree
+// (see Server.OnResolveGrant). Returns the created grant's status for
+// rendering.
+func (c *Client) GrantCreate(pid int32, name string, profiles []string, projectRoot string, ttl time.Duration) (GrantStatus, error) {
 	resp, err := c.call(Request{
 		Op:            OpGrantCreate,
 		TargetPID:     pid,
+		GrantName:     name,
 		GrantProfiles: profiles,
 		ProjectRoot:   projectRoot,
 		TTLSeconds:    int64(ttl / time.Second),

--- a/internal/agent/grant.go
+++ b/internal/agent/grant.go
@@ -37,6 +37,15 @@ import (
 // afterwards only routes to a decision the human already made — the same
 // footing as `jit run --trust`, narrowed from "everything, this session" to
 // "these secrets, until this deadline".
+//
+// A TREE-SCOPED grant (nameFilter set) anchors the same way, one level up:
+// the root is the creating human's own session root (their terminal app or
+// tmux server, agent-verified as the caller's real ancestor), and the filter
+// name narrows which of its descendants are served — including descendants
+// started AFTER creation, which is the shape's whole point ("any claude I
+// start from this terminal in the next hour"). The name is the weak half and
+// is never the gate: it can only shrink what the kernel-verified tree
+// admits, and the prompt names both halves.
 
 // MaxGrantTTL caps a grant's lifetime, creation and extension alike. A week
 // is deliberately generous (a machine left working over a long weekend) while
@@ -76,7 +85,15 @@ type processGrant struct {
 	rootStart int64 // fork-time stamp — the anti-pid-recycling anchor
 	name      string
 	command   string
-	profiles  []string
+	// nameFilter, when set, makes this a tree-scoped grant: rootPID is the
+	// caller's session root (terminal app, tmux server) and only descendants
+	// whose ancestry passes through a process with this display name are
+	// served — including ones started after creation. anchorName is that
+	// root's display name, for status and the prompt. Both empty on an
+	// exact-process grant.
+	nameFilter string
+	anchorName string
+	profiles   []string
 	// deks maps hex(sha256(wrapped bytes)) -> the covered secret. Keyed on
 	// the wrapped bytes themselves so the serve path needs no vault access
 	// at all: the client already sends exactly those bytes on every unwrap.
@@ -105,6 +122,7 @@ func (g *processGrant) status(rootAlive bool) GrantStatus {
 		PID:         g.rootPID,
 		Name:        g.name,
 		Command:     g.command,
+		Anchor:      g.anchorName,
 		Profiles:    append([]string(nil), g.profiles...),
 		Secrets:     g.secretPaths(),
 		CreatedUnix: g.created.Unix(),
@@ -188,6 +206,23 @@ func (s *Server) createGrant(req Request, c *caller) Response {
 		return Response{OK: false, Error: fmt.Sprintf("grant_create: process %d cannot be anchored (already exiting?)", req.TargetPID)}
 	}
 
+	// Tree mode: the anchor must be the CALLER's own ancestor, and never
+	// launchd. A grant may only ever be hung under a session the requesting
+	// human is actually inside — without the ancestry check, any same-user
+	// process could anchor a name-filtered grant under someone else's
+	// terminal tree; without the launchd check, "anchored under pid 1" would
+	// be a machine-wide name grant, the exact shape tree grants exist to
+	// refuse (everything descends from launchd, so the tree would gate
+	// nothing and the name would decide alone).
+	if req.GrantName != "" {
+		if req.TargetPID == 1 {
+			return Response{OK: false, Error: "grant_create: launchd is not a session root - a tree grant anchors under your own terminal"}
+		}
+		if !lineage.AncestryContainsPID(c.pid, req.TargetPID) {
+			return Response{OK: false, Error: fmt.Sprintf("grant_create: pid %d is not an ancestor of the requesting process - a tree grant anchors to your own session root", req.TargetPID)}
+		}
+	}
+
 	// Resolution happens BEFORE the prompt (same ordering as OnCanGrant): an
 	// unresolvable profile fails without burning a Touch ID, and the human
 	// approves the whole named set or none of it.
@@ -199,7 +234,15 @@ func (s *Server) createGrant(req Request, c *caller) Response {
 		return Response{OK: false, Error: "grant_create: the named profiles resolve to no secrets"}
 	}
 
-	reason := grantCreateReason(target.Name(), req.GrantProfiles, len(secrets), ttl)
+	// For a tree grant the covered name is the human's own typed word (they
+	// are describing their intent, not a process describing itself) and the
+	// anchor rendering stays kernel-derived from the verified pid — so every
+	// prompt fact is still either human-typed-about-self or kernel-vouched.
+	who, under := target.Name(), ""
+	if req.GrantName != "" {
+		who, under = req.GrantName, target.Name()
+	}
+	reason := grantCreateReason(who, under, req.GrantProfiles, len(secrets), ttl)
 	event, mek, err := s.discloseChallengeOp(reason, OpGrantCreate, c)
 	if s.OnSessionEvent != nil {
 		s.OnSessionEvent(*event)
@@ -214,15 +257,17 @@ func (s *Server) createGrant(req Request, c *caller) Response {
 		return Response{OK: false, Error: err.Error()}
 	}
 	g := &processGrant{
-		id:        id,
-		rootPID:   req.TargetPID,
-		rootStart: rootStart,
-		name:      target.Name(),
-		command:   target.Command(),
-		profiles:  append([]string(nil), req.GrantProfiles...),
-		deks:      make(map[string]grantSecret, len(secrets)),
-		created:   time.Now(),
-		expires:   time.Now().Add(ttl),
+		id:         id,
+		rootPID:    req.TargetPID,
+		rootStart:  rootStart,
+		name:       who,
+		command:    target.Command(),
+		nameFilter: req.GrantName,
+		anchorName: under,
+		profiles:   append([]string(nil), req.GrantProfiles...),
+		deks:       make(map[string]grantSecret, len(secrets)),
+		created:    time.Now(),
+		expires:    time.Now().Add(ttl),
 	}
 	for _, sec := range secrets {
 		dek, err := open(mek, sec.Wrapped, []byte(sec.Class))
@@ -257,16 +302,30 @@ func (s *Server) createGrant(req Request, c *caller) Response {
 }
 
 // grantCreateReason words the creation prompt. Everything in it is
-// agent-derived or abort-verified: the name comes from the kernel via the
-// target pid, the count and duration ARE the grant's scope, and the profile
-// names were resolved by the agent itself to exactly the secrets being
-// granted (OnResolveGrant), never echoed from free text. The scope statement
-// ("unattended, until ...") is the half that must never be the truncated
-// half, same budget discipline as trustReason.
-func grantCreateReason(name string, profiles []string, count int, ttl time.Duration) string {
-	who := truncate(name, maxTrustWhoLen)
+// agent-derived, human-typed-about-self, or abort-verified: an exact grant's
+// name comes from the kernel via the target pid, a tree grant's name is the
+// creating human's own word with the anchor (under) kernel-derived from the
+// verified session root, the count and duration ARE the grant's scope, and
+// the profile names were resolved by the agent itself to exactly the secrets
+// being granted (OnResolveGrant), never echoed from free text. The scope
+// statement ("unattended, until ...") is the half that must never be the
+// truncated half, same budget discipline as trustReason.
+func grantCreateReason(name, under string, profiles []string, count int, ttl time.Duration) string {
+	// A tree grant's who-clause carries two names ("claude under iTerm2"),
+	// so its budgets shrink: 11 runes per name and 16 for the profiles is
+	// what keeps the whole sentence — including a worst-case "167h59m" TTL —
+	// inside maxReasonLen, checked by TestGrantCreateReasonWording's
+	// worst-case fixture.
+	whoBudget, profBudget := maxTrustWhoLen, 20
+	if under != "" {
+		whoBudget, profBudget = 11, 16
+	}
+	who := truncate(name, whoBudget)
 	if who == "" {
 		who = "this process"
+	}
+	if under != "" {
+		who += " under " + truncate(under, whoBudget)
 	}
 	noun := "secrets"
 	if count == 1 {
@@ -278,7 +337,7 @@ func grantCreateReason(name string, profiles []string, count int, ttl time.Durat
 	// never be the half a long tool name pushes off the prompt. The outer
 	// truncate is a belt only.
 	return truncate(fmt.Sprintf("let %s use %d %s (%s) unattended for %s",
-		who, count, noun, truncate(strings.Join(profiles, ", "), 20), formatGrantTTL(ttl)), maxReasonLen)
+		who, count, noun, truncate(strings.Join(profiles, ", "), profBudget), formatGrantTTL(ttl)), maxReasonLen)
 }
 
 // formatGrantTTL renders a duration the way a human typed it: "8h", "45m",
@@ -321,14 +380,15 @@ func (s *Server) grantUnwrap(c *caller, wrapped []byte) (dek []byte, path string
 	// descent OUTSIDE grantMu — AncestryContainsPID walks sysctls, and list/
 	// revoke must not queue behind it (trustRoots' exact discipline).
 	type candidate struct {
-		id        string
-		rootPID   int32
-		rootStart int64
+		id         string
+		rootPID    int32
+		rootStart  int64
+		nameFilter string
 	}
 	var cands []candidate
 	for _, g := range s.grants {
 		if _, covered := g.deks[digest]; covered {
-			cands = append(cands, candidate{id: g.id, rootPID: g.rootPID, rootStart: g.rootStart})
+			cands = append(cands, candidate{id: g.id, rootPID: g.rootPID, rootStart: g.rootStart, nameFilter: g.nameFilter})
 		}
 	}
 	s.grantMu.Unlock()
@@ -343,7 +403,14 @@ func (s *Server) grantUnwrap(c *caller, wrapped []byte) (dek []byte, path string
 			s.endGrant(cand.id, grantEndExited)
 			continue
 		}
-		if !lineage.AncestryContainsPID(c.pid, cand.rootPID) {
+		// Tree grants add the name condition to the same fail-closed walk:
+		// the caller's chain must pass through the filter name at or below
+		// the root it then reaches. Exact grants keep the bare descent test.
+		if cand.nameFilter != "" {
+			if !lineage.AncestryNamedWithin(c.pid, cand.rootPID, cand.nameFilter) {
+				continue
+			}
+		} else if !lineage.AncestryContainsPID(c.pid, cand.rootPID) {
 			continue
 		}
 		s.grantMu.Lock()
@@ -424,11 +491,11 @@ func (s *Server) extendGrant(req Request, c *caller) Response {
 	}
 	s.grantMu.Lock()
 	g := s.grants[req.GrantID]
-	var name string
+	var name, under string
 	var count int
 	var profiles []string
 	if g != nil {
-		name, count, profiles = g.name, len(g.deks), g.profiles
+		name, under, count, profiles = g.name, g.anchorName, len(g.deks), g.profiles
 	}
 	s.grantMu.Unlock()
 	if g == nil {
@@ -437,7 +504,7 @@ func (s *Server) extendGrant(req Request, c *caller) Response {
 
 	// grantCreateReason already words the full scope; re-lead it as an
 	// extension so the prompt says what is actually happening.
-	reason := truncate("extend: "+grantCreateReason(name, profiles, count, ttl), maxReasonLen)
+	reason := truncate("extend: "+grantCreateReason(name, under, profiles, count, ttl), maxReasonLen)
 	event, mek, err := s.discloseChallengeOp(reason, OpGrantExtend, c)
 	if s.OnSessionEvent != nil {
 		s.OnSessionEvent(*event)

--- a/internal/agent/grant_test.go
+++ b/internal/agent/grant_test.go
@@ -15,6 +15,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/jitpass/jit/internal/lineage"
 )
 
 // grantTestMEK matches fakeFetcher's key so tests can pre-seal wrapped DEKs
@@ -51,7 +53,7 @@ func TestGrantServesAcrossLockWithoutPrompting(t *testing.T) {
 	wireGrantResolver(s, sec)
 
 	c := NewClient(socketPath)
-	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
 	if err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}
@@ -100,6 +102,107 @@ func TestGrantServesAcrossLockWithoutPrompting(t *testing.T) {
 	}
 }
 
+// TestTreeGrantServesByNameUnderAnchor pins the tree-scoped shape: a grant
+// anchored at the caller's parent with the caller's own name as the filter
+// must serve — the caller here stands in for "a claude started at any point
+// inside the window", since creation records no pid set to check against.
+func TestTreeGrantServesByNameUnderAnchor(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	ownName := ""
+	if p, ok := lineage.Describe(int32(os.Getpid())); ok { // #nosec G115 -- test pid
+		ownName = p.Name()
+	}
+	if ownName == "" {
+		t.Fatal("Describe(self) yields no name")
+	}
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getppid()), ownName, []string{"jamf"}, "", time.Hour) // #nosec G115 -- test ppid
+	if err != nil {
+		t.Fatalf("GrantCreate (tree): %v", err)
+	}
+	if st.Anchor == "" {
+		t.Error("tree grant reports no Anchor; the list cannot say what it hangs under")
+	}
+	if st.Name != ownName {
+		t.Errorf("tree grant Name = %q, want the filter %q", st.Name, ownName)
+	}
+
+	got, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp")
+	if err != nil {
+		t.Fatalf("UnwrapKeyLabeled under tree grant: %v", err)
+	}
+	if !bytes.Equal(got, dek) {
+		t.Errorf("tree grant served %x, want %x", got, dek)
+	}
+	if gotCalls := atomic.LoadInt32(&calls); gotCalls != 1 {
+		t.Errorf("tree-grant serve challenged the human (%d fetches, want 1)", gotCalls)
+	}
+}
+
+// TestTreeGrantNameMissFallsThrough: same anchor, a name the caller's chain
+// does not carry — the grant must not serve, and the request rides the
+// ordinary challenge path instead.
+func TestTreeGrantNameMissFallsThrough(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	dek := bytes.Repeat([]byte{0x07}, 32)
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", dek)
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	if _, err := c.GrantCreate(int32(os.Getppid()), "sleep", []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test ppid
+		t.Fatalf("GrantCreate (tree, granting ahead of any sleep): %v", err)
+	}
+	if _, err := c.UnwrapKeyLabeled(sec.Wrapped, "jamf/api-pass", "mcp"); err != nil {
+		t.Fatalf("UnwrapKeyLabeled: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("caller not named sleep was served by the tree grant (%d fetches, want 2)", got)
+	}
+}
+
+// TestTreeGrantAnchorMustBeCallersOwnAncestor: anchoring under a pid the
+// creator does not descend from must fail before any prompt, and launchd is
+// never a session root.
+func TestTreeGrantAnchorMustBeCallersOwnAncestor(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x07}, 32))
+	wireGrantResolver(s, sec)
+
+	// A child is inside OUR tree, but we are not inside ITS tree.
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting child: %v", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+	}()
+
+	c := NewClient(socketPath)
+	if _, err := c.GrantCreate(int32(child.Process.Pid), "sleep", []string{"jamf"}, "", time.Hour); err == nil || !strings.Contains(err.Error(), "ancestor") { // #nosec G115 -- test pid
+		t.Errorf("tree grant anchored under a non-ancestor = %v, want an ancestry refusal", err)
+	}
+	if _, err := c.GrantCreate(1, "sleep", []string{"jamf"}, "", time.Hour); err == nil || !strings.Contains(err.Error(), "launchd") {
+		t.Errorf("tree grant anchored under launchd = %v, want a launchd refusal", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 0 {
+		t.Errorf("refused tree grants reached the prompt %d times, want 0", got)
+	}
+}
+
 func TestGrantMissFallsThroughToOrdinaryUnlock(t *testing.T) {
 	var calls int32
 	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
@@ -110,7 +213,7 @@ func TestGrantMissFallsThroughToOrdinaryUnlock(t *testing.T) {
 	wireGrantResolver(s, covered)
 
 	c := NewClient(socketPath)
-	if _, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
+	if _, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
 		t.Fatalf("GrantCreate: %v", err)
 	}
 
@@ -150,7 +253,7 @@ func TestGrantDoesNotServeAForeignProcessTree(t *testing.T) {
 	}()
 
 	c := NewClient(socketPath)
-	if _, err := c.GrantCreate(int32(child.Process.Pid), []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
+	if _, err := c.GrantCreate(int32(child.Process.Pid), "", []string{"jamf"}, "", time.Hour); err != nil { // #nosec G115 -- test pid
 		t.Fatalf("GrantCreate: %v", err)
 	}
 
@@ -187,7 +290,7 @@ func TestGrantEndsWhenRootExits(t *testing.T) {
 	pid := int32(child.Process.Pid) // #nosec G115 -- test pid
 
 	c := NewClient(socketPath)
-	if _, err := c.GrantCreate(pid, []string{"jamf"}, "", time.Hour); err != nil {
+	if _, err := c.GrantCreate(pid, "", []string{"jamf"}, "", time.Hour); err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}
 	_ = child.Process.Kill()
@@ -213,7 +316,7 @@ func TestGrantExpiryEndsTheGrant(t *testing.T) {
 	wireGrantResolver(s, sec)
 
 	c := NewClient(socketPath)
-	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
 	if err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}
@@ -250,7 +353,7 @@ func TestGrantRevokeIsImmediateAndUnauthenticated(t *testing.T) {
 	wireGrantResolver(s, sec)
 
 	c := NewClient(socketPath)
-	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
 	if err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}
@@ -282,7 +385,7 @@ func TestGrantExtendReprompts(t *testing.T) {
 	wireGrantResolver(s, sec)
 
 	c := NewClient(socketPath)
-	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
 	if err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}
@@ -313,7 +416,7 @@ func TestGrantCreateFailsClosedOnClassMismatch(t *testing.T) {
 	wireGrantResolver(s, good, GrantSecret{Path: "aws/key", Wrapped: wrapped, Class: "docker"})
 
 	c := NewClient(socketPath)
-	_, err = c.GrantCreate(int32(os.Getpid()), []string{"jamf", "aws"}, "", time.Hour) // #nosec G115 -- test pid
+	_, err = c.GrantCreate(int32(os.Getpid()), "", []string{"jamf", "aws"}, "", time.Hour) // #nosec G115 -- test pid
 	if err == nil || !strings.Contains(err.Error(), "no grant created") {
 		t.Fatalf("GrantCreate with a lying class = %v, want a no-grant-created failure", err)
 	}
@@ -356,15 +459,21 @@ func TestGrantCreateValidatesBeforePrompting(t *testing.T) {
 }
 
 func TestGrantCreateReasonWording(t *testing.T) {
-	got := grantCreateReason("claude", []string{"jamf", "aws-ci"}, 3, 8*time.Hour)
+	got := grantCreateReason("claude", "", []string{"jamf", "aws-ci"}, 3, 8*time.Hour)
 	want := "let claude use 3 secrets (jamf, aws-ci) unattended for 8h"
 	if got != want {
 		t.Errorf("grantCreateReason = %q, want %q", got, want)
 	}
-	if r := grantCreateReason("", []string{"p"}, 1, time.Minute); !strings.Contains(r, "this process") {
+	// The tree-scoped shape must name both halves of the perimeter: the
+	// filter name AND the anchor the human is hanging it under.
+	tree := grantCreateReason("claude", "iTerm2", []string{"jamf"}, 1, time.Hour)
+	if want := "let claude under iTerm2 use 1 secret (jamf) unattended for 1h"; tree != want {
+		t.Errorf("tree grantCreateReason = %q, want %q", tree, want)
+	}
+	if r := grantCreateReason("", "", []string{"p"}, 1, time.Minute); !strings.Contains(r, "this process") {
 		t.Errorf("nameless reason = %q, want a 'this process' fallback", r)
 	}
-	long := grantCreateReason(strings.Repeat("x", 100), []string{strings.Repeat("y", 100)}, 12, 3*24*time.Hour)
+	long := grantCreateReason(strings.Repeat("x", 100), strings.Repeat("z", 100), []string{strings.Repeat("y", 100)}, 12, 3*24*time.Hour)
 	if len([]rune(long)) > maxReasonLen {
 		t.Errorf("reason is %d runes, must fit the %d-rune prompt budget", len([]rune(long)), maxReasonLen)
 	}
@@ -414,7 +523,7 @@ func TestGrantEventsReachTheDurableSink(t *testing.T) {
 	wireGrantResolver(s, sec)
 
 	c := NewClient(socketPath)
-	st, err := c.GrantCreate(int32(os.Getpid()), []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
 	if err != nil {
 		t.Fatalf("GrantCreate: %v", err)
 	}

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -80,6 +80,17 @@ type Request struct {
 	// should shadow the global ones during that resolution — the caller's cwd,
 	// exactly the layering `jit run` applies. Empty means global-only.
 	ProjectRoot string `json:"project_root,omitempty"`
+	// GrantName ("grant_create") switches the grant from exact-process to
+	// tree-scoped: TargetPID is then the SESSION ROOT to anchor under (the
+	// caller's own terminal app or tmux server — the agent verifies it is
+	// genuinely the caller's ancestor), and the grant serves any process at
+	// or below that root whose ancestry passes through a process with this
+	// display name — including ones started after creation, which is the
+	// point. The name is the human's own typed word about their intent and
+	// only ever NARROWS the kernel-verified tree (lineage.AncestryNamedWithin);
+	// it never widens anything, so the "identity never decides" doctrine
+	// holds. Empty means the exact-process grant TargetPID has always meant.
+	GrantName string `json:"grant_name,omitempty"`
 	// GrantID ("grant_revoke"/"grant_extend") names the grant to act on.
 	GrantID string `json:"grant_id,omitempty"`
 	// TTLSeconds ("grant_create"/"grant_extend") is the requested lifetime.
@@ -130,7 +141,9 @@ const (
 	// challenge, TargetPID's process tree may unwrap the covered profiles'
 	// secrets until the grant expires — without further prompts, and across
 	// re-locks (the one authorization state that deliberately survives them;
-	// see Server's grant fields). OpGrantExtend re-prompts for more time on an
+	// see Server's grant fields). With GrantName set the tree is the caller's
+	// own session root and the name narrows it — the shape that also covers
+	// processes started after creation. OpGrantExtend re-prompts for more time on an
 	// existing grant; OpGrantRevoke ends one with no prompt at all (reducing
 	// access is always free); OpGrantList reads the current set, prompt-free
 	// for the same reason OpHistory is.
@@ -328,10 +341,16 @@ type Response struct {
 type GrantStatus struct {
 	ID  string `json:"id"`
 	PID int32  `json:"pid"`
-	// Name is the root process's display name ("claude"); Command its full
-	// invocation for a wide terminal.
+	// Name is what the grant covers: the root process's display name for an
+	// exact-process grant ("claude"), or the name filter for a tree-scoped
+	// one (also "claude" — the list reads the same either way). Command is
+	// the root's full invocation for a wide terminal.
 	Name    string `json:"name,omitempty"`
 	Command string `json:"command,omitempty"`
+	// Anchor is set on tree-scoped grants only: the display name of the
+	// session root the grant is anchored under ("iTerm2", "tmux_server"),
+	// whose pid is PID. Empty means an exact-process grant.
+	Anchor string `json:"anchor,omitempty"`
 	// Profiles are the profile names the grant was created from; Secrets the
 	// concrete vault paths it actually covers (resolved at creation — a later
 	// profile edit never widens a standing grant).

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -660,16 +660,27 @@ func grantAgo(d time.Duration) string {
 // completeGrantCreateEntry rides the parent command's positional completion:
 // cobra offers the subcommands (list/revoke/extend) on its own, and without
 // this the CREATE form - the whole point of the command - was invisible at
-// exactly the moment a user double-tabs to discover it. Offering the
-// --process flag as a candidate plus an active-help line puts the create
-// shape on the same screen as the subcommands.
+// exactly the moment a user double-tabs to discover it. It offers the FIRST
+// flag the create form still lacks, in the order the usage line reads
+// (--process, --profile, --for): cobra has already parsed the typed flags
+// into the bound vars by the time this runs, so a tab after `--process bash`
+// walks forward to --profile instead of re-offering what is on the line.
 func completeGrantCreateEntry(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	comps := []string{"--process\tcreate: grant a program by name, future sessions included (then --profile, --for)"}
-	comps = cobra.AppendActiveHelp(comps, "create a grant: "+grantCreateUsage)
-	return comps, cobra.ShellCompDirectiveNoFileComp
+	switch {
+	case grantProcess == "" && grantPIDFlag == 0:
+		comps := []string{"--process\tcreate: grant a program by name, future sessions included (then --profile, --for)"}
+		comps = cobra.AppendActiveHelp(comps, "create a grant: "+grantCreateUsage)
+		return comps, cobra.ShellCompDirectiveNoFileComp
+	case len(grantProfileNames) == 0:
+		return []string{"--profile\tprofile whose secrets the grant covers (repeatable)"}, cobra.ShellCompDirectiveNoFileComp
+	case grantFor == "":
+		return []string{"--for\thow long the grant lasts (45m, 8h, 3d - max 7d)"}, cobra.ShellCompDirectiveNoFileComp
+	default:
+		return cobra.AppendActiveHelp(nil, "all set - press enter to create the grant"), cobra.ShellCompDirectiveNoFileComp
+	}
 }
 
 // completeGrantFor offers --for values: common picks up to the 7d cap, with

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -510,7 +510,11 @@ func resolveGrantSecrets(root string) func(profiles []string, projectRoot string
 				seen[secretPath] = true
 				wrapped, class, err := v.WrappedDEK(secretPath)
 				if err != nil {
-					return nil, fmt.Errorf("profile %s: %w", name, err)
+					// Name the entry, not just the profile: "profile x: secret
+					// not found" leaves the user diffing fourteen manifest
+					// lines against `jit vault list` by hand (a real dead end,
+					// hit on the first live tree-grant create).
+					return nil, fmt.Errorf("profile %s: %s: %w (the profile names it, the vault does not have it - `jit vault list` shows what is stored)", name, secretPath, err)
 				}
 				out = append(out, agent.GrantSecret{Path: secretPath, Wrapped: wrapped, Class: class})
 			}

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -199,6 +199,16 @@ func runGrantCreate(out io.Writer) error {
 	if err != nil {
 		return notRunningHint(err)
 	}
+	// A service older than tree grants ignores the unknown grant_name field
+	// and mints an EXACT grant anchored at the terminal — every process under
+	// it, no name filter: strictly wider than what the human just approved.
+	// The reply betrays it (no Anchor on a tree request), and reducing access
+	// is free, so revoke before reporting anything. The window is real but
+	// short: the service swaps itself onto a replaced binary within seconds.
+	if target.name != "" && st.Anchor == "" {
+		_ = ac.GrantRevoke(st.ID)
+		return fmt.Errorf("the running service predates tree grants and granted the whole terminal instead; revoked it - run `jit service restart` and retry")
+	}
 	printGrantCreated(out, st)
 	return nil
 }

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -25,12 +25,15 @@ import (
 )
 
 // jit grant — process grants (design/process-grants.md): pre-approve a
-// RUNNING process tree to use one or more profiles' secrets unattended, for
-// a bounded time, with one Touch ID given while you are still at the
-// keyboard. The bare command creates; list/revoke/extend manage what exists.
-// All state lives in the service's memory — the CLI here is a thin client
-// over the grant_* RPCs, plus the name-to-pid resolution and completion
-// that need a terminal-side view.
+// process tree to use one or more profiles' secrets unattended, for a
+// bounded time, with one Touch ID given while you are still at the
+// keyboard. --process NAME is tree-scoped: anchored to the terminal it is
+// typed in, covering every NAME under it, running now or started later
+// within the window. --pid is the exact-one-running-process mode. The bare
+// command creates; list/revoke/extend manage what exists. All state lives
+// in the service's memory — the CLI here is a thin client over the grant_*
+// RPCs, plus the anchor resolution and completion that need a terminal-side
+// view.
 
 var (
 	grantProcess      string
@@ -44,24 +47,30 @@ var (
 var grantCmd = &cobra.Command{
 	Use:     "grant --process NAME --profile NAME --for DURATION",
 	GroupID: groupSecrets,
-	Short:   "Pre-approve a running process to use profiles unattended",
-	Long: `Create a process grant: with one Touch ID now, allow a process that is
-already running (and everything it launches) to use the named profiles'
-secrets without further prompts, until the grant expires - including while
-the screen is locked or you are away.
+	Short:   "Pre-approve a program to use profiles unattended",
+	Long: `Create a process grant: with one Touch ID now, allow a program (and
+everything it launches) to use the named profiles' secrets without further
+prompts, until the grant expires - including while the screen is locked or
+you are away.
 
-The grant is anchored to the live process you name, not to its name: a new
-process called the same thing tomorrow inherits nothing. It covers exactly
-the secrets the named profiles resolve to at creation time, ends at its
-deadline (or when the process exits, or on 'jit grant revoke'), and every
+--process NAME is scoped to the terminal you type it in: every NAME under
+this terminal - running now or started later, in any tab - is covered
+until the deadline. The anchor is the terminal app itself, verified
+through kernel ancestry, so a same-named process elsewhere on the machine
+inherits nothing, and the grant ends early if the terminal app quits.
+--pid grants one exact running process instead, and ends when it exits.
+
+A grant covers exactly the secrets the named profiles resolve to at
+creation time, ends at its deadline (or on 'jit grant revoke'), and every
 serve under it is recorded in 'jit audit'.
 
 Grants live in the service's memory: they survive screen lock by design,
 and do not survive a service restart or reboot.`,
-	Example: `  # let the running claude session use the jamf profile for 8 hours
+	Example: `  # let claude use the jamf profile for 8 hours - current sessions and
+  # any started from this terminal within the window
   jit grant --process claude --profile jamf --for 8h
 
-  # several profiles in one grant, anchored by pid when the name is ambiguous
+  # several profiles, for one exact running process only
   jit grant --pid 4211 --profile jamf --profile aws-ci --for 1d
 
   # see, shorten, or end what is open
@@ -186,7 +195,7 @@ func runGrantCreate(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	st, err := ac.GrantCreate(target.PID, grantProfileNames, cwd, ttl)
+	st, err := ac.GrantCreate(target.anchor.PID, target.name, grantProfileNames, cwd, ttl)
 	if err != nil {
 		return notRunningHint(err)
 	}
@@ -194,37 +203,39 @@ func runGrantCreate(out io.Writer) error {
 	return nil
 }
 
-// resolveGrantTarget turns --process/--pid into the live process the grant
-// anchors to. A name that matches several running processes is an error that
-// lists them — the human picks with --pid; jit never guesses which claude
-// they meant.
-func resolveGrantTarget() (lineage.Process, error) {
+// grantTarget is what a create resolves --process/--pid into: the process
+// the grant anchors to, plus (tree mode only) the name that narrows its
+// descendants. An empty name is the exact-one-process grant --pid means.
+type grantTarget struct {
+	anchor lineage.Process
+	name   string
+}
+
+// resolveGrantTarget turns --process/--pid into the grant's anchor.
+// --process needs no live match and no disambiguation: it anchors to THIS
+// terminal's session root and covers the name inside it — the sessions
+// running now and the ones started later within the window, which is why a
+// name that matches nothing yet is fine, not an error. --pid keeps the
+// exact-process shape for the times one specific tree is the point.
+func resolveGrantTarget() (grantTarget, error) {
 	if grantPIDFlag != 0 && grantProcess != "" {
-		return lineage.Process{}, fmt.Errorf("give --process or --pid, not both")
+		return grantTarget{}, fmt.Errorf("give --process or --pid, not both")
 	}
 	if grantPIDFlag != 0 {
 		p, ok := lineage.Describe(grantPIDFlag)
 		if !ok {
-			return lineage.Process{}, fmt.Errorf("no process with pid %d (it may have exited)", grantPIDFlag)
+			return grantTarget{}, fmt.Errorf("no process with pid %d (it may have exited)", grantPIDFlag)
 		}
-		return p, nil
+		return grantTarget{anchor: p}, nil
 	}
 	if grantProcess == "" {
-		return lineage.Process{}, fmt.Errorf("--process is required (the running program to grant to; tab-completes from recent callers)")
+		return grantTarget{}, fmt.Errorf("--process is required (the program to grant to; tab-completes from recent callers)")
 	}
-	procs := lineage.ProcessesNamed(grantProcess)
-	switch len(procs) {
-	case 0:
-		return lineage.Process{}, fmt.Errorf("nothing named %q is running - a grant anchors to a live process, start it first", grantProcess)
-	case 1:
-		return procs[0], nil
+	root, ok := lineage.SessionRoot(int32(os.Getpid())) // #nosec G115 -- darwin pids fit int32
+	if !ok {
+		return grantTarget{}, fmt.Errorf("no terminal tree to anchor %q to - run this from your terminal, or anchor one exact process with `--pid`", grantProcess)
 	}
-	lines := make([]string, 0, len(procs))
-	for _, p := range procs {
-		lines = append(lines, fmt.Sprintf("  --pid %-6d %s", p.PID, truncateEnd(p.Command(), 60)))
-	}
-	return lineage.Process{}, fmt.Errorf("%d processes are named %q, pick one with --pid:\n%s",
-		len(procs), grantProcess, strings.Join(lines, "\n"))
+	return grantTarget{anchor: root, name: grantProcess}, nil
 }
 
 func printGrantCreated(out io.Writer, st agent.GrantStatus) {
@@ -233,7 +244,27 @@ func printGrantCreated(out io.Writer, st agent.GrantStatus) {
 		st.Name, glyphAction, strings.Join(st.Profiles, ", "), grantClock(st.ExpiresUnix))
 	fmt.Fprintf(out, "  %s %s: %s\n", glyphBranch,
 		countWord(len(st.Secrets), "secret", "secrets"), truncateEnd(strings.Join(st.Secrets, ", "), 58))
+	if st.Anchor != "" {
+		fmt.Fprintf(out, "  %s covers %s under %s: %s, any started before %s\n", glyphBranch,
+			st.Name, st.Anchor, grantRunningNow(st.Name, st.PID), grantClock(st.ExpiresUnix))
+	}
 	fmt.Fprintf(out, "  %s end it early: %s\n", glyphBranch, cPath.Sprint("jit grant revoke "+st.ID))
+}
+
+// grantRunningNow phrases how many processes a fresh tree grant covers at
+// this moment — the reassurance half ("2 running now") or the granting-ahead
+// half ("none running yet"), both of which the human should see stated.
+func grantRunningNow(name string, anchorPID int32) string {
+	n := 0
+	for _, p := range lineage.ProcessesNamed(name) {
+		if lineage.AncestryContainsPID(p.PID, anchorPID) {
+			n++
+		}
+	}
+	if n == 0 {
+		return "none running yet"
+	}
+	return fmt.Sprintf("%d running now", n)
 }
 
 func runGrantList(out io.Writer) error {
@@ -284,6 +315,9 @@ func renderGrantRows(out io.Writer, grants []agent.GrantStatus) {
 		if !g.RootAlive {
 			glyph, ink = glyphRisk, cRisk
 			state = "process exited, ending"
+			if g.Anchor != "" {
+				state = "terminal closed, ending"
+			}
 		}
 		serves := "unused"
 		if g.Serves > 0 {
@@ -520,7 +554,7 @@ func completeGrantProcessNames(cmd *cobra.Command, args []string, toComplete str
 		// because it only shows up on a machine that has not used jit yet —
 		// exactly the machine that needs telling.
 		return cobra.AppendActiveHelp(nil,
-				"no recent callers recorded - name any running program, or use --pid"),
+				"no recent callers recorded - type any program name (it need not be running yet)"),
 			cobra.ShellCompDirectiveNoFileComp
 	}
 
@@ -549,10 +583,10 @@ func completeGrantProcessNames(cmd *cobra.Command, args []string, toComplete str
 	return out, cobra.ShellCompDirectiveNoFileComp
 }
 
-// completeGrantPIDs offers the visible processes for --pid, the flag that
-// exists precisely because --process was ambiguous — so answering it with
-// filenames left the disambiguation with no way to see the two candidates it
-// is meant to choose between. Same process table --process annotates from.
+// completeGrantPIDs offers the visible processes for --pid, the
+// exact-one-process mode — so answering it with filenames left the pick with
+// no way to see the candidates it is meant to choose between. Same process
+// table --process annotates from.
 func completeGrantPIDs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	// Never the whole process table: a bare list of every visible pid runs to
 	// several hundred rows of system daemons, which is a worse answer than the
@@ -575,15 +609,38 @@ func completeGrantPIDs(cmd *cobra.Command, args []string, toComplete string) ([]
 		if !strings.HasPrefix(pid, toComplete) {
 			continue
 		}
-		out = append(out, pid+"\t"+name)
+		out = append(out, pid+"\t"+name+grantPIDDetail(p.PID))
 	}
 	if len(out) == 0 {
 		if grantProcess != "" {
 			return cobra.AppendActiveHelp(nil, "nothing named "+grantProcess+" is running"), cobra.ShellCompDirectiveNoFileComp
 		}
-		return cobra.AppendActiveHelp(nil, "name --process first, and --pid narrows it to one of its pids"), cobra.ShellCompDirectiveNoFileComp
+		return cobra.AppendActiveHelp(nil, "--pid grants one exact running process (--process covers a name under this terminal)"), cobra.ShellCompDirectiveNoFileComp
 	}
 	return out, cobra.ShellCompDirectiveNoFileComp
+}
+
+// grantPIDDetail annotates one --pid candidate with what tells identical
+// names apart: the directory the process runs in (seven rows saying only
+// "claude" were a real report — the cwd is which PROJECT each one is) and
+// how long it has lived, newest usually being the one meant. Display only,
+// like everything lineage answers.
+func grantPIDDetail(pid int32) string {
+	detail := ""
+	if cwd := lineage.ProcessCWD(pid); cwd != "" {
+		if home, err := os.UserHomeDir(); err == nil && home != "" {
+			if cwd == home {
+				cwd = "~"
+			} else if strings.HasPrefix(cwd, home+"/") {
+				cwd = "~" + cwd[len(home):]
+			}
+		}
+		detail += " · in " + cwd
+	}
+	if start, ok := lineage.ProcessStartTime(pid); ok {
+		detail += " · started " + grantAgo(time.Since(time.UnixMicro(start))) + " ago"
+	}
+	return detail
 }
 
 // grantAgo renders an age in one coarse unit for a completion description.
@@ -593,8 +650,10 @@ func grantAgo(d time.Duration) string {
 		return "moments"
 	case d < time.Hour:
 		return fmt.Sprintf("%dm", d/time.Minute)
-	default:
+	case d < 48*time.Hour:
 		return fmt.Sprintf("%dh", d/time.Hour)
+	default:
+		return fmt.Sprintf("%dd", d/(24*time.Hour))
 	}
 }
 
@@ -608,7 +667,7 @@ func completeGrantCreateEntry(cmd *cobra.Command, args []string, toComplete stri
 	if len(args) > 0 {
 		return nil, cobra.ShellCompDirectiveNoFileComp
 	}
-	comps := []string{"--process\tcreate: grant a running program (then --profile, --for)"}
+	comps := []string{"--process\tcreate: grant a program by name, future sessions included (then --profile, --for)"}
 	comps = cobra.AppendActiveHelp(comps, "create a grant: "+grantCreateUsage)
 	return comps, cobra.ShellCompDirectiveNoFileComp
 }
@@ -656,8 +715,8 @@ func completeGrantIDs(cmd *cobra.Command, args []string, toComplete string) ([]s
 }
 
 func init() {
-	grantCmd.Flags().StringVar(&grantProcess, "process", "", "running program the grant anchors to, by name (tab-completes from recent callers)")
-	grantCmd.Flags().Int32Var(&grantPIDFlag, "pid", 0, "running process the grant anchors to, by pid (when --process is ambiguous)")
+	grantCmd.Flags().StringVar(&grantProcess, "process", "", "program to cover, by name: every one under this terminal, running or started later")
+	grantCmd.Flags().Int32Var(&grantPIDFlag, "pid", 0, "one exact running process to grant instead (ends when it exits)")
 	grantCmd.Flags().StringArrayVar(&grantProfileNames, "profile", nil, "profile whose secrets the grant covers (repeatable)")
 	grantCmd.Flags().StringVar(&grantFor, "for", "", "how long the grant lasts (45m, 8h, 3d - max 7d)")
 	_ = grantCmd.RegisterFlagCompletionFunc("process", completeGrantProcessNames)

--- a/internal/cli/grant_test.go
+++ b/internal/cli/grant_test.go
@@ -250,6 +250,44 @@ func TestGrantCompletionSurfacesCreatePath(t *testing.T) {
 	}
 }
 
+// Once a create flag is on the line, tabbing again must offer the NEXT flag
+// the create form needs, never re-offer one already given - a real user
+// report: `jit grant --process bash <Tab>` suggested --process again.
+func TestGrantCompletionWalksTheCreateFlagsInOrder(t *testing.T) {
+	defer func() { grantProcess = ""; grantPIDFlag = 0; grantProfileNames = nil; grantFor = "" }()
+
+	grantProcess = "bash"
+	comps, _ := completeGrantCreateEntry(nil, nil, "")
+	joined := strings.Join(comps, "\n")
+	if strings.Contains(joined, "--process") {
+		t.Errorf("--process already typed but offered again:\n%s", joined)
+	}
+	if !strings.Contains(joined, "--profile\t") {
+		t.Errorf("after --process the next offer must be --profile:\n%s", joined)
+	}
+
+	grantProfileNames = []string{"jamf"}
+	comps, _ = completeGrantCreateEntry(nil, nil, "")
+	joined = strings.Join(comps, "\n")
+	if !strings.Contains(joined, "--for\t") {
+		t.Errorf("after --process and --profile the next offer must be --for:\n%s", joined)
+	}
+
+	grantFor = "8h"
+	comps, _ = completeGrantCreateEntry(nil, nil, "")
+	joined = strings.Join(comps, "\n")
+	if strings.Contains(joined, "--") {
+		t.Errorf("complete create line must offer no more flags:\n%s", joined)
+	}
+
+	grantProcess, grantPIDFlag = "", 4242
+	comps, _ = completeGrantCreateEntry(nil, nil, "")
+	joined = strings.Join(comps, "\n")
+	if strings.Contains(joined, "--process") {
+		t.Errorf("--pid anchors the grant too, must not push --process:\n%s", joined)
+	}
+}
+
 func TestGrantForCompletionSaysFreeForm(t *testing.T) {
 	comps, _ := completeGrantFor(nil, nil, "")
 	joined := strings.Join(comps, "\n")

--- a/internal/cli/grant_test.go
+++ b/internal/cli/grant_test.go
@@ -171,16 +171,64 @@ func TestGrantListRendering(t *testing.T) {
 			ExpiresUnix: time.Now().Add(6 * time.Hour).Unix(), Serves: 4, RootAlive: true},
 		{ID: "g-2c91aa00", Name: "terraform", Profiles: []string{"aws-ci"}, Secrets: []string{"c"},
 			ExpiresUnix: time.Now().Add(24 * time.Hour).Unix(), RootAlive: false},
+		{ID: "g-55e01b2d", Name: "claude", Anchor: "iTerm2", Profiles: []string{"jamf"}, Secrets: []string{"a"},
+			ExpiresUnix: time.Now().Add(time.Hour).Unix(), RootAlive: false},
 	}
 	renderGrantRows(&b, grants)
 	out := b.String()
-	for _, want := range []string{"[Grants] 2", "g-7f3a2c81", "4 serves", "process exited, ending", "unused"} {
+	// The dead-anchor wording depends on the grant's shape: an exact grant's
+	// root is the process itself ("process exited"), a tree grant's is the
+	// terminal it hangs under ("terminal closed").
+	for _, want := range []string{"[Grants] 3", "g-7f3a2c81", "4 serves", "process exited, ending", "terminal closed, ending", "unused"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("grant list output missing %q:\n%s", want, out)
 		}
 	}
 	if strings.Contains(out, "\t") {
 		t.Error("grant list uses tabs; columns are whitespace-padded in the house style")
+	}
+}
+
+// TestResolveGrantTargetTreeMode: --process anchors to this session's root
+// with the name as the filter — no live match required, no disambiguation —
+// while --pid stays the exact-one-process mode.
+func TestResolveGrantTargetTreeMode(t *testing.T) {
+	grantPIDFlag, grantProcess = 0, "claude"
+	defer func() { grantProcess = "" }()
+	target, err := resolveGrantTarget()
+	if err != nil {
+		t.Skipf("no session root above this test process (bare runner): %v", err)
+	}
+	if target.name != "claude" {
+		t.Errorf("tree target name = %q, want claude", target.name)
+	}
+	self := int32(os.Getpid()) // #nosec G115 -- test pid
+	if target.anchor.PID <= 1 || target.anchor.PID == self {
+		t.Errorf("tree anchor pid = %d, want a proper ancestor of the CLI", target.anchor.PID)
+	}
+}
+
+// TestGrantCreatedShowsTreeScope: a tree grant's confirmation must state its
+// perimeter (name under anchor) and the granting-ahead fact when nothing
+// matches yet; an exact grant's must not carry a scope line at all.
+func TestGrantCreatedShowsTreeScope(t *testing.T) {
+	var b strings.Builder
+	printGrantCreated(&b, agent.GrantStatus{ID: "g-1", Name: "claude", Anchor: "iTerm2",
+		PID: 999999998, Profiles: []string{"jamf"}, Secrets: []string{"jamf/api"},
+		ExpiresUnix: time.Now().Add(time.Hour).Unix()})
+	out := b.String()
+	if !strings.Contains(out, "covers claude under iTerm2") {
+		t.Errorf("tree confirmation lacks the scope line:\n%s", out)
+	}
+	if !strings.Contains(out, "none running yet") {
+		t.Errorf("tree confirmation with no live match must say it grants ahead:\n%s", out)
+	}
+	b.Reset()
+	printGrantCreated(&b, agent.GrantStatus{ID: "g-2", Name: "claude", PID: 123,
+		Profiles: []string{"jamf"}, Secrets: []string{"jamf/api"},
+		ExpiresUnix: time.Now().Add(time.Hour).Unix()})
+	if strings.Contains(b.String(), "covers") {
+		t.Errorf("exact-grant confirmation must not carry a tree scope line:\n%s", b.String())
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -689,7 +689,7 @@ func printGrantsSection(w io.Writer, r statusResult) {
 	case len(r.Agent.Grants) == 0:
 		printStatusValue(w, "%s", "none active")
 		if r.Vault.SecretsStored > 0 {
-			printStatusAction(w, "`"+grantCreateUsage+"` pre-approves a running program")
+			printStatusAction(w, "`"+grantCreateUsage+"` pre-approves a program to work unattended")
 		}
 		return
 	}

--- a/internal/lineage/caller.go
+++ b/internal/lineage/caller.go
@@ -64,6 +64,32 @@ func (p Process) Name() string {
 	return filepath.Base(p.ExecPath)
 }
 
+// MatchesName reports whether this process should count as name for a tree
+// grant's filter walk (AncestryNamedWithin) and its creation-time count:
+// the kernel-derived display Name, or — when that is empty or different —
+// the base name of argv[0].
+//
+// Accepting argv here is a deliberate, documented step past Name()'s
+// doctrine, taken because of a real failure: Claude Code self-updates by
+// REPLACING its on-disk binary, after which the kernel reports no exec path
+// for the still-running process, Name() is honestly empty, and every serve
+// through the longest-running claude on the machine fails closed. The grant
+// filter is the half of the gate that only ever NARROWS a kernel-verified
+// tree bounded by a human-approved deadline — a process inside that tree
+// claiming a name via argv gains routing the human's perimeter already
+// contains, and a process outside it gains nothing whatever it claims. The
+// prompt and every display surface keep using Name(), which never trusts
+// argv.
+func (p Process) MatchesName(name string) bool {
+	if name == "" {
+		return false
+	}
+	if p.Name() == name {
+		return true
+	}
+	return len(p.Argv) > 0 && filepath.Base(p.Argv[0]) == name
+}
+
 // isVersionLike reports whether a path component is nothing but a version
 // ("2.1.209", "v3", "1.0.0-rc2") — a name that identifies a release, never a
 // program.
@@ -254,7 +280,10 @@ func ProcessesNamed(name string) []Process {
 	}
 	var out []Process
 	for _, p := range VisibleProcesses() {
-		if p.Name() == name {
+		// MatchesName so this listing agrees with the tree-grant serve walk:
+		// a grant confirmation that counts "1 running now" while the serve
+		// path would match two is a report that lies about scope.
+		if p.MatchesName(name) {
 			out = append(out, p)
 		}
 	}

--- a/internal/lineage/grant.go
+++ b/internal/lineage/grant.go
@@ -106,6 +106,90 @@ func AncestryContainsPID(pid, root int32) bool {
 	return false
 }
 
+// AncestryNamedWithin walks pid's parent chain toward launchd and reports
+// whether the chain passes through a process whose display Name() is name at
+// or below root, and then reaches root itself. It is AncestryContainsPID
+// with one extra condition, and the same fail-closed posture: any unreadable
+// link, cycle, or cap overrun answers false.
+//
+// This is the serve gate for a tree-scoped process grant ("claude under
+// iTerm2"). The two conditions carry very different weight, and the design
+// leans on the strong one: reaching root is a kernel fact no process can
+// arrange for itself, while the name is self-chosen (argv/exec path) and
+// trivially claimed. The name therefore only NARROWS which descendants of
+// the human-approved root are served — a process outside root's tree gains
+// nothing by renaming itself, and a hostile process already inside the tree
+// was already inside the perimeter the human approved. The decision is the
+// disclosed challenge bound to root at creation; this walk only routes to it.
+func AncestryNamedWithin(pid, root int32, name string) bool {
+	// root <= 1 answers false outright: everything descends from launchd, so
+	// a launchd-rooted walk would let the self-chosen name decide alone —
+	// creation refuses to mint such a grant, and this is the serve-side belt.
+	if pid <= 0 || root <= 1 || name == "" {
+		return false
+	}
+	cur := pid
+	nameSeen := false
+	for depth := 0; depth < grantAncestryCap; depth++ {
+		if !nameSeen {
+			if p, ok := Describe(cur); ok && p.Name() == name {
+				nameSeen = true
+			}
+		}
+		if cur == root {
+			return nameSeen
+		}
+		if cur <= 1 {
+			return false
+		}
+		kp, err := unix.SysctlKinfoProc("kern.proc.pid", int(cur))
+		if err != nil {
+			return false
+		}
+		ppid := int32(kp.Eproc.Ppid)
+		if ppid == cur {
+			return false // self-parent: impossible, but never loop on it
+		}
+		cur = ppid
+	}
+	return false
+}
+
+// SessionRoot returns the topmost ancestor of pid below launchd — the
+// terminal app, tmux server, or SSH connection that owns pid's session —
+// which is what a tree-scoped grant anchors to. ok is false when pid has no
+// such ancestor to speak of: it is launchd's own child (a daemon has no
+// session), or the chain was unreadable from the first hop. A chain that
+// becomes unreadable partway returns the topmost ancestor that could be
+// read: a narrower anchor is the safe direction, never a wider one.
+func SessionRoot(pid int32) (Process, bool) {
+	if pid <= 0 {
+		return Process{}, false
+	}
+	top := int32(0) // topmost ancestor read so far, strictly above pid
+	cur := pid
+	for depth := 0; depth < grantAncestryCap; depth++ {
+		kp, err := unix.SysctlKinfoProc("kern.proc.pid", int(cur))
+		if err != nil {
+			break // unreadable from here up: top is the narrowest safe anchor
+		}
+		ppid := int32(kp.Eproc.Ppid)
+		if ppid <= 1 || ppid == cur {
+			break // cur is launchd's child: the session root (or the cycle guard fired)
+		}
+		top = ppid
+		cur = ppid
+	}
+	if top == 0 {
+		return Process{}, false
+	}
+	p, ok := Describe(top)
+	if !ok {
+		return Process{}, false
+	}
+	return p, true
+}
+
 // ProcessStartTime returns pid's fork-time stamp in microseconds since the
 // epoch, ok=false when the process is gone or unreadable. The stamp is
 // stable across execve (spike-verified through a double exec), which is

--- a/internal/lineage/grant.go
+++ b/internal/lineage/grant.go
@@ -132,7 +132,11 @@ func AncestryNamedWithin(pid, root int32, name string) bool {
 	nameSeen := false
 	for depth := 0; depth < grantAncestryCap; depth++ {
 		if !nameSeen {
-			if p, ok := Describe(cur); ok && p.Name() == name {
+			// MatchesName, not Name(): a self-updated tool's exec path is
+			// unreadable (binary replaced under the running process) and its
+			// kernel name honestly empty — see MatchesName for why argv is
+			// acceptable in this walk and nowhere else.
+			if p, ok := Describe(cur); ok && p.MatchesName(name) {
 				nameSeen = true
 			}
 		}

--- a/internal/lineage/grant_test.go
+++ b/internal/lineage/grant_test.go
@@ -86,6 +86,28 @@ func TestAncestryNamedWithinRealTree(t *testing.T) {
 	}
 }
 
+// TestMatchesNameFallsBackToArgv pins the one place argv may name a process:
+// the tree-grant filter walk, where a self-updated tool (binary replaced
+// under the running process, exec path unreadable, Name() honestly empty)
+// must still count as itself — found live, when the longest-running claude
+// on the machine stopped matching its own grant.
+func TestMatchesNameFallsBackToArgv(t *testing.T) {
+	updated := Process{PID: 42, Argv: []string{"claude", "--resume"}}
+	if updated.Name() != "" {
+		t.Fatalf("fixture broken: expected an empty kernel name, got %q", updated.Name())
+	}
+	if !updated.MatchesName("claude") {
+		t.Error("a process with no exec path but argv[0]=claude must match claude")
+	}
+	if updated.MatchesName("gh") || updated.MatchesName("") {
+		t.Error("argv fallback must not match a different or empty name")
+	}
+	normal := Process{PID: 43, ExecPath: "/opt/tools/gh", Argv: []string{"gh", "pr"}}
+	if !normal.MatchesName("gh") || normal.MatchesName("pr") {
+		t.Error("a kernel-named process must match by that name only")
+	}
+}
+
 // TestSessionRootIsAProperAncestor pins the anchor derivation: the session
 // root must be a real, describable ancestor of the caller, strictly above
 // it, and never launchd itself.

--- a/internal/lineage/grant_test.go
+++ b/internal/lineage/grant_test.go
@@ -37,6 +37,75 @@ func TestAncestryContainsPIDRealTree(t *testing.T) {
 	}
 }
 
+// TestAncestryNamedWithinRealTree pins the tree-grant serve gate to the live
+// process tree: the name must appear on the chain at or below the root the
+// chain then reaches, and either condition failing answers false.
+func TestAncestryNamedWithinRealTree(t *testing.T) {
+	self := int32(os.Getpid())
+	parent := int32(os.Getppid())
+	ownName := ""
+	if p, ok := Describe(self); ok {
+		ownName = p.Name()
+	}
+	if ownName == "" {
+		t.Fatal("Describe(self) yields no name; the fixture below is meaningless")
+	}
+
+	if !AncestryNamedWithin(self, parent, ownName) {
+		t.Errorf("self (named %q) under its parent must be served", ownName)
+	}
+	if AncestryNamedWithin(self, parent, "no-such-name-zz9") {
+		t.Error("a name absent from the chain must not be served")
+	}
+	if AncestryNamedWithin(parent, self, ownName) {
+		t.Error("a caller outside the root's tree must not be served, whatever the name")
+	}
+
+	// A child named sleep: the name sits BELOW the caller-to-root walk's
+	// start, i.e. the child itself carries it.
+	child := exec.Command("sleep", "60")
+	if err := child.Start(); err != nil {
+		t.Fatalf("starting child: %v", err)
+	}
+	defer func() {
+		_ = child.Process.Kill()
+		_, _ = child.Process.Wait()
+	}()
+	childPID := int32(child.Process.Pid) // #nosec G115 -- a pid always fits int32 on darwin
+	if !AncestryNamedWithin(childPID, self, "sleep") {
+		t.Error("a child named sleep under this test must be served")
+	}
+	if AncestryNamedWithin(childPID, self, "claude") {
+		t.Error("the child's chain carries no claude; it must not be served")
+	}
+
+	// launchd may never be the root: everything descends from pid 1, so the
+	// walk answering true there would let the name decide alone.
+	if AncestryNamedWithin(childPID, 1, "sleep") {
+		t.Error("a launchd-rooted walk must always answer false")
+	}
+}
+
+// TestSessionRootIsAProperAncestor pins the anchor derivation: the session
+// root must be a real, describable ancestor of the caller, strictly above
+// it, and never launchd itself.
+func TestSessionRootIsAProperAncestor(t *testing.T) {
+	self := int32(os.Getpid())
+	root, ok := SessionRoot(self)
+	if !ok {
+		t.Skip("this test process is launchd's own child (bare CI runner); no session root to derive")
+	}
+	if root.PID == self || root.PID <= 1 {
+		t.Fatalf("SessionRoot(self) = pid %d, want a proper ancestor above self and above launchd", root.PID)
+	}
+	if !AncestryContainsPID(self, root.PID) {
+		t.Errorf("SessionRoot returned pid %d which is not an ancestor of the caller", root.PID)
+	}
+	if _, ok := SessionRoot(0); ok {
+		t.Error("SessionRoot(0) must fail")
+	}
+}
+
 func TestProcessStartTimeSelfStableAndDeadPIDFails(t *testing.T) {
 	first, ok := ProcessStartTime(int32(os.Getpid()))
 	if !ok || first == 0 {

--- a/internal/lineage/lineage.go
+++ b/internal/lineage/lineage.go
@@ -26,6 +26,10 @@ static int get_pid_path(pid_t pid, char *buf, uint32_t bufsize) {
 	return proc_pidpath(pid, buf, bufsize);
 }
 
+static int get_pid_cwd(pid_t pid, struct proc_vnodepathinfo *out) {
+	return proc_pidinfo(pid, PROC_PIDVNODEPATHINFO, 0, out, sizeof(*out));
+}
+
 static int is_vnode_type(uint32_t fdtype) {
 	return fdtype == PROX_FDTYPE_VNODE;
 }
@@ -224,6 +228,23 @@ func vnodeInfo(pid, fd int32) (path string, vtype int32, err error) {
 	path = C.GoString(&info.pvip.vip_path[0])
 	vtype = int32(info.pvip.vip_vi.vi_type)
 	return path, vtype, nil
+}
+
+// ProcessCWD returns pid's current working directory, or "" if unavailable
+// (the process exited, is another user's, or the kernel has no vnode path
+// for it). Display only, pidExecPath's exact posture: it annotates the
+// `jit grant --pid` completion so seven identical "claude" rows become
+// tellable apart by the project each one sits in — it never gates.
+func ProcessCWD(pid int32) string {
+	if pid <= 0 {
+		return ""
+	}
+	var info C.struct_proc_vnodepathinfo
+	n := C.get_pid_cwd(C.pid_t(pid), &info)
+	if n <= 0 {
+		return ""
+	}
+	return C.GoString(&info.pvi_cdir.vip_path[0])
 }
 
 // pidExecPath returns pid's executable path, or "" if unavailable — purely


### PR DESCRIPTION
## What

`jit grant --process NAME` no longer freezes one pid. It anchors to the **session root** of the terminal it is typed in (iTerm2, Terminal, a tmux server, an IDE, an SSH connection — whatever the topmost ancestor below launchd is) and serves any process whose ancestry passes through NAME at or below that root — **including processes started after creation**, which is the point: one Touch ID covers "every claude I start from this terminal for the next hour", and a script scheduled to fire in ten minutes inside that tree.

```
$ jit grant --process claude --profile mcp-internal-tool --for 15m
🔐  let claude under iTerm2 use 2 secrets (mcp-internal-tool) unattended for 15m
✓ granted g-e2af125c   claude → mcp-internal-tool   until 10:04
  └ 2 secrets: mcp-internal-tool/CAIDO_URL, mcp-internal-tool/GITHUB_TOK…
  └ covers claude under iTerm2: 4 running now, any started before 10:04
  └ end it early: jit grant revoke g-e2af125c
```

This dissolves two dead ends the old resolution had: the pick-one-of-seven-identical-pids error is gone (the grant covers them all), and granting ahead of the launch is valid ("none running yet"). `--pid` keeps the exact-one-process mode, its completion now annotated with each candidate's cwd and age.

## Security model

- The strong half is kernel fact: the requester must **descend from the exact terminal process** the human granted from (pid + fork-time pinned, `lineage.AncestryNamedWithin`, fail-closed on any unreadable link).
- The name is the weak half and **never decides alone**: it only narrows what the tree admits. A process elsewhere renaming itself `claude` gains nothing; machine-wide-by-name was considered and rejected.
- The agent refuses anchors outside the caller's own ancestry, and refuses launchd (pid 1) outright — everything descends from it, so that anchor would be the machine-wide name gate this shape exists to avoid.
- The prompt names both halves: `let claude under iTerm2 use …`. Version skew is guarded: an older service that ignores `grant_name` would mint a wider grant; the CLI detects the shape mismatch and revokes it on the spot.

## Found live while testing on a real machine

- **A self-updated tool lost its own name**: Claude Code replaces its on-disk binary, the kernel then reports no exec path, and the longest-running claude stopped matching its grant (serves failed closed). `MatchesName` accepts argv[0] in exactly two places — the filter walk and the creation-time count — with the doctrine documented; prompts and display keep the argv-distrusting `Name()`.
- An unresolvable profile entry now names the missing vault path instead of just the profile.

## Test plan

- Unit: tree serve by name under anchor, name-miss falls through to the ordinary challenge, anchor-not-your-ancestor and launchd-anchor refusals (prompt-free), argv fallback matching, `SessionRoot`/`AncestryNamedWithin` against the live process tree, prompt-budget worst case, list/confirmation rendering.
- Live on the dev VM (passcode in place of Touch ID): create from inside a claude session → prompt reads `let claude under iTerm2 …` → **locked** service serves both secrets with zero prompts → still locked after → `2 serves` on `jit grant list` → revoke ends it with the audit `grant_end` carrying the paths.
- `go test -race ./...`, gofmt, vet, staticcheck, gosec all clean; command docs regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JcVvNCoijFe5p4Shppb9xZ