### PR TITLE
service log: page long reads and make -n 0 mean everything

### DIFF
--- a/docs/reference/commands/jit_service_log.md
+++ b/docs/reference/commands/jit_service_log.md
@@ -28,7 +28,8 @@ jit service log [flags]
 
 ```
   -f, --follow      keep printing new lines as the service writes them (Ctrl-C to stop)
-  -n, --lines int   how many trailing lines to print (default 50)
+  -n, --lines int   how many trailing lines to print (0 for the whole file) (default 50)
+      --no-pager    print straight to the terminal instead of paging through $PAGER
       --raw         print the log file's bytes exactly as written, without the formatted view
 ```
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -1047,6 +1047,13 @@ var agentLogCmd = &cobra.Command{
 			fmt.Fprint(out, hlCmds(fmt.Sprintf("No service log yet at %s, it's written once the service runs; it starts on its own the first time you use jit, or run `jit service restart`.\n", displayLogPath(logPath))))
 			return nil
 		}
+		if !agentLogFollow {
+			// A static read pages like `jit audit` does; --follow keeps the
+			// terminal, since a poll loop must never sit behind a pager.
+			var donePaging func()
+			out, donePaging = pageableOutput(cmd)
+			defer donePaging()
+		}
 		writeAgentLogTail(out, tailLines(data, agentLogLines))
 
 		if !agentLogFollow {
@@ -1110,14 +1117,15 @@ func writeAgentLogTail(out io.Writer, data []byte) {
 }
 
 // tailLines returns the last n lines of data, newline-terminated — the
-// whole file when it has fewer.
+// whole file when it has fewer, or when n is 0: `-n 0` means everything,
+// the same convention `jit audit --limit 0` teaches.
 func tailLines(data []byte, n int) []byte {
 	trimmed := bytes.TrimSuffix(data, []byte("\n"))
-	if n <= 0 || len(trimmed) == 0 {
+	if len(trimmed) == 0 {
 		return nil
 	}
 	lines := bytes.Split(trimmed, []byte("\n"))
-	if len(lines) > n {
+	if n > 0 && len(lines) > n {
 		lines = lines[len(lines)-n:]
 	}
 	return append(bytes.Join(lines, []byte("\n")), '\n')
@@ -1782,7 +1790,8 @@ func init() {
 	agentRunCmd.Flags().DurationVar(&agentTTL, "ttl", 5*time.Minute, "how long an unlocked session stays cached before auto-locking (values above the 8h maximum session age are clamped to it)")
 	agentRunCmd.Flags().BoolVar(&agentConsent, "consent", true, "prompt for per-process consent (Touch ID) the first time each tool reaches for a credential (on by default; use --consent=false to disable)")
 	agentStatusCmd.Flags().StringVar(&agentStatusFormat, "format", "text", `output format: "text" (default) or "json"`)
-	agentLogCmd.Flags().IntVarP(&agentLogLines, "lines", "n", 50, "how many trailing lines to print")
+	agentLogCmd.Flags().IntVarP(&agentLogLines, "lines", "n", 50, "how many trailing lines to print (0 for the whole file)")
+	registerPagerFlag(agentLogCmd)
 	agentLogCmd.Flags().BoolVarP(&agentLogFollow, "follow", "f", false, "keep printing new lines as the service writes them (Ctrl-C to stop)")
 	agentLogCmd.Flags().BoolVar(&agentLogRaw, "raw", false, "print the log file's bytes exactly as written, without the formatted view")
 

--- a/internal/cli/agentlog_test.go
+++ b/internal/cli/agentlog_test.go
@@ -155,8 +155,8 @@ func TestTailLines(t *testing.T) {
 	if got := tailLines(nil, 5); got != nil {
 		t.Errorf("tailLines(nil) = %q, want nil", got)
 	}
-	if got := tailLines(data, 0); got != nil {
-		t.Errorf("tailLines(n=0) = %q, want nil", got)
+	if got := string(tailLines(data, 0)); got != "one\ntwo\nthree\n" {
+		t.Errorf("tailLines(n=0) = %q, want the whole file: 0 means everything, as in `jit audit --limit 0`", got)
 	}
 	// A file without a trailing newline still yields newline-terminated output.
 	if got := string(tailLines([]byte("one\ntwo"), 1)); got != "two\n" {
@@ -193,6 +193,14 @@ func TestAgentLogCommandPrintsTail(t *testing.T) {
 	}
 	if out != "2026-07-16 10:00:01 line two\n2026-07-16 10:00:02 line three\n" {
 		t.Errorf("jit agent log -n 2 = %q, want exactly the last two lines", out)
+	}
+
+	out, err = execAgentLog(t, "-n", "0")
+	if err != nil {
+		t.Fatalf("jit agent log -n 0: %v", err)
+	}
+	if out != content {
+		t.Errorf("jit agent log -n 0 = %q, want the whole file", out)
 	}
 }
 


### PR DESCRIPTION
`jit service log` is the one remaining long-report command that didn't get the pager treatment in #49. This closes the gap, plus one consistency fix the pager made visible.

## What changed

- **Static reads page.** `jit service log` now resolves `$JIT_PAGER` → `$PAGER` → `less` exactly like `jit audit` and `jit scan`, with the shared `--no-pager` opt-out. Same invariants: only the command's output writer is wrapped (color and real window width survive), pipes and redirects are untouched, and the default 50-line tail that fits one screen still prints inline via `less -F`.
- **`--follow` never pages.** A poll loop behind a pager shows nothing; the stream keeps the terminal, same rule as `jit audit --follow`.
- **`-n 0` now means the whole file.** It used to print *nothing* (`tailLines` returned nil for `n <= 0`), while `jit audit --limit 0` means everything — and audit's capped-header trailer now actively teaches that convention. The flag help says so: `0 for the whole file`.

## Tests

- `TestTailLines` updated: `n=0` returns the whole file.
- `TestAgentLogCommandPrintsTail` grew a `-n 0` end-to-end case through the real command.
- Existing pager tests in `pager_test.go` already cover the shared machinery; the buffer-substitution guard keeps every CLI test unpaged.

Full gate run locally: `go test -race ./...`, gofmt, vet, staticcheck, gosec, `go mod verify`/`tidy`, docs-gen (regenerated `jit_service_log.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)