### PR TITLE
cli: TAB stops re-offering flags you already typed · docs catch up with the pager and tree grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,18 +220,23 @@ that names exactly what you're signing:
 
 ```console
 $ jit grant --process claude --profile jamf --for 8h
-  Touch ID  ->  let claude use 2 secrets (jamf) unattended for 8h
+  Touch ID  ->  let claude under iTerm2 use 2 secrets (jamf) unattended for 8h
 ✓ granted g-7f3a2c81   claude -> jamf   until 17:42
+  └ covers claude under iTerm2: 1 running now, any started before 17:42
 ```
 
-For the next 8 hours, that running process (and what it launches) gets those
-secrets with no prompts - through screen lock and all. It's a live process
-being named, not a name being trusted: a new program calling itself `claude`
-tomorrow inherits nothing, and the grant ends at its deadline, when the process
-exits, or the moment you type `jit grant revoke` (which needs no fingerprint -
-taking access away is always free). Every serve lands in the audit trail as its
-own event, so the morning after you can read exactly what your agent touched
-while you slept. Full details: [process grants](./docs/service/grants.md).
+For the next 8 hours, every `claude` under **the terminal you typed that in**
+(and what it launches) gets those secrets with no prompts - through screen lock
+and all, including sessions you start later: a new tab, the next `claude`, a
+script that fires at 3am. It's your terminal being named, not a name being
+trusted: a program calling itself `claude` somewhere else on the machine
+doesn't descend from that tree and inherits nothing. The grant ends at its
+deadline, when you quit that terminal, or the moment you type `jit grant
+revoke` (which needs no fingerprint - taking access away is always free). Want
+one exact process instead, gone when it exits? `--pid`. Every serve lands in
+the audit trail as its own event, so the morning after you can read exactly
+what your agent touched while you slept. Full details:
+[process grants](./docs/service/grants.md).
 
 ## The audit trail: what happened, and who did it
 

--- a/design/process-grants.md
+++ b/design/process-grants.md
@@ -94,6 +94,31 @@ Consequences, all deliberate:
 `--pid` keeps the original exact-one-process semantics, now annotated in
 completion with each candidate's cwd and age (the seven-identical-rows fix).
 
+### Two things the first live create taught us
+
+**The name half must accept argv, or a self-updating tool loses its own
+grant.** Claude Code updates by REPLACING its on-disk binary; afterwards the
+kernel reports no exec path for the still-running process, `Process.Name()`
+is honestly empty, and the longest-running claude on the machine stops
+matching the grant made for it: every serve fails closed. `MatchesName`
+therefore accepts argv[0]'s base name, in exactly two places: the filter walk
+and the creation-time count that feeds "2 running now" (they must agree, or
+the confirmation lies about scope). Prompts and every display surface keep
+using `Name()`, which never trusts argv. This is consistent with the doctrine
+above rather than an exception to it: condition 1 already carried no security
+weight, and a process that is already inside the human-approved tree gains
+only routing the perimeter contains.
+
+**A service older than tree grants would silently widen the scope.** It
+ignores the unknown `grant_name` field and mints an EXACT grant anchored at
+the terminal: every process under it, no filter, strictly wider than what
+the human just approved. The reply betrays the skew (no `Anchor` on a tree
+request), so the CLI revokes the grant on the spot and names the fix
+(`jit service restart`). Reducing access is free, so this happens before
+anything is reported. The window is short (the service swaps onto a replaced
+binary within seconds), but "wider than the prompt said" is never acceptable,
+however briefly.
+
 ## Mechanics: a scoped DEK cache, not a weaker vault
 
 The enabling fact: the agent is a DEK-unwrapping oracle. `OpUnwrap` receives

--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -94,6 +94,12 @@ followed. A path that doesn't exist is an error, not a silently empty scan.
 | `jit scan --format ndjson` | one JSON record per finding plus a closing summary, for piping into other tools ([schema](../reference/scan-ndjson.md)) |
 | `jit scan -o report.md` | write the report to a file instead of stdout |
 
+A machine-wide report runs past one screen, so on a terminal it pages through
+your pager (`$JIT_PAGER`, then `$PAGER`, then `less`) the moment the report
+starts - the progress trail above it stays visible while the scan runs.
+`--no-pager` prints straight through, and piping or `-o` never pages at all
+([CLI conventions](../reference/conventions.md#long-reports-page-like-git)).
+
 The "Outside jit's scope" advisory appears in the default view, in `--full`,
 and in markdown. It is deliberately **not** in NDJSON: that schema describes
 findings jit stands behind, and this is a note to a human.

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -121,7 +121,7 @@ never have to remember or retype an exact path or name:
 | `jit migrate undo` | files with a restorable backup, plus each one's parent directory |
 | `jit unmount` | your live-mounted file paths |
 | any `--profile` flag | profile names visible from the current directory |
-| `jit grant` | the create shape; `--process` offers programs that recently asked for a secret |
+| `jit grant` | the create shape one flag at a time: `--process` (programs that recently asked for a secret) or `--pid`, then `--profile`, then `--for` |
 | `jit grant revoke`/`extend` | your live grant ids, each with its program and expiry |
 | `jit wrap add` | every tool jit knows how to wrap, then the required `--env`/`--grant` |
 | `jit wrap undo` | the tools you've currently wrapped |
@@ -136,6 +136,12 @@ completing an argument never triggers a Touch ID prompt mid-keystroke. Where
 there is nothing to offer yet (an empty vault, no profiles here, no live
 grants), `<TAB>` prints a one-line hint naming the command that changes that
 instead of going silent.
+
+Where a command's flags are the thing to complete - `jit grant`, `jit wrap
+add`, `jit audit`, `jit export` - `<TAB>` accounts for what you've already
+typed: a flag on the line is not offered again (a repeatable one like `--env`
+still is), and the commands that build up a single request walk their flags in
+order, ending with "press enter" once the line is valid.
 
 **zsh** (macOS default):
 

--- a/docs/getting-started/troubleshooting.md
+++ b/docs/getting-started/troubleshooting.md
@@ -64,6 +64,16 @@ description: Placeholder values, hanging reads, surprise Touch ID prompts, MCP s
   upgraded that way; otherwise run `jit service restart` to move it onto the
   current binary now (it also switches on its own within a few seconds once
   idle). See [Upgrading](./install.md#upgrading).
+- **`jit grant --process` says the service predates tree grants.** The running
+  service is an older binary that would have granted your whole terminal
+  instead of only the named program - wider than the prompt you approved. jit
+  revokes that grant on the spot rather than leaving it standing; run
+  `jit service restart` and create it again. Same cause as the "different
+  build" warning above.
+- **A grant covers your tool but a mounted file still prompts.** Grants cover
+  pull-at-use delivery, not FIFO mounts, which keep their own
+  [consent gating](../service/consent.md). See
+  [the honest limits](../service/grants.md#the-honest-limits).
 - **A wrapped tool stopped authenticating.** See
   [Wrap troubleshooting](../wrap/troubleshooting.md) - `jit doctor --wrap`
   checks every shim, PATH entry, and profile.

--- a/docs/reference/conventions.md
+++ b/docs/reference/conventions.md
@@ -74,6 +74,27 @@ summary does not match), but a loop over every line will see it. Use
 jit vault list --format json | jq -r '.secrets[].path'
 ```
 
+## Long reports page like git
+
+`jit audit` and `jit scan` can run well past one screen, so on a terminal they
+page their report through your pager: `$JIT_PAGER` if set, then `$PAGER`, then
+`less`. Colour and the real terminal width survive into it, because only the
+report's output stream is redirected, never the process's stdout.
+
+| To do this | Use |
+|---|---|
+| Read a long report | nothing - it pages by itself on a terminal |
+| Print straight through, this once | `--no-pager` |
+| Never page, anywhere | `export JIT_PAGER=cat` (or `PAGER=cat`, or either set empty) |
+| Use your own pager settings | export `LESS` yourself; jit passes it through and only defaults to `LESS=FRX` when it is unset |
+
+Paging engages **only** when stdout is a real terminal. Piped or redirected
+output is byte-identical to what it was before paging existed, so
+`jit audit --format logfmt | grep denied` and `jit scan -o report.md` need no
+flag. `jit audit --follow` never pages either: it streams live, and a pager
+buffering an endless tail would show nothing. A `$PAGER` that names a program
+you don't have prints a warning on stderr and the report anyway.
+
 ## Confirmation flags
 
 Anything destructive asks first. One flag skips the question, everywhere:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -37,3 +37,6 @@ lifetime - it is never exported to your shell or written anywhere.
 | `ZDOTDIR` | when set, [`jit guard history`](../migrate/shell-history.md) writes its source line to `$ZDOTDIR/.zshrc` instead of `~/.zshrc` - the file your zsh actually reads |
 | `HISTFILE` | consulted by `jit scan` and `jit migrate` to find a relocated shell history file. Note zsh and bash keep this as an ordinary shell parameter, **not** an exported one, so jit usually cannot see it: name the file explicitly (`jit migrate ~/.cache/zsh/history`, which is routed by name) or `export HISTFILE` if you want the machine-wide scan to reach it |
 | `JIT_GUARD_BIN` | overrides which `jit` binary the installed history-guard hook invokes; exists for jit's own tests, not for daily use |
+| `JIT_PAGER` | the pager for jit's long reports (`jit audit`, `jit scan`), checked before `$PAGER`. Set it to `cat` or the empty string to never page, whatever `$PAGER` says |
+| `PAGER` | the fallback when `$JIT_PAGER` is unset; `less` if neither is. Same `cat`/empty escape hatch. See [CLI conventions](./conventions.md#long-reports-page-like-git) |
+| `LESS` | if you export your own, jit passes it through untouched. Only when it is unset does jit run bare `less` with `LESS=FRX` (quit inline when the report fits one screen, keep colour, stay in scrollback) |

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -125,11 +125,19 @@ are prompt-free.
 the session key, consent decisions, `--trust` roots, run attachments - drops
 the moment the session ends, because those all ride an approval whose scope
 was "this session". A grant's approval said something different, out loud:
-*unattended, until a deadline*, for named secrets and one live process tree
-(anchored by pid and kernel fork-time, so a recycled pid inherits nothing).
-It is strictly narrower than the session it stands in for: never the master
-key, only the covered secrets' data keys, in service memory only, ended by
-its deadline, its process exiting, a restart, or an unauthenticated
+*unattended, until a deadline*, for named secrets and one live process tree.
+`--process NAME` anchors that tree at the terminal it was typed in (pinned by
+pid and kernel fork-time, so a recycled pid inherits nothing) and serves only
+callers whose ancestry passes through both that terminal and a process named
+NAME - membership is evaluated per read against the live tree, so a session
+started later inside the same terminal is covered and a same-named process
+outside it never is. Only the terminal half is a kernel fact; the name half
+is self-reported (exec path, or argv when a self-updating tool has replaced
+its own binary) and carries no security weight, because it can only narrow
+what the approved tree already admits. `--pid` anchors one exact process
+instead. It is strictly narrower than the session it stands in for: never the
+master key, only the covered secrets' data keys, in service memory only, ended by
+its deadline, its anchor exiting, a restart, or an unauthenticated
 `jit grant revoke`. The decision point is unchanged - a human on a disclosed
 prompt - it just happens before the absence instead of during it, and every
 serve under it is a distinct [`jit audit`](../service/provenance.md) event.

--- a/docs/service/index.md
+++ b/docs/service/index.md
@@ -22,9 +22,11 @@ hooks (`aws`, `kubectl`) and `jit run`. On top of it,
 the first time each tool reaches for a real credential, naming who is asking,
 so an unlocked session is never a blank cheque. And for the opposite
 situation - work that must keep running while you are *away* from the
-keyboard - a [process grant](./grants.md) lets you pre-approve one running
-tool for named profiles and a bounded time, with one Touch ID given while
-you are still there. It deliberately does **not**
+keyboard - a [process grant](./grants.md) lets you pre-approve a named tool
+under this terminal for named profiles and a bounded time, with one Touch ID
+given while you are still there. The scope is the terminal's process tree, so
+sessions that start later inside it are covered too, and you can grant before
+the tool is even running. It deliberately does **not**
 cover the sensitive [`jit vault`](../vault/index.md) management commands
 (`get`/`set`/`rm`/`import`/`restore`/`clean`/`prune`/`delete`/`export`):
 those always require a fresh Touch ID/passcode on every run, unlocked or

--- a/docs/service/provenance.md
+++ b/docs/service/provenance.md
@@ -125,3 +125,26 @@ The session events above are read only through `jit audit` now; they are no
 longer duplicated into the service's own log. That log, `jit service log` (and
 `-f` to follow it), is the raw operational record behind the daemon: startup,
 per-mount reader lineage, and the prose detail of any serve error.
+
+## Reading a long trail
+
+The report shows the newest 50 matching entries by default, and its header
+counts the **whole match set**, not the page:
+
+```
+jit audit — 50 of 214 events · Mon 10 Aug – Today
+```
+
+So `--since 3d` reports three days' span and three days' failure counts even
+when the cap cut the rows below it - a header that tallied only what printed
+read as "the older history was deleted". The trailer's first hint is the way
+out, `jit audit --limit 0`, with the full count next to it; `--limit N` picks
+any other page size. Failed, denied and decoy tallies are measured before the
+cap too, so a refusal the cap pushed off the page still earns its filter a
+mention.
+
+Long reports page through your pager on a terminal (`$JIT_PAGER`, then
+`$PAGER`, then `less`), so `--limit 0` is readable rather than a wall of
+scrollback. `--no-pager` prints straight through, `--follow` never pages, and
+piped output is unchanged. See
+[CLI conventions](../reference/conventions.md#long-reports-page-like-git).

--- a/internal/cli/argcomplete_test.go
+++ b/internal/cli/argcomplete_test.go
@@ -274,6 +274,75 @@ func TestWrapAddCompletionSurfacesTheRequiredFlag(t *testing.T) {
 	}
 }
 
+// A flag already typed must move the offer forward, never repeat: --grant
+// and --env exclude each other, and only --env is repeatable. Same class as
+// the grant report (`--process bash <Tab>` offered --process again).
+func TestWrapAddCompletionWalksForwardFromTypedFlags(t *testing.T) {
+	withFixtureHome(t)
+	t.Cleanup(func() {
+		wrapAddEnv, wrapAddGrant = nil, ""
+		wrapAddCmd.Flags().Lookup("env").Changed = false
+		wrapAddCmd.Flags().Lookup("grant").Changed = false
+	})
+
+	out := completeThrough(t, "wrap", "add", "gh", "--env", "GH_TOKEN=wrap-gh/GH_TOKEN", "")
+	if strings.Contains(out, "--grant") {
+		t.Errorf("--env excludes --grant, yet it is still offered:\n%s", out)
+	}
+	if !strings.Contains(out, "--env\t") {
+		t.Errorf("--env is repeatable and must stay on offer:\n%s", out)
+	}
+
+	wrapAddEnv = nil
+	out = completeThrough(t, "wrap", "add", "gcloud", "--grant", "gcp", "")
+	if strings.Contains(out, "--env") || strings.Contains(out, "--grant\t") {
+		t.Errorf("`wrap add gcloud --grant gcp` is complete, no more flags belong on offer:\n%s", out)
+	}
+}
+
+// A filter already on the line must drop out of the bare-command offer;
+// --kind stays because it is repeatable.
+func TestAuditCompletionDropsTypedFilters(t *testing.T) {
+	withFixtureHome(t)
+	// Other tests run `jit audit` with filters through the same rootCmd, and
+	// a flag's Changed survives Execute - a fresh process per TAB in real
+	// life, so only this suite needs the reset.
+	for _, name := range []string{"status", "kind", "since", "secret", "follow"} {
+		auditCmd.Flags().Lookup(name).Changed = false
+	}
+	t.Cleanup(func() {
+		auditStatus = ""
+		auditKinds = nil
+		auditCmd.Flags().Lookup("status").Changed = false
+		auditCmd.Flags().Lookup("kind").Changed = false
+	})
+	out := completeThrough(t, "audit", "--status", "ok", "--kind", "use", "")
+	if strings.Contains(out, "--status\t") {
+		t.Errorf("--status already typed but offered again:\n%s", out)
+	}
+	if !strings.Contains(out, "--kind\t") {
+		t.Errorf("--kind is repeatable and must stay on offer:\n%s", out)
+	}
+	if !strings.Contains(out, "--since\t") {
+		t.Errorf("untyped filters must stay on offer:\n%s", out)
+	}
+}
+
+func TestExportCompletionDropsTypedFlags(t *testing.T) {
+	withFixtureHome(t)
+	t.Cleanup(func() {
+		exportProfile = ""
+		exportCmd.Flags().Lookup("profile").Changed = false
+	})
+	out := completeThrough(t, "export", "--profile", "dev", "")
+	if strings.Contains(out, "--profile\t") {
+		t.Errorf("--profile already typed but offered again:\n%s", out)
+	}
+	if !strings.Contains(out, "--mode\t") {
+		t.Errorf("--mode must stay on offer:\n%s", out)
+	}
+}
+
 // The bare command must show the filters that are the whole point of it.
 func TestAuditCompletionSurfacesItsFilters(t *testing.T) {
 	withFixtureHome(t)

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -145,13 +145,13 @@ func completeAuditTimes(cmd *cobra.Command, args []string, toComplete string) ([
 // flag, and none of them was discoverable at the moment someone double-taps
 // to find out. Same shape as completeGrantCreateEntry.
 func completeAuditEntry(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-	comps := []string{
+	comps := dropTypedFlags(cmd, []string{
 		"--kind\tonly these kinds: " + strings.Join(auditCanonicalKinds(), ", "),
 		"--since\tonly entries after an age or a date",
 		"--status\tonly this status: " + strings.Join(auditStatuses, ", "),
 		"--secret\tonly events that touched a secret whose name contains this",
 		"--follow\tprint the matching tail, then stream new entries live",
-	}
+	})
 	comps = cobra.AppendActiveHelp(comps, "audit takes filters, not arguments: jit audit --kind use --since 2h")
 	return comps, cobra.ShellCompDirectiveNoFileComp
 }

--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -106,14 +106,14 @@ func init() {
 	// export takes no arguments, so silenceFileCompletionForNoArgCommands
 	// would stop the file listing on its own; naming the two flags and the
 	// eval form is what makes the bare TAB useful rather than merely quiet.
-	exportCmd.ValidArgsFunction = func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	exportCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		comps := []string{
+		comps := dropTypedFlags(cmd, []string{
 			"--profile\texport this profile verbatim, instead of the project layers",
 			"--mode\talso merge .env.<mode> and .env.<mode>.local",
-		}
+		})
 		comps = cobra.AppendActiveHelp(comps, `load them into this shell: eval "$(jit export)"`)
 		return comps, cobra.ShellCompDirectiveNoFileComp
 	}

--- a/internal/cli/valuecomplete.go
+++ b/internal/cli/valuecomplete.go
@@ -55,6 +55,33 @@ func filterValues(values []string, toComplete string) []string {
 	return out
 }
 
+// dropTypedFlags removes the "--flag\tdescription" candidates whose flag is
+// already on the line - tabbing after `jit audit --status ok` re-offered
+// --status, the same class of bug as grant's create walk. A repeatable flag
+// (slice/array) stays: typing it again is legitimate. Cobra has parsed the
+// typed flags by the time a ValidArgsFunction runs, so Changed is
+// authoritative. The unordered filter offers (audit, export) share this;
+// the ordered create walks (grant, wrap add) encode their order by hand.
+func dropTypedFlags(cmd *cobra.Command, comps []string) []string {
+	if cmd == nil {
+		return comps
+	}
+	out := make([]string, 0, len(comps))
+	for _, c := range comps {
+		name := c
+		if i := strings.IndexByte(name, '\t'); i >= 0 {
+			name = name[:i]
+		}
+		f := cmd.Flags().Lookup(strings.TrimPrefix(name, "--"))
+		if f != nil && f.Changed &&
+			!strings.Contains(f.Value.Type(), "Slice") && !strings.Contains(f.Value.Type(), "Array") {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
 // firstArgOnly restricts a value completion to the FIRST positional, for the
 // commands that take at most one (`service ttl`, `service consent`). Past it
 // there is nothing to offer, and cobra's fallback is file completion for a

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -530,14 +530,25 @@ func completeWrapCatalog(cmd *cobra.Command, args []string, toComplete string) (
 	// and it is where the REQUIRED flag belongs instead: `jit wrap add gh`
 	// alone is not a valid command, yet neither --env nor --grant ever
 	// appeared on tab. Same shape as completeGrantCreateEntry: the flag as a
-	// candidate, the whole line as active help.
+	// candidate, the whole line as active help - and like there, a flag
+	// already on the line moves the offer forward instead of repeating.
+	// --env and --grant are mutually exclusive, --env alone is repeatable.
 	if len(args) != 0 {
-		comps := []string{
-			"--env\tinject VAR=<vault-path> into the tool (repeatable)",
-			"--grant\tgrant a global file mount instead: " + knownWithNames(globalMountKinds(homeForWrapCompletion())),
+		switch {
+		case wrapAddGrant != "":
+			return cobra.AppendActiveHelp(nil, "all set - press enter to wrap"), cobra.ShellCompDirectiveNoFileComp
+		case len(wrapAddEnv) > 0:
+			comps := []string{"--env\tinject another VAR=<vault-path> (repeatable)"}
+			comps = cobra.AppendActiveHelp(comps, "press enter to wrap, or add another --env")
+			return comps, cobra.ShellCompDirectiveNoFileComp
+		default:
+			comps := []string{
+				"--env\tinject VAR=<vault-path> into the tool (repeatable)",
+				"--grant\tgrant a global file mount instead: " + knownWithNames(globalMountKinds(homeForWrapCompletion())),
+			}
+			comps = cobra.AppendActiveHelp(comps, "one of the two is required: "+wrapAddUsage)
+			return comps, cobra.ShellCompDirectiveNoFileComp
 		}
-		comps = cobra.AppendActiveHelp(comps, "one of the two is required: "+wrapAddUsage)
-		return comps, cobra.ShellCompDirectiveNoFileComp
 	}
 	var out []string
 	for _, tool := range wrap.CatalogTools() {


### PR DESCRIPTION
Two things, both follow-ups to what just merged.

**Completion.** Every entry completer that offers `--flag` candidates on a bare TAB now accounts for what is already on the line. `jit wrap add` walks forward (`--env` excludes `--grant`, one `--env` invites another, then "press enter to wrap"); `jit audit` and `jit export` drop typed filters through a shared `dropTypedFlags` helper that keeps repeatable flags on offer. These four (grant, wrap add, audit, export) are the only flag-offering entry completions in the CLI.

**Docs.** The generated command reference already carried the new flags; the hand-written pages still described the old behavior.

- `jit audit`'s cap and the pager (#49) had no prose at all: a "long reports page like git" section in CLI conventions, a "reading a long trail" section in provenance (`50 of 214 events`, `--limit 0`), the three env vars, and a paging note on the scan page.
- Tree-scoped `--process` (#50) left three pages describing an exact-pid grant - the README, the security architecture doc and the service index. All three now say terminal tree, future sessions covered, `--pid` for the exact one.
- The architecture doc states which half of the match is a kernel fact and which is self-reported, since `MatchesName` accepts argv now; the design doc records why (a self-updating tool losing its own grant) alongside the older-service skew guard.
- Troubleshooting gains the "service predates tree grants" entry and the grants-don't-cover-mounts one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY2nZpJLhGHp8sZgvDi31