### PR TITLE
vault: duplicates are told apart by origin, not by key names

### DIFF
--- a/design/vault-duplicates.md
+++ b/design/vault-duplicates.md
@@ -1,0 +1,173 @@
+# Spec: handling duplicates in the vault
+
+Status: implemented (2026-08-13)
+Scope: `jit vault list`'s group headers and duplicate note, a `jit vault rm`
+reference warning, a new `jit vault duplicates` command, and a migrate-time
+disclosure note.
+Non-goals: deduplicating storage, any new envelope field, any new deleting
+command.
+
+## Problem
+
+On a real machine (118 secrets, 28 groups), `jit vault list` closed with three
+notes of the form:
+
+```
+note: claude-inventory-export, developer-secrets-export, jamf-2 hold the same
+keys, a re-migrated file? jit vault rm the stale copy.
+```
+
+All three were wrong, and the one real duplicate went unreported.
+
+`printDuplicateGroupNudge` fingerprinted a group by **key names alone**, with a
+three-key floor. That rule cannot distinguish the two situations that produce
+identical key sets:
+
+- Five separate export scripts, each a live `.env` with its own mount, all
+  holding the same Jamf API client. Deleting any one breaks that script.
+- `mcp-caido` and `mcp-caido-2`: one `.mcp.json` in a workspace folder that was
+  copied, with both copies migrated. A genuine duplicate - and invisible to the
+  old rule, because the group holds a single key.
+
+Worse, the remedy it named is the wrong command even when a group *is* stale.
+`jit vault rm` deletes envelope files only: the profile manifest keeps naming
+the deleted path and the mount keeps serving a FIFO nothing can fill. It also
+had no referenced-by check at all, so following the note broke a live mount with
+no warning.
+
+The two existing duplicate surfaces both missed this case for the same reason:
+`jit vault orphans` keys on "referenced by nothing", and `jit status`'s
+`DuplicateOf` (secretsreconcile.go) only annotates *unreferenced* groups. Both
+caido groups are referenced, by their own live profiles.
+
+## Verdicts
+
+Origin is the discriminator, not the name and not the key set.
+
+| Verdict | Evidence | Remedy |
+| --- | --- | --- |
+| **Re-migration fork** | two groups, identical recorded `Origin` | retire one |
+| **Copied-file parallel migration** | same key set, same origin *tail* (`ws/.mcp.json`), different prefix | retire one |
+| **Abandoned namespace** | `Origin` no longer exists on disk | retire it |
+| **Shared credential** | same value, same key, independent live origins | **keep all** |
+| **Coincidental key names** | same key names, different values | not a duplicate |
+
+The origin tail is one segment beyond the basename on purpose: every project has
+a `.mcp.json`, so a bare basename would call two unrelated projects' configs
+copies of each other.
+
+The remedy differs per verdict, and routing it correctly is most of the value:
+
+- origin file still exists -> `jit migrate remove <file>` (file, profile and
+  secrets together). Note it writes that file's values back as PLAINTEXT on
+  its way out - it un-migrates the copy, it does not shred it - so retiring a
+  copy you want gone is two steps: `migrate remove`, then delete the file or
+  folder. It also refuses to delete a secret another project's profile
+  references, which is what makes retiring one copy of a shared credential
+  safe.
+- origin gone, nothing references it -> `jit vault orphans --prune`
+- origin gone, still wired -> `jit vault rm <paths>`
+- values diverged -> **no removal pick**; which copy is right is the user's call
+- shared credential -> no removal at all, plus the list of places a rotation
+  must reach
+
+## Identity, not deduplication
+
+The vault keeps N copies. It learns which ones are the same credential; it does
+not collapse them.
+
+Three reasons. The envelope AAD binds ciphertext to its exact path, so a shared
+object needs an indirection layer with its own delete-ownership semantics.
+Removal is destructive and every other jit surface is non-destructive by default
+(`scan` never writes; `migrate` has `undo`). And the actual pain is not disk: it
+is "which can I safely delete" and "I rotated this, which places are now stale" -
+both of which identity answers and deduplication does not.
+
+Sharing already exists where it belongs. Profile manifests map a variable name to
+a full vault path and are explicitly decoupled from the vault tree
+(`internal/profile/doc.go`), so two profiles referencing one path is already a
+legal, supported state. Nothing new was needed to make sharing possible; what was
+missing was jit *noticing*.
+
+## Why value comparison needs no envelope change
+
+Comparing values needs plaintext, which needs an unlock. An earlier draft
+proposed an envelope v4 field holding a keyed HMAC of each value so comparison
+could happen without decrypting.
+
+That was solving an invented problem. `jit vault duplicates` is a dedicated
+command that is *allowed* to prompt, and `jit vault export` already sets the
+precedent for bulk decryption under one unlock. So the command decrypts in
+memory, hashes, compares, and persists nothing. No envelope change, no new
+crypto surface.
+
+It also sidesteps a real hazard the stored-fingerprint design created: a plain
+digest per secret would turn the vault directory into a guess-confirmation
+oracle for low-entropy values (`http://127.0.0.1:8080`, `true`, a file path) for
+exactly the attacker envelope encryption exists to stop. A keyed HMAC avoids
+that, but its key must be MEK-wrapped, which means comparison needs an unlock
+anyway - the same constraint, with a format migration attached.
+
+## What `--prune` may delete, and why the rest is out of reach
+
+An earlier draft of this spec argued the command should be read-only outright,
+on the scan-reports/migrate-fixes split. That was the wrong frame: that split is
+about `jit scan` vs `jit migrate`, not about every report. `jit vault orphans
+--prune` and `jit vault prune` are both vault reports with deleting flags, and
+this is the same namespace and the same idiom (confirmation, then a fresh
+user-presence check, since `Remove` only unlinks envelope files and would
+otherwise need no gesture at all).
+
+So `--prune` exists, scoped to the one shape that is unambiguously vault
+garbage: **origin file gone AND referenced by nothing**. That is exactly the
+object class `orphans --prune` already deletes, reached by duplicate evidence
+instead of by reference-counting.
+
+Everything else keeps a printed command, and `--prune` reports what it left
+behind rather than skipping silently (a cleanup that quietly passes over most of
+what it just listed reads as "cleaned everything"):
+
+- **origin file still on disk** - retiring the copy means un-migrating it.
+  Deleting the secrets alone would leave a registered mount serving a FIFO no
+  writer can fill. `jit migrate remove` is the command that already does the
+  whole job, including refusing to delete a secret another project references.
+- **origin gone, but a profile still names the paths** - deleting leaves that
+  manifest pointing at holes. A per-path `jit vault rm` decision.
+- **diverged values, or a shared credential** - not jit's call at all.
+
+The flag is `--prune`, not `--clean`: `jit vault clean` already means "delete
+every secret in the vault", so `--clean` here would read as "delete all the
+duplicates" at the exact moment some findings are shared credentials that must
+be kept.
+
+## Surfaces
+
+1. **Group headers carry provenance** (`sharedGroupNote`). A top-level group whose
+   members share one `Origin` states `class · from <origin> · <age>` once on the
+   header, per the house "shared fact on the group header" rule. A uniformly
+   manual group reads `set directly`; mixed origins say nothing; nested headers
+   never restate the top-level fact; a long origin is middle-truncated to the
+   window and dropped entirely below 12 remaining columns.
+
+   This alone dissolves much of the confusion: `[jamf] 14 · dotenv · from
+   ~/custom_scripts/.env` and `[jamf-2] 8 · dotenv · from
+   ~/custom_scripts/computer_inventory/.env` are visibly two different scripts,
+   not a stale copy, before any detector runs.
+
+2. **The note is origin-backed** and routes to `jit vault duplicates`. It never
+   recommends `rm`. Because origin evidence is strong, it has no key-count floor
+   (the old three-key floor is what hid the single-key caido pair).
+
+3. **`jit vault rm` warns** when a doomed path is still wired, naming the profile
+   and mount and printing the `jit migrate remove` that cleans up properly.
+   Advisory and fail-open (`referencesForPaths` is deliberately lenient where
+   `collectReferencedPaths` is strict - the strict one feeds a deleter, this one
+   feeds a warning).
+
+4. **`jit vault duplicates`** renders the verdicts above, with `--format json`.
+
+5. **Migrate discloses at birth**: storing a value the vault already holds under
+   another group prints one note on the result line. Disclosure only - the file
+   migrates normally into its own profile. Config-named keys (`looksLikeConfig`)
+   and values under 6 bytes are excluded, so `OUTPUT_FILE` and `8080` never read
+   as shared credentials.

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ then **[Install](./getting-started/install.md)** →
 
 - [Store, read, and delete secrets](./vault/index.md) - `set`/`get`/`list`/`rm`, rotating a key, undoing a rotation with `history`/`restore`
 - [Back up and restore](./vault/backup-restore.md) - passphrase-encrypted export/import
-- [Maintenance](./vault/maintenance.md) - `rekey`, `prune`, `clean`, `delete`
+- [Maintenance](./vault/maintenance.md) - `rekey`, `duplicates`, `prune`, `orphans`, `clean`, `delete`
 
 ## The background service
 

--- a/docs/migrate/index.md
+++ b/docs/migrate/index.md
@@ -101,6 +101,14 @@ explicitly: it never scrubs git history, so the old value is still
 recoverable via `git log -p` no matter what happens going forward - rotate
 that credential.
 
+If a file stores a value the vault already holds under another profile -
+the same API client used by several scripts, or a workspace folder you
+copied and migrated twice - `migrate` says so on the result line and keeps
+going. The copy is stored normally under its own profile, because merging
+them would mean one `rm` later breaking every tool that shares it.
+[`jit vault duplicates`](../vault/maintenance.md#jit-vault-duplicates---find-groups-that-hold-the-same-secrets)
+compares the values and says which copies, if any, are safe to retire.
+
 ## What each category turns into
 
 Limit a run to specific categories with `--only`

--- a/docs/reference/commands/jit_vault.md
+++ b/docs/reference/commands/jit_vault.md
@@ -30,6 +30,7 @@ jit vault
 * [jit](jit.md)	 - Local-first developer secret runtime
 * [jit vault clean](jit_vault_clean.md)	 - Delete every secret in the vault (the vault itself stays set up)
 * [jit vault delete](jit_vault_delete.md)	 - Permanently destroy the whole vault, including its encryption key
+* [jit vault duplicates](jit_vault_duplicates.md)	 - Report groups that hold the same secrets, and which are safe to retire
 * [jit vault export](jit_vault_export.md)	 - Export every secret to a passphrase-encrypted local backup file
 * [jit vault get](jit_vault_get.md)	 - Decrypt and print a secret
 * [jit vault history](jit_vault_history.md)	 - List a secret's archived previous versions

--- a/docs/reference/commands/jit_vault_duplicates.md
+++ b/docs/reference/commands/jit_vault_duplicates.md
@@ -1,0 +1,65 @@
+## jit vault duplicates
+
+Report groups that hold the same secrets, and which are safe to retire
+
+### Synopsis
+
+Compares every stored secret's decrypted value in memory (one unlock, no
+value ever printed or written) and reports two things `jit vault list`
+cannot know from names alone:
+
+  Duplicated groups: the same key names migrated from the same file, or
+  from two copies of it (a re-migrated project, a copied workspace tree).
+  When the values still match, the report names the copy that looks stale
+  and the command that retires it cleanly: `jit migrate remove <file>`
+  while the file still exists (it restores that file's plaintext, then
+  deletes its profile and secrets), otherwise --prune or `jit vault rm`.
+  Diverged copies (same file ancestry, different values now) are reported
+  without a removal pick.
+
+  Shared credentials: the same value stored by independent files, e.g.
+  one API client used by five export scripts. These are NOT stale copies,
+  removing any breaks its tool, and the report lists every place a
+  rotation has to reach.
+
+Reporting only by default. --prune deletes the ONE shape that is pure
+vault garbage: a stale copy whose origin file is already gone AND that no
+profile jit can see references, after a [y/N] confirmation and a fresh
+Touch ID/passcode. Everything else keeps its printed command instead, on
+purpose: a copy whose file still exists has to be un-migrated by
+`jit migrate remove` (which restores its plaintext, deregisters its mount
+and drops its profile — deleting just the secrets would leave a mount
+serving a file nothing can fill), a copy a profile still names is a
+per-path `jit vault rm` decision, and diverged or shared copies are never
+jit's call at all. --prune always reports what it left behind and why.
+
+```
+jit vault duplicates [flags]
+```
+
+### Examples
+
+```
+  jit vault duplicates
+  jit vault duplicates --prune
+  jit vault duplicates --format json
+```
+
+### Options
+
+```
+      --format string   output format: "text" (default) or "json" (default "text")
+      --prune           delete stale copies whose origin file is gone and which nothing references
+  -y, --yes             skip the confirmation prompt (never the fingerprint)
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit vault](jit_vault.md)	 - Manage the local encrypted secret vault
+

--- a/docs/vault/index.md
+++ b/docs/vault/index.md
@@ -27,28 +27,45 @@ version timestamps, never a value.
 
 `jit vault set myapp/NEW_KEY` prompts for a value and stores it (add `-f`
 to overwrite an existing path, `--stdin` to pipe the value in);
-`jit vault rm <path>` deletes one secret (it confirms first).
+`jit vault rm <path>` deletes one secret (it confirms first). If a profile
+or a live mount still points at that path, `rm` names it before the
+confirmation: deleting only the secret leaves the mount serving a file
+nothing can fill, so for a migrated file the right cleanup is
+[`jit migrate remove <file>`](../migrate/undo-and-remove.md), which takes
+the file, its profile and its secrets down together.
 `jit vault get <path>` decrypts and prints one (`--copy` sends it to the
 clipboard instead - marked so clipboard managers skip it, and auto-cleared
 after 45 seconds unless you've copied something else by then); on a
 terminal, a footer line follows on stderr with when the secret was
 last updated and which profile uses it - piped output gets the value only.
 `jit vault list` shows what's stored - names and paths only, never values.
-On a terminal, entries group under a header per prefix:
+On a terminal, entries group under a header per prefix, and each group
+states where it came from and how recently it changed:
 
 ```
 $ jit vault list
-myapp/ (2)
-  DATABASE_URL
-  STRIPE_API_KEY
-notion-sync/ (1)
-  NOTION_API_KEY
+[myapp] 2 · dotenv · from ~/code/myapp/.env · 7d ago
+    DATABASE_URL  STRIPE_API_KEY
 
-3 secrets stored, plus 2 encrypted file backups kept for `jit migrate undo` (list with --all).
+[notion-sync] 1 · mcp · from ~/.mcp.json · 2d ago
+    NOTION_API_KEY
+
+3 secrets stored, plus 2 encrypted file backups kept for jit migrate undo (list with --all).
 ```
+
+That header line is what tells two look-alike groups apart: `myapp` and
+`myapp-2` holding the same key names are only a duplicate if they came
+from the same file. A group whose members were migrated from different
+files, or set by hand, says so instead (`set directly`), and a long path
+is truncated rather than wrapped. When two groups do look like one file
+stored twice, a note under the listing points at
+[`jit vault duplicates`](./maintenance.md#jit-vault-duplicates---find-groups-that-hold-the-same-secrets),
+which compares the actual values.
 
 Piped or redirected, output stays one full path per line
 (`myapp/DATABASE_URL`), so it feeds `grep` and scripts unchanged.
+`-l` annotates each secret with its own class and age; `--by origin`
+buckets by source file instead of by path.
 
 With [shell completion](../getting-started/install.md#shell-completion)
 installed, `jit vault get <TAB>` completes stored paths - names only, so
@@ -117,6 +134,7 @@ credential helper.
 
 - **[Back up and restore](./backup-restore.md)** - `vault export` /
   `vault import`, for disaster recovery
-- **[Maintenance](./maintenance.md)** - `rekey` the master key, `prune`
-  stale backups, delete secrets nothing references with `orphans`, `clean`
-  out all secrets, or `delete` the vault entirely
+- **[Maintenance](./maintenance.md)** - `rekey` the master key, find
+  copies of the same secret with `duplicates`, `prune` stale backups,
+  delete secrets nothing references with `orphans`, `clean` out all
+  secrets, or `delete` the vault entirely

--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -3,7 +3,7 @@ title: Vault maintenance
 description: Prune stale file backups, empty the vault, or destroy it entirely.
 ---
 
-# Vault maintenance - `rekey`, `prune`, `orphans`, `clean`, `delete`
+# Vault maintenance - `rekey`, `duplicates`, `prune`, `orphans`, `clean`, `delete`
 
 These commands run in increasing order of severity. The destructive ones
 confirm first (`-y` skips the prompt) and require a fresh Touch ID/passcode.
@@ -21,6 +21,67 @@ any point: both keys exist until the final step, every re-wrapped secret is
 verified before it's written, re-running `jit vault rekey` finishes an
 interrupted rotation, and other vault commands refuse to write while one is
 in progress.
+
+## `jit vault duplicates` - find groups that hold the same secrets
+
+Answers "which of these look-alike groups can I safely delete?" - the
+question a listing can't, because it takes comparing the actual values.
+Under one unlock it decrypts every stored secret in memory (nothing is
+printed or written), then reports:
+
+- **Duplicated groups**: the same key names migrated from the same file, or
+  from two copies of it (a re-migrated project, a copied workspace tree).
+  When the values still match, the report names the copy that looks stale
+  and the command that retires it cleanly. Which command depends on whether
+  the stale copy's file is still on disk:
+
+  | The stale copy's origin file | Command | What it does |
+  |---|---|---|
+  | still there | [`jit migrate remove <file>`](../migrate/undo-and-remove.md) | un-migrates that one file: **writes its values back as plaintext**, then deletes its profile, its secrets and its backups. Delete the file or folder yourself afterwards if you don't want it. |
+  | already gone, nothing references it | `jit vault duplicates --prune` | deletes those secrets for you (see below) |
+  | gone, but a profile still names it | `jit vault rm <paths>` | deletes exactly those secrets, leaving you to fix the profile |
+
+  `migrate remove` never deletes a secret another profile outside that
+  project also references - it keeps and reports it - so retiring one copy
+  cannot break a tool that shares the credential. Copies that have diverged
+  (same ancestry, different values now) are reported without a removal pick:
+  which copy is right is your call.
+- **Shared credentials**: the same value stored by independent files, for
+  example one API client used by five export scripts. These are *not* stale
+  copies - removing any breaks its tool - and the report lists every place
+  a rotation has to reach.
+
+### `--prune`
+
+Reporting is the default. `jit vault duplicates --prune` deletes the one
+shape that is pure vault garbage: a stale copy whose **origin file is gone
+and which no profile references**. It confirms first (`-y` skips the
+prompt) and requires a fresh Touch ID/passcode.
+
+It deliberately will not touch the others, and says so instead of
+reporting a clean sweep:
+
+```
+Deleted 2 duplicated secrets.
+
+Left alone, 2 findings need a command only you should run:
+  └ mcp-caido-2: jit migrate remove ~/Desktop/Share/ai_security_workspace/.mcp.json
+  └ a, b: copies have diverged, compare them first
+```
+
+A copy whose file still exists has to be un-migrated by `jit migrate
+remove`, which restores the plaintext, deregisters the mount and drops the
+profile - deleting just its secrets would leave a live mount serving a file
+nothing can fill. A copy some profile still names is a per-path decision.
+Diverged copies and shared credentials are never jit's call.
+
+Note the neighbouring commands delete different things under the same word:
+`vault prune` deletes file *backups*, `vault orphans --prune` deletes
+*unreferenced* secrets, and this deletes *duplicated* ones. Each
+confirmation names its own.
+
+`jit migrate` also discloses on the spot when a file it is migrating stores
+values the vault already holds under another group.
 
 ## `jit vault prune` - delete stale file backups
 

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -522,6 +522,12 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 	// (pristine) backup of each shared file the only one.
 	backups := migrate.NewBackupTracker()
 
+	// Lazy, once-per-run index of every value already stored, for the
+	// duplicate-disclosure notes below (see migrateduplicates.go). Lazy so
+	// a run that migrates none of the disclosing categories never pays the
+	// full-vault read.
+	dupIdx := &dupIndexOnce{v: v}
+
 	// Each migrated category gets the same "[Label] (N)" header + bullet
 	// shape the plan itself already uses (printMigratePlan/
 	// printMigratePlanCategory) — a real, reported problem: this log used
@@ -557,6 +563,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 				fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`, replaced with a safe pointer file (never mounted; nothing reads a backup file live)\n",
 					displayPath(home, envPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 				noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
+				noteDuplicateValues(out, v, dupIdx.get(), result.ProfileName, result.Variables)
 				continue
 			}
 			if err := addMount(mount.Entry{MountPath: result.EnvPath, ProfilePath: result.ProfilePath}); err != nil {
@@ -567,6 +574,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 			}
 			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n", displayPath(home, envPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
 			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
+			noteDuplicateValues(out, v, dupIdx.get(), result.ProfileName, result.Variables)
 		}
 		fmt.Fprintln(out)
 	}
@@ -736,6 +744,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 					displayPath(home, mcpPath), sm.ServerName, sm.ProfileName, countWord(len(sm.Variables), "var", "vars"), result.BackupPath)))
 				noteNamespaceMove(out, sm.NamespaceMovedFrom, sm.ProfileName)
 				noteRewrap(out, sm.RewrappedFrom)
+				noteDuplicateValues(out, v, dupIdx.get(), sm.ProfileName, sm.Variables)
 			}
 			// A project block that could not be parsed still holds whatever
 			// `jit scan` flagged. Saying nothing here would report success

--- a/internal/cli/migrateduplicates.go
+++ b/internal/cli/migrateduplicates.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// Migrate-time duplicate disclosure: when a migration stores a value the
+// vault already holds under another group, say so on the spot — the moment
+// the copy is born, not months later in a listing. Disclosure only, by the
+// annotate-never-collapse decision: the file still migrates normally into
+// its own profile (collapsing copies would change who breaks when one is
+// later removed), and the note routes to `jit vault duplicates` for the
+// full comparison and remedy.
+
+// buildVaultValueIndex digests every secret ALREADY stored before this run
+// writes anything, mapping value digest -> the first vault path holding it.
+// Values are hashed as read and never kept. Best-effort: an unreadable
+// envelope is skipped, and a nil index (a listing failure) simply disables
+// the notes — disclosure must never fail a migration.
+func buildVaultValueIndex(v *vault.Vault) map[string]string {
+	paths, err := v.List()
+	if err != nil {
+		return nil
+	}
+	secrets, _ := splitBackupPaths(paths)
+	idx := make(map[string]string, len(secrets))
+	for _, p := range secrets {
+		value, err := v.Get(p)
+		if err != nil {
+			continue
+		}
+		sum := sha256.Sum256(value)
+		key := fmt.Sprintf("%x", sum)
+		if _, ok := idx[key]; !ok {
+			idx[key] = p
+		}
+	}
+	return idx
+}
+
+// minDuplicateValueLen keeps trivially-coincidental values ("true", a port
+// number) from reading as duplicates; a real credential or endpoint is
+// comfortably longer.
+const minDuplicateValueLen = 6
+
+// noteDuplicateValues prints one note under a migrated file's result line
+// when values just stored under profileName duplicate what other groups
+// already held. Key names that look like plain configuration are skipped on
+// sharedCredentialFindings' reasoning (two scripts sharing OUTPUT_FILE is
+// not a duplicate credential), as are very short values.
+func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string]string, profileName string, vars []string) {
+	if len(idx) == 0 {
+		return
+	}
+	dupCount := 0
+	groupSet := map[string]bool{}
+	for _, name := range vars {
+		if looksLikeConfig(name) {
+			continue
+		}
+		value, err := v.Get(profileName + "/" + name)
+		if err != nil || len(value) < minDuplicateValueLen {
+			continue
+		}
+		sum := sha256.Sum256(value)
+		existing, ok := idx[fmt.Sprintf("%x", sum)]
+		if !ok {
+			continue
+		}
+		if g := groupPrefix(existing); g != profileName {
+			dupCount++
+			groupSet[g] = true
+		}
+	}
+	if dupCount == 0 {
+		return
+	}
+	groups := make([]string, 0, len(groupSet))
+	for g := range groupSet {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+	fmt.Fprint(out, hlCmds(fmt.Sprintf("    note: %s already stored under %s, see `jit vault duplicates`\n",
+		countWord(dupCount, "value is", "values are"), truncateList(groups, 3))))
+}
+
+// dupIndexOnce builds the value index lazily, once per migrate run, and
+// only when a category that discloses duplicates actually applied a file.
+type dupIndexOnce struct {
+	v     *vault.Vault
+	built bool
+	idx   map[string]string
+}
+
+func (d *dupIndexOnce) get() map[string]string {
+	if !d.built {
+		d.built = true
+		d.idx = buildVaultValueIndex(d.v)
+	}
+	return d.idx
+}

--- a/internal/cli/migrateduplicates_test.go
+++ b/internal/cli/migrateduplicates_test.go
@@ -1,0 +1,68 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// TestNoteDuplicateValues pins migrate's duplicate disclosure: a value the
+// vault already held under another group gets one note routing to
+// `jit vault duplicates`, while config-named keys, trivially short values,
+// the profile's own paths, and a missing index all stay silent — and the
+// note never blocks or changes the migration itself (it only prints).
+func TestNoteDuplicateValues(t *testing.T) {
+	withFixtureHome(t)
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+	set := func(path, value string) {
+		t.Helper()
+		if err := v.Set(path, []byte(value)); err != nil {
+			t.Fatalf("Set(%s): %v", path, err)
+		}
+	}
+
+	// The pre-existing copy, then the index snapshot, then the "migration".
+	set("mcp-caido/CAIDO_URL", "http://127.0.0.1:8080")
+	set("mcp-caido/OUTPUT_FILE", "/tmp/out.json")
+	idx := buildVaultValueIndex(v)
+	set("mcp-caido-2/CAIDO_URL", "http://127.0.0.1:8080") // duplicate value
+	set("mcp-caido-2/OUTPUT_FILE", "/tmp/out.json")       // duplicate but config-named
+	set("mcp-caido-2/DEPTH", "8080")                      // short: coincidence fodder
+
+	var buf bytes.Buffer
+	noteDuplicateValues(&buf, v, idx, "mcp-caido-2", []string{"CAIDO_URL", "OUTPUT_FILE", "DEPTH"})
+	out := buf.String()
+	if !strings.Contains(out, "1 value is already stored under mcp-caido") ||
+		!strings.Contains(out, "jit vault duplicates") {
+		t.Errorf("expected one duplicate note naming the group, got:\n%s", out)
+	}
+	if strings.Contains(out, "OUTPUT_FILE") || strings.Contains(out, "2 values") {
+		t.Errorf("config-named and short values must not count, got:\n%s", out)
+	}
+
+	// Re-noting the ORIGINAL profile against an index that holds its own
+	// paths must stay silent — a group is never its own duplicate.
+	buf.Reset()
+	noteDuplicateValues(&buf, v, buildVaultValueIndex(v), "mcp-caido", []string{"CAIDO_URL"})
+	if strings.Contains(buf.String(), "already stored under mcp-caido,") {
+		t.Errorf("a profile must not report itself, got:\n%s", buf.String())
+	}
+
+	// A nil index (listing failed) disables disclosure, never errors.
+	buf.Reset()
+	noteDuplicateValues(&buf, v, nil, "mcp-caido-2", []string{"CAIDO_URL"})
+	if buf.Len() != 0 {
+		t.Errorf("nil index must print nothing, got:\n%s", buf.String())
+	}
+}

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -177,18 +178,27 @@ func printVaultList(out io.Writer, secrets, backups []string, showBackups, group
 	// piped/grep listing (grouped == false) and the provenance axes stay
 	// uncluttered.
 	if grouped && axis == "path" {
-		printDuplicateGroupNudge(out, secrets)
+		printDuplicateGroupNudge(out, secrets, meta)
 	}
 }
 
-// printDuplicateGroupNudge emits one hint when two or more top-level
-// groups hold an identical set of key names — the "wiz/ and
-// custom_scripts-wiz/ are the same five WIZ_ keys" case, a common sign of an
-// accidentally re-migrated file. Conservative on purpose: it fires only for
-// sets of at least three keys, so intentional small look-alikes (a couple of
-// sandboxes each holding DATABASE_URL + STRIPE_KEY) don't trip it.
-func printDuplicateGroupNudge(out io.Writer, secrets []string) {
-	const minKeys = 3
+// printDuplicateGroupNudge emits one hint when two or more top-level groups
+// look like the same file stored twice: an identical set of key names AND
+// origins that agree — either literally the same recorded path (a
+// re-migration that forked a namespace) or the same file in two directories
+// (a copied project tree, e.g. ~/Documents/ws/.mcp.json and
+// ~/Desktop/Share/ws/.mcp.json both migrated). Key names alone are NOT
+// evidence and no longer nudge: on a real vault, five separate export
+// scripts each legitimately held the same Jamf client keys, and the old
+// key-set-only rule told the user to `jit vault rm` copies that were all
+// live. Origin matching is what separates "one file, twice" from "one
+// credential, many tools" — and it is strong enough evidence that even a
+// one-key group (the case the old three-key floor existed to filter) may
+// fire. Groups with no recorded origin, or members that disagree, stay
+// silent. The nudge names the evidence and routes to `jit vault duplicates`
+// (which compares actual values under an unlock) rather than telling anyone
+// to delete on filename evidence alone.
+func printDuplicateGroupNudge(out io.Writer, secrets []string, meta map[string]vault.SecretInfo) {
 	members := map[string][]string{} // top-level group -> its sub-paths
 	var order []string
 	for _, p := range secrets {
@@ -202,36 +212,84 @@ func printDuplicateGroupNudge(out io.Writer, secrets []string) {
 		}
 		members[g] = append(members[g], p[slash+1:])
 	}
-	bySignature := map[string][]string{} // key-set signature -> group names
+	// A group participates only with a uniform recorded origin.
+	groupOrigin := func(g string) string {
+		origin := ""
+		for i, key := range members[g] {
+			info, ok := meta[g+"/"+key]
+			if !ok || info.Origin == "" {
+				return ""
+			}
+			if i == 0 {
+				origin = info.Origin
+			} else if info.Origin != origin {
+				return ""
+			}
+		}
+		return origin
+	}
+	// Cluster on key set + origin tail (the file's own name under its
+	// parent directory): equal origins share a tail by construction, and a
+	// copied tree keeps the tail while the prefix moves. One extra segment
+	// beyond the basename on purpose — every project has a ".mcp.json", so
+	// the bare basename would call two unrelated projects' configs copies.
+	type cluster struct {
+		groups  []string
+		origins []string
+	}
+	byEvidence := map[string]*cluster{}
+	var clusterOrder []string
 	for _, g := range order {
-		keys := members[g]
-		if len(keys) < minKeys {
+		origin := groupOrigin(g)
+		if origin == "" {
 			continue
 		}
-		sorted := append([]string(nil), keys...)
-		sort.Strings(sorted)
-		sig := strings.Join(sorted, "\x00")
-		bySignature[sig] = append(bySignature[sig], g)
+		keys := append([]string(nil), members[g]...)
+		sort.Strings(keys)
+		sig := strings.Join(keys, "\x00") + "\x00\x00" + originTail(origin)
+		if _, ok := byEvidence[sig]; !ok {
+			byEvidence[sig] = &cluster{}
+			clusterOrder = append(clusterOrder, sig)
+		}
+		byEvidence[sig].groups = append(byEvidence[sig].groups, g)
+		byEvidence[sig].origins = append(byEvidence[sig].origins, origin)
 	}
-	var dupes [][]string
-	for _, g := range order {
-		keys := members[g]
-		if len(keys) < minKeys {
+	for _, sig := range clusterOrder {
+		c := byEvidence[sig]
+		if len(c.groups) < 2 {
 			continue
 		}
-		sorted := append([]string(nil), keys...)
-		sort.Strings(sorted)
-		sig := strings.Join(sorted, "\x00")
-		if groups := bySignature[sig]; len(groups) > 1 && groups[0] == g {
-			dupes = append(dupes, groups) // report once, at the first group
+		sameOrigin := true
+		for _, o := range c.origins[1:] {
+			if o != c.origins[0] {
+				sameOrigin = false
+				break
+			}
 		}
+		names := strings.Join(c.groups, ", ")
+		if sameOrigin {
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("note: %s were migrated from the same file (%s), see `jit vault duplicates`.\n",
+				names, shortPath(c.origins[0]))))
+			continue
+		}
+		copies := "two copies"
+		if len(c.groups) > 2 {
+			copies = fmt.Sprintf("%d copies", len(c.groups))
+		}
+		fmt.Fprint(out, hlCmds(fmt.Sprintf("note: %s hold the same keys from %s of %s, see `jit vault duplicates`.\n",
+			names, copies, originTail(c.origins[0]))))
 	}
-	if len(dupes) == 0 {
-		return
+}
+
+// originTail is an origin path's identifying suffix — its final segment
+// under its parent directory ("ws/.mcp.json") — the piece a copied tree
+// preserves while its location changes.
+func originTail(origin string) string {
+	dir := filepath.Base(filepath.Dir(origin))
+	if dir == "." || dir == string(filepath.Separator) || dir == "/" {
+		return filepath.Base(origin)
 	}
-	for _, groups := range dupes {
-		fmt.Fprint(out, hlCmds(fmt.Sprintf("note: %s hold the same keys, a re-migrated file? `jit vault rm` the stale copy.\n", strings.Join(groups, ", "))))
-	}
+	return dir + "/" + filepath.Base(origin)
 }
 
 // printGroupedSecrets renders secrets as an indented tree, nesting on every
@@ -286,7 +344,8 @@ func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth i
 				fmt.Fprintln(out)
 			}
 			printSecretGroupHeader(out, indent, paths[i][:slash], j-i,
-				sharedGroupNote(paths[i:j], ancestorPath, meta))
+				sharedGroupNote(paths[i:j], ancestorPath, meta,
+					groupHeaderUsed(indent, paths[i][:slash], j-i), depth == 0))
 			sub := make([]string, j-i)
 			for k := i; k < j; k++ {
 				sub[k-i] = paths[k][len(seg):]
@@ -326,7 +385,8 @@ func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth i
 			fmt.Fprintln(out)
 		}
 		printSecretGroupHeader(out, indent, paths[i][:slash], j-i,
-			sharedGroupNote(paths[i:j], ancestorPath, meta))
+			sharedGroupNote(paths[i:j], ancestorPath, meta,
+				groupHeaderUsed(indent, paths[i][:slash], j-i), depth == 0))
 		sub := make([]string, j-i)
 		for k := i; k < j; k++ {
 			sub[k-i] = paths[k][len(seg):]
@@ -350,6 +410,13 @@ func printSecretGroupHeader(out io.Writer, indent, name string, n int, note stri
 	_, _ = fmt.Fprintf(out, " %d\n", n)
 }
 
+// groupHeaderUsed is how many columns printSecretGroupHeader's own prefix
+// ("[name] N") occupies before the note starts — what sharedGroupNote
+// budgets the origin against.
+func groupHeaderUsed(indent, name string, n int) int {
+	return len(fmt.Sprintf("%s[%s] %d", indent, name, n))
+}
+
 // sharedGroupNote is the Tree shape's per-group note: one fact every member
 // of the group shares, stated once on the header instead of repeated down the
 // column (design/output-style.md — "a shared per-group note is stated once on
@@ -368,28 +435,94 @@ func printSecretGroupHeader(out io.Writer, indent, name string, n int, note stri
 // where it is actionable: as "unknown" per secret under -l, and grouped
 // under `--by origin`.
 //
+// A top-level group additionally reports where its members came from and how
+// fresh they are: "from <origin> · <age>" when every member shares one
+// recorded Origin, or "set directly" for a uniformly manual group (that class
+// MEANS `jit vault set`, so the phrase is a fact, not absence-reporting). This
+// is what lets look-alike groups tell themselves apart in the listing —
+// [jamf-2] from ~/custom_scripts/computer_inventory/.env is visibly not a
+// stale copy of [jamf] from ~/custom_scripts/.env, and two migrations of a
+// copied file show two origins one line apart. Nested headers skip it: the
+// tree nests on path segments of ONE group, so every nested header would
+// restate the top-level fact. The age is the newest member's last update,
+// one clock for every group whatever its class.
+//
+// used is how many columns the caller's header prefix ("[name] N") already
+// occupies; a long origin is middle-truncated to what remains of the window
+// (truncate, never wrap — house rule), and dropped entirely when fewer than
+// originMinWidth columns remain, because a five-character sliver of a path
+// identifies nothing.
+//
 // paths are relative to ancestorPath (what printSecretTree has consumed so
 // far), so the two rejoin to the real vault path meta is keyed by.
-func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.SecretInfo) string {
+func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.SecretInfo, used int, topLevel bool) string {
 	if len(meta) == 0 || len(paths) == 0 {
 		return ""
 	}
-	class := ""
+	class, origin := "", ""
+	classUniform, originUniform := true, true
+	var newest int64
 	for i, rel := range paths {
 		info, ok := meta[ancestorPath+rel]
 		if !ok {
 			return "" // a member we know nothing about: claim nothing
 		}
 		if i == 0 {
-			class = info.Class
-			continue
+			class, origin = info.Class, info.Origin
+		} else {
+			if info.Class != class {
+				classUniform = false
+			}
+			if info.Origin != origin {
+				originUniform = false
+			}
 		}
-		if info.Class != class {
-			return "" // members disagree
+		if info.UpdatedUnix > newest {
+			newest = info.UpdatedUnix
 		}
 	}
-	return class
+	var parts []string
+	if classUniform && class != "" {
+		parts = append(parts, class)
+	}
+	if !topLevel {
+		return strings.Join(parts, " · ")
+	}
+	age := ""
+	if newest > 0 {
+		age = humanAgo(time.Since(time.Unix(newest, 0))) + " ago"
+	}
+	src := ""
+	switch {
+	case originUniform && origin != "":
+		src = "from " + shortPath(origin)
+	case classUniform && class == vault.ClassManual && originUniform && origin == "":
+		src = "set directly"
+	}
+	if src != "" {
+		// Budget: prefix + " · " joins + this src + the age still to come.
+		avail := outputWidth() - used
+		for _, p := range parts {
+			avail -= len(p) + 3
+		}
+		avail -= 3 // src's own " · "
+		if age != "" {
+			avail -= len(age) + 3
+		}
+		if avail >= originMinWidth {
+			parts = append(parts, promptEllipsis(src, avail))
+		}
+	}
+	if age != "" {
+		parts = append(parts, age)
+	}
+	return strings.Join(parts, " · ")
 }
+
+// originMinWidth is the narrowest rendering of a group's origin worth
+// printing — below it, sharedGroupNote drops the origin rather than showing
+// an unidentifiable sliver of path.
+const originMinWidth = 12
 
 // validateListBy guards the --by axis. "path" is the default first-segment
 // grouping; "origin"/"group" bucket by provenance instead.
@@ -944,6 +1077,19 @@ var vaultRmCmd = &cobra.Command{
 		for _, path := range args {
 			if err := vault.ValidatePath(path); err != nil {
 				return fmt.Errorf("jit vault rm: %w", err)
+			}
+		}
+
+		// Advisory, before the confirmation: name whatever still points at
+		// each doomed path. rm deletes only the envelope file, so a wired
+		// secret leaves its profile naming a hole and its mount serving a
+		// FIFO nothing can fill — the user should learn that here, not
+		// from a hung tool an hour later. Best-effort by design (see
+		// referencesForPaths); a lookup failure changes nothing about the
+		// delete itself.
+		if root, err := vaultRootDir(); err == nil {
+			if cwd, err := os.Getwd(); err == nil {
+				printRmReferenceWarnings(cmd.OutOrStdout(), referencesForPaths(root, cwd, args))
 			}
 		}
 

--- a/internal/cli/vault_test.go
+++ b/internal/cli/vault_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/termtext"
 	"github.com/jitpass/jit/internal/vault"
 )
 
@@ -815,6 +816,69 @@ func TestPrintVaultListLong(t *testing.T) {
 	}
 }
 
+// TestGroupHeaderProvenance pins the top-level group header's provenance
+// note: a group whose members share one recorded Origin states it once on
+// the header with the newest member's age ("dotenv · from <origin> · 2d
+// ago"), a uniformly manual group reads "set directly", mixed origins say
+// nothing, nested headers never restate the top-level fact, and an origin
+// too long for the window is truncated, never wrapped.
+func TestGroupHeaderProvenance(t *testing.T) {
+	now := time.Now().Unix()
+	secrets := []string{
+		"jamf/CLIENT_ID", "jamf/CLIENT_SECRET",
+		"manual-grp/KEY_A", "manual-grp/KEY_B",
+		"mixed/ONE", "mixed/TWO",
+		"nested/sub/KEY",
+	}
+	meta := map[string]vault.SecretInfo{
+		"jamf/CLIENT_ID":     {Class: vault.ClassDotenv, Origin: "/x/scripts/jamf/.env", UpdatedUnix: now - 3*24*3600},
+		"jamf/CLIENT_SECRET": {Class: vault.ClassDotenv, Origin: "/x/scripts/jamf/.env", UpdatedUnix: now - 9*24*3600},
+		"manual-grp/KEY_A":   {Class: vault.ClassManual, UpdatedUnix: now - 3600},
+		"manual-grp/KEY_B":   {Class: vault.ClassManual, UpdatedUnix: now - 7200},
+		"mixed/ONE":          {Class: vault.ClassDotenv, Origin: "/x/a/.env", UpdatedUnix: now},
+		"mixed/TWO":          {Class: vault.ClassDotenv, Origin: "/x/b/.env", UpdatedUnix: now},
+		"nested/sub/KEY":     {Class: vault.ClassMCP, Origin: "/x/n/.mcp.json", UpdatedUnix: now},
+	}
+
+	var buf bytes.Buffer
+	printVaultList(&buf, secrets, nil, false, true, false, meta, "path")
+	out := buf.String()
+
+	if !strings.Contains(out, "[jamf] 2 · dotenv · from /x/scripts/jamf/.env · 3d ago") {
+		t.Errorf("uniform-origin group must carry origin + newest age on its header, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[manual-grp] 2 · manual · set directly · 1h ago") {
+		t.Errorf("uniformly manual group must read \"set directly\", got:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "[mixed]") && strings.Contains(line, "from ") {
+			t.Errorf("mixed-origin group must not claim an origin, got line:\n%s", line)
+		}
+		// The nested [sub] header must not restate what [nested] already
+		// carries.
+		if strings.Contains(line, "[sub]") && (strings.Contains(line, "from ") || strings.Contains(line, "ago")) {
+			t.Errorf("nested header must not restate provenance, got line:\n%s", line)
+		}
+	}
+	if !strings.Contains(out, "[nested] 1 · mcp · from /x/n/.mcp.json") {
+		t.Errorf("top-level header of a nested group carries the provenance, got:\n%s", out)
+	}
+
+	// An origin longer than the window is middle-truncated onto the one
+	// header line, and a window too narrow for any useful origin drops it.
+	long := "/very/long/prefix/" + strings.Repeat("deep/", 30) + ".env"
+	buf.Reset()
+	printVaultList(&buf, []string{"big/KEY"}, nil, false, true, false,
+		map[string]vault.SecretInfo{"big/KEY": {Class: vault.ClassDotenv, Origin: long, UpdatedUnix: now}}, "path")
+	header, _, _ := strings.Cut(buf.String(), "\n")
+	if w := termtext.VisibleWidth(header); w > 80 {
+		t.Errorf("header must truncate to the window, got %d columns:\n%s", w, header)
+	}
+	if !strings.Contains(header, "…") {
+		t.Errorf("a too-long origin must be visibly truncated, got:\n%s", header)
+	}
+}
+
 // TestPrintSecretsByProvenance pins --by origin: secrets bucket under their
 // source file (with class + count), a distinct file makes a distinct bucket,
 // and provenance-less secrets collect under "no recorded source" last.
@@ -913,26 +977,87 @@ func TestLooksLikeConfig(t *testing.T) {
 	}
 }
 
-// TestPrintDuplicateGroupNudge: identical key sets across groups trigger one
-// hint, but small look-alikes (2 keys) and genuinely distinct groups don't.
+// TestPrintDuplicateGroupNudge pins the origin-backed duplicate hint: the
+// nudge fires only when groups share both their key set AND origin evidence
+// (the same recorded file, or the same file's tail in two directories), it
+// routes to `jit vault duplicates` rather than telling anyone to rm, and —
+// the regression that motivated the rewrite — same key names from DIFFERENT
+// live files stay silent, because five export scripts sharing Jamf keys are
+// not stale copies of each other.
 func TestPrintDuplicateGroupNudge(t *testing.T) {
-	// wiz/ and custom_scripts-wiz/ share five keys -> nudge.
-	dup := []string{
-		"wiz/A", "wiz/B", "wiz/C", "wiz/D",
-		"custom_scripts-wiz/A", "custom_scripts-wiz/B", "custom_scripts-wiz/C", "custom_scripts-wiz/D",
+	origin := func(paths []string, o string) map[string]vault.SecretInfo {
+		m := map[string]vault.SecretInfo{}
+		for _, p := range paths {
+			m[p] = vault.SecretInfo{Origin: o}
+		}
+		return m
 	}
-	var buf bytes.Buffer
-	printDuplicateGroupNudge(&buf, dup)
-	if !strings.Contains(buf.String(), "wiz/, custom_scripts-wiz/") && !strings.Contains(buf.String(), "hold the same keys") {
-		t.Errorf("expected a duplicate-group nudge, got:\n%s", buf.String())
+	merge := func(ms ...map[string]vault.SecretInfo) map[string]vault.SecretInfo {
+		out := map[string]vault.SecretInfo{}
+		for _, m := range ms {
+			for k, v := range m {
+				out[k] = v
+			}
+		}
+		return out
 	}
 
-	// Two-key sandboxes are below the threshold -> silence.
+	// The same file migrated into two namespaces -> nudge naming the file.
+	sameFile := []string{"wiz/A", "wiz/B", "wiz-2/A", "wiz-2/B"}
+	meta := merge(
+		origin([]string{"wiz/A", "wiz/B"}, "/u/x/scripts/.env"),
+		origin([]string{"wiz-2/A", "wiz-2/B"}, "/u/x/scripts/.env"),
+	)
+	var buf bytes.Buffer
+	printDuplicateGroupNudge(&buf, sameFile, meta)
+	if !strings.Contains(buf.String(), "wiz, wiz-2 were migrated from the same file") ||
+		!strings.Contains(buf.String(), "jit vault duplicates") {
+		t.Errorf("expected a same-file nudge routing to jit vault duplicates, got:\n%s", buf.String())
+	}
+
+	// Two copies of one file in different trees -> nudge naming the tail,
+	// even for a single-key group (origin evidence needs no key-count floor).
+	copied := []string{"mcp-caido/CAIDO_URL", "mcp-caido-2/CAIDO_URL"}
+	meta = merge(
+		origin([]string{"mcp-caido/CAIDO_URL"}, "/u/x/Documents/ws/.mcp.json"),
+		origin([]string{"mcp-caido-2/CAIDO_URL"}, "/u/x/Desktop/Share/ws/.mcp.json"),
+	)
 	buf.Reset()
-	small := []string{"sandbox/DATABASE_URL", "sandbox/STRIPE_KEY", "sandbox-2/DATABASE_URL", "sandbox-2/STRIPE_KEY"}
-	printDuplicateGroupNudge(&buf, small)
+	printDuplicateGroupNudge(&buf, copied, meta)
+	if !strings.Contains(buf.String(), "two copies of ws/.mcp.json") {
+		t.Errorf("expected a copied-file nudge naming the tail, got:\n%s", buf.String())
+	}
+
+	// Same key names from different live files -> silence. This is the
+	// shared-credential shape the old key-set-only nudge mislabeled.
+	shared := []string{
+		"export-a/JAMF_CLIENT_ID", "export-a/JAMF_CLIENT_SECRET", "export-a/JAMF_URL",
+		"export-b/JAMF_CLIENT_ID", "export-b/JAMF_CLIENT_SECRET", "export-b/JAMF_URL",
+	}
+	meta = merge(
+		origin([]string{"export-a/JAMF_CLIENT_ID", "export-a/JAMF_CLIENT_SECRET", "export-a/JAMF_URL"}, "/u/x/scripts/inventory/.env"),
+		origin([]string{"export-b/JAMF_CLIENT_ID", "export-b/JAMF_CLIENT_SECRET", "export-b/JAMF_URL"}, "/u/x/scripts/computers/.env"),
+	)
+	buf.Reset()
+	printDuplicateGroupNudge(&buf, shared, meta)
 	if buf.Len() != 0 {
-		t.Errorf("2-key look-alikes must not nudge, got:\n%s", buf.String())
+		t.Errorf("same keys from different files must not nudge, got:\n%s", buf.String())
+	}
+
+	// No recorded origin -> key names alone are not evidence -> silence.
+	buf.Reset()
+	printDuplicateGroupNudge(&buf, sameFile, map[string]vault.SecretInfo{})
+	if buf.Len() != 0 {
+		t.Errorf("origin-less groups must not nudge, got:\n%s", buf.String())
+	}
+	// The rm footgun must be gone from every nudge.
+	buf.Reset()
+	printDuplicateGroupNudge(&buf, sameFile, merge(
+		origin([]string{"wiz/A", "wiz/B"}, "/u/x/scripts/.env"),
+		origin([]string{"wiz-2/A", "wiz-2/B"}, "/u/x/scripts/.env"),
+	))
+	if strings.Contains(buf.String(), "vault rm") {
+		t.Errorf("the nudge must never recommend rm on listing evidence, got:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -1,0 +1,578 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// jit vault duplicates is the answer to "which of these look-alike groups
+// can I safely delete?" — the question `jit vault list`'s nudge raises but
+// cannot answer, because answering takes evidence no listing may gather:
+// whether the VALUES actually match, which only exists behind an unlock.
+//
+// It decrypts every stored secret in memory, compares hashes, and prints a
+// verdict per finding with the exact remedy command. Reporting is the
+// default; --prune acts on ONE shape only, the stale copy whose origin file
+// is gone and which nothing references — pure vault garbage, the same
+// object class `jit vault orphans --prune` already deletes, reached here by
+// duplicate evidence rather than by reference-counting.
+//
+// Every other shape keeps a printed command instead, because the correct
+// cleanup is not "delete these secrets":
+//
+//   - origin file still on disk -> `jit migrate remove <file>`. Retiring
+//     that copy means un-migrating it (restore its plaintext, deregister
+//     its mount, drop its profile). Deleting only the secrets would leave a
+//     registered mount serving a FIFO no writer can fill.
+//   - origin gone but a profile still names the paths -> `jit vault rm`,
+//     per path, since deleting them leaves that manifest pointing at holes.
+//   - values diverged, or the groups are a shared credential -> no removal
+//     at all; neither is jit's call.
+//
+// --prune always reports what it left behind and why. A cleanup that
+// silently skips most of what it listed reads as "cleaned everything".
+
+// dupGroup is one top-level vault group with everything the verdicts need:
+// its sorted key names, its uniform recorded origin (empty when absent or
+// mixed), whether that origin still exists on disk, what references it, and
+// a per-key digest of its decrypted values.
+type dupGroup struct {
+	name         string
+	keys         []string          // sorted key names
+	origin       string            // uniform recorded origin, "" when absent/mixed
+	originExists bool              // stat of origin, false when origin == ""
+	profiles     []string          // referencing profile names (deduped)
+	mountPath    string            // a mount serving this group's profile, "" when none
+	hashes       map[string]string // key -> value digest
+}
+
+// dupFinding is one same-file verdict: two or more groups holding the same
+// key set from the same file (or two copies of it), with the value
+// comparison's result and the routed remedy.
+type dupFinding struct {
+	Groups      []string `json:"groups"`
+	Keys        []string `json:"keys"`
+	Origins     []string `json:"origins"` // parallel to Groups
+	SameOrigin  bool     `json:"same_origin"`
+	ValuesMatch bool     `json:"values_match"`
+	// RemoveGroup/RemoveCommand: the copy the report suggests retiring and
+	// the command that retires it correctly. Empty when values differ —
+	// diverged copies are the user's call, not a heuristic's.
+	RemoveGroup   string `json:"remove_group,omitempty"`
+	RemoveCommand string `json:"remove_command,omitempty"`
+	// Prunable marks the findings `--prune` may delete itself: the stale
+	// copy's origin file is GONE and no profile jit can see references it,
+	// so its secrets are vault garbage with nothing live behind them. See
+	// vaultDuplicatesCmd's Long for why the other shapes are deliberately
+	// out of --prune's reach.
+	Prunable bool `json:"prunable"`
+	// RemovePaths are the stale copy's vault paths, what --prune deletes.
+	RemovePaths []string `json:"remove_paths,omitempty"`
+}
+
+// sharedFinding is one shared-credential verdict: the same value stored
+// under the same key names by independent files. Not a problem — the point
+// of reporting it is to STOP these being mistaken for stale copies, and to
+// name every place a rotation has to reach.
+type sharedFinding struct {
+	Keys   []string `json:"keys"`
+	Groups []string `json:"groups"`
+}
+
+var (
+	vaultDuplicatesFormat string
+	vaultDuplicatesPrune  bool
+	vaultDuplicatesYes    bool
+)
+
+var vaultDuplicatesCmd = &cobra.Command{
+	Use:   "duplicates",
+	Short: "Report groups that hold the same secrets, and which are safe to retire",
+	Long: "Compares every stored secret's decrypted value in memory (one unlock, no\n" +
+		"value ever printed or written) and reports two things `jit vault list`\n" +
+		"cannot know from names alone:\n\n" +
+		"  " + "Duplicated groups: the same key names migrated from the same file, or\n" +
+		"  from two copies of it (a re-migrated project, a copied workspace tree).\n" +
+		"  When the values still match, the report names the copy that looks stale\n" +
+		"  and the command that retires it cleanly: `jit migrate remove <file>`\n" +
+		"  while the file still exists (it restores that file's plaintext, then\n" +
+		"  deletes its profile and secrets), otherwise --prune or `jit vault rm`.\n" +
+		"  Diverged copies (same file ancestry, different values now) are reported\n" +
+		"  without a removal pick.\n\n" +
+		"  Shared credentials: the same value stored by independent files, e.g.\n" +
+		"  one API client used by five export scripts. These are NOT stale copies,\n" +
+		"  removing any breaks its tool, and the report lists every place a\n" +
+		"  rotation has to reach.\n\n" +
+		"Reporting only by default. --prune deletes the ONE shape that is pure\n" +
+		"vault garbage: a stale copy whose origin file is already gone AND that no\n" +
+		"profile jit can see references, after a [y/N] confirmation and a fresh\n" +
+		"Touch ID/passcode. Everything else keeps its printed command instead, on\n" +
+		"purpose: a copy whose file still exists has to be un-migrated by\n" +
+		"`jit migrate remove` (which restores its plaintext, deregisters its mount\n" +
+		"and drops its profile — deleting just the secrets would leave a mount\n" +
+		"serving a file nothing can fill), a copy a profile still names is a\n" +
+		"per-path `jit vault rm` decision, and diverged or shared copies are never\n" +
+		"jit's call at all. --prune always reports what it left behind and why.",
+	Example: "  jit vault duplicates\n" +
+		"  jit vault duplicates --prune\n" +
+		"  jit vault duplicates --format json",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := validateOutputFormat(vaultDuplicatesFormat); err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		out := cmd.OutOrStdout()
+		root, err := vaultRootDir()
+		if err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+
+		v, err := openVault()
+		if err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		paths, err := v.List()
+		if err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		secrets, _ := splitBackupPaths(paths)
+
+		groups, compared, err := gatherDupGroups(v, root, cwd, secrets)
+		if err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		findings := sameFileFindings(groups)
+		shared := sharedCredentialFindings(groups, findings)
+
+		if vaultDuplicatesFormat == "json" {
+			if err := writeJSON(out, struct {
+				Findings          []dupFinding    `json:"findings"`
+				SharedCredentials []sharedFinding `json:"shared_credentials"`
+				SecretsCompared   int             `json:"secrets_compared"`
+			}{findings, shared, compared}); err != nil {
+				return fmt.Errorf("jit vault duplicates: %w", err)
+			}
+			if !vaultDuplicatesPrune {
+				return nil
+			}
+		} else {
+			printDuplicatesReport(out, findings, shared, compared)
+		}
+		if !vaultDuplicatesPrune {
+			return nil
+		}
+		if err := pruneDuplicates(cmd, v, findings); err != nil {
+			return fmt.Errorf("jit vault duplicates: %w", err)
+		}
+		return nil
+	},
+}
+
+// pruneDuplicates deletes the prunable findings' stale copies: origin file
+// gone, referenced by nothing. Everything else is reported as left behind
+// with the command that would retire it — a silent skip would read as
+// "cleaned everything" when it hadn't.
+func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) error {
+	out := cmd.OutOrStdout()
+	if vaultDuplicatesFormat == "json" {
+		out = cmd.ErrOrStderr() // stdout already carries the machine output
+	}
+	var paths []string
+	var left []dupFinding
+	prunableGroups := 0
+	for _, f := range findings {
+		if f.Prunable {
+			paths = append(paths, f.RemovePaths...)
+			prunableGroups++
+			continue
+		}
+		if f.RemoveCommand != "" || !f.ValuesMatch {
+			left = append(left, f)
+		}
+	}
+	reportLeft := func() {
+		if len(left) == 0 {
+			return
+		}
+		fmt.Fprintf(out, "\nLeft alone, %s %s a command only you should run:\n",
+			countWord(len(left), "finding", "findings"),
+			pluralWord(len(left), "needs", "need"))
+		for _, f := range left {
+			if !f.ValuesMatch {
+				fmt.Fprintf(out, "  %s %s: copies have diverged, compare them first\n",
+					glyphBranch, strings.Join(f.Groups, ", "))
+				continue
+			}
+			fmt.Fprintf(out, "  %s %s: ", glyphBranch, f.RemoveGroup)
+			_, _ = cPath.Fprintln(out, f.RemoveCommand)
+		}
+	}
+	if len(paths) == 0 {
+		fmt.Fprintln(out, "\nNothing to prune: no duplicate's stale copy is both file-less and unreferenced.")
+		reportLeft()
+		return nil
+	}
+	fmt.Fprintf(out, "\nPruning %s from %s whose origin file is gone and which nothing references:\n",
+		countWord(len(paths), "secret", "secrets"),
+		countWord(prunableGroups, "duplicate group", "duplicate groups"))
+	for _, p := range paths {
+		fmt.Fprintf(out, "  %s %s\n", glyphBullet, p)
+	}
+	// Names its own object class and disclaims the neighbouring prunes' —
+	// see the matching comment in `jit vault prune`: three commands in this
+	// namespace delete different things under the same word.
+	if !vaultDuplicatesYes && !confirmPrompt(cmd, fmt.Sprintf(
+		"Permanently delete %s? This removes duplicated secret values, not `jit migrate`'s file backups. This can't be undone. [y/N] ",
+		countWord(len(paths), "duplicated secret", "duplicated secrets"))) {
+		fmt.Fprintln(out, "Aborted. Nothing was deleted.")
+		reportLeft()
+		return nil
+	}
+	// Fresh biometric gate, same idiom as rm/orphans/prune: Remove only
+	// unlinks envelope files, so this explicit user-presence check is what
+	// forces a fingerprint here, locked or not.
+	if err := requireUserPresence(fmt.Sprintf("delete %s from the vault",
+		countWord(len(paths), "duplicated secret", "duplicated secrets"))); err != nil {
+		return err
+	}
+	for _, p := range paths {
+		if err := v.Remove(p); err != nil && !errors.Is(err, vault.ErrNotFound) {
+			return fmt.Errorf("deleting %s: %w", p, err)
+		}
+	}
+	fmt.Fprintf(out, "Deleted %s.\n", countWord(len(paths), "duplicated secret", "duplicated secrets"))
+	reportLeft()
+	return nil
+}
+
+// gatherDupGroups decrypts and digests every stored secret, grouped by top
+// path segment. Values are hashed the moment they are read and never kept;
+// the digest map is all any later stage sees. compared counts the secrets
+// actually decrypted (an envelope that fails to read is skipped — one
+// unreadable secret must not take down the whole report).
+func gatherDupGroups(v *vault.Vault, root, cwd string, secrets []string) (map[string]*dupGroup, int, error) {
+	refs := referencesForPaths(root, cwd, secrets)
+	groups := map[string]*dupGroup{}
+	compared := 0
+	for _, p := range secrets {
+		name := groupPrefix(p)
+		key := strings.TrimPrefix(p, name+"/")
+		if key == p {
+			continue // a group-less top-level path joins no comparison
+		}
+		g := groups[name]
+		if g == nil {
+			g = &dupGroup{name: name, originExists: false, hashes: map[string]string{}}
+			groups[name] = g
+		}
+		g.keys = append(g.keys, key)
+
+		if info, err := v.Info(p); err == nil {
+			switch {
+			case len(g.hashes) == 0 && g.origin == "" && len(g.keys) == 1:
+				g.origin = info.Origin
+			case g.origin != info.Origin:
+				g.origin = "" // mixed origins claim nothing
+			}
+		}
+		for _, r := range refs[p] {
+			if !slices.Contains(g.profiles, r.ProfileName) {
+				g.profiles = append(g.profiles, r.ProfileName)
+			}
+			if r.MountPath != "" && g.mountPath == "" {
+				g.mountPath = r.MountPath
+			}
+		}
+
+		value, err := v.Get(p)
+		if err != nil {
+			continue
+		}
+		sum := sha256.Sum256(value)
+		g.hashes[key] = fmt.Sprintf("%x", sum)
+		compared++
+	}
+	for _, g := range groups {
+		sort.Strings(g.keys)
+		sort.Strings(g.profiles)
+		if g.origin != "" {
+			_, statErr := os.Stat(g.origin)
+			g.originExists = statErr == nil
+		}
+	}
+	return groups, compared, nil
+}
+
+// sameFileFindings clusters groups on (key set, origin tail) — the same
+// evidence rule the listing's nudge uses — and settles each cluster with
+// the value comparison the nudge can't run. The removal pick prefers, in
+// order: a copy whose origin file is gone (nothing can still read it), a
+// copy nothing references, then the lexicographically-later name (the
+// claimNamespace "-2" fork is the later arrival). No pick at all when
+// values differ.
+func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
+	byEvidence := map[string][]*dupGroup{}
+	for _, g := range groups {
+		if g.origin == "" || len(g.keys) == 0 {
+			continue
+		}
+		sig := strings.Join(g.keys, "\x00") + "\x00\x00" + originTail(g.origin)
+		byEvidence[sig] = append(byEvidence[sig], g)
+	}
+	var findings []dupFinding
+	for _, cluster := range byEvidence {
+		if len(cluster) < 2 {
+			continue
+		}
+		sort.Slice(cluster, func(i, j int) bool { return cluster[i].name < cluster[j].name })
+		f := dupFinding{Keys: cluster[0].keys, SameOrigin: true, ValuesMatch: true}
+		for _, g := range cluster {
+			f.Groups = append(f.Groups, g.name)
+			f.Origins = append(f.Origins, g.origin)
+			if g.origin != cluster[0].origin {
+				f.SameOrigin = false
+			}
+			for _, k := range f.Keys {
+				if g.hashes[k] == "" || g.hashes[k] != cluster[0].hashes[k] {
+					f.ValuesMatch = false
+				}
+			}
+		}
+		if f.ValuesMatch {
+			pick := pickRemoval(cluster)
+			f.RemoveGroup = pick.name
+			f.RemovePaths = groupSecretPaths(pick)
+			switch {
+			case pick.origin != "" && pick.originExists:
+				// The file is still there, so retiring this copy means
+				// un-migrating it: restore its plaintext, deregister its
+				// mount, drop its profile. That is `jit migrate remove`'s
+				// whole job — --prune must not reimplement it, and must
+				// not delete the secrets out from under a mount that is
+				// still serving the file.
+				f.RemoveCommand = "jit migrate remove " + shortPath(pick.origin)
+			case len(pick.profiles) == 0:
+				f.RemoveCommand = "jit vault duplicates --prune"
+				f.Prunable = true
+			default:
+				// Origin gone but a profile still names these paths:
+				// deleting them leaves that manifest pointing at holes.
+				// Worth doing, but as a decision the user makes per path.
+				f.RemoveCommand = "jit vault rm " + strings.Join(f.RemovePaths, " ")
+			}
+		}
+		findings = append(findings, f)
+	}
+	sort.Slice(findings, func(i, j int) bool { return findings[i].Groups[0] < findings[j].Groups[0] })
+	return findings
+}
+
+// pickRemoval chooses which copy of a matching cluster the report suggests
+// retiring. It is a suggestion, printed under a caveat — never acted on.
+func pickRemoval(cluster []*dupGroup) *dupGroup {
+	for _, g := range cluster {
+		if g.origin != "" && !g.originExists {
+			return g
+		}
+	}
+	for _, g := range cluster {
+		if len(g.profiles) == 0 {
+			return g
+		}
+	}
+	return cluster[len(cluster)-1]
+}
+
+func groupSecretPaths(g *dupGroup) []string {
+	paths := make([]string, 0, len(g.keys))
+	for _, k := range g.keys {
+		paths = append(paths, g.name+"/"+k)
+	}
+	return paths
+}
+
+// sharedCredentialFindings reports the same VALUE stored under the same key
+// by groups that same-file evidence did not pair — independent tools
+// holding one credential. Key names that look like plain configuration
+// (looksLikeConfig: OUTPUT_FILE, DEBUG, ...) don't count: two scripts
+// writing to the same output path is not a shared credential, and
+// reporting it would bury the ones that are.
+func sharedCredentialFindings(groups map[string]*dupGroup, consumed []dupFinding) []sharedFinding {
+	inFinding := map[string]bool{}
+	for _, f := range consumed {
+		for _, g := range f.Groups {
+			inFinding[g] = true
+		}
+	}
+	// (key, digest) -> group names sharing it.
+	sharing := map[string][]string{}
+	for _, g := range groups {
+		if inFinding[g.name] {
+			continue
+		}
+		for k, h := range g.hashes {
+			if h == "" || looksLikeConfig(k) {
+				continue
+			}
+			id := k + "\x00" + h
+			sharing[id] = append(sharing[id], g.name)
+		}
+	}
+	// Merge per-key clusters that cover the identical set of groups into
+	// one finding (the five-export-scripts case is one credential, three
+	// keys — three lines would triple-report one fact).
+	byGroupSet := map[string]*sharedFinding{}
+	var order []string
+	ids := make([]string, 0, len(sharing))
+	for id := range sharing {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		names := sharing[id]
+		if len(names) < 2 {
+			continue
+		}
+		sort.Strings(names)
+		setKey := strings.Join(names, "\x00")
+		f := byGroupSet[setKey]
+		if f == nil {
+			f = &sharedFinding{Groups: names}
+			byGroupSet[setKey] = f
+			order = append(order, setKey)
+		}
+		f.Keys = append(f.Keys, strings.SplitN(id, "\x00", 2)[0])
+	}
+	findings := make([]sharedFinding, 0, len(order))
+	sort.Strings(order)
+	for _, setKey := range order {
+		f := byGroupSet[setKey]
+		sort.Strings(f.Keys)
+		findings = append(findings, *f)
+	}
+	return findings
+}
+
+// printDuplicatesReport renders the text report: a findings section in the
+// house report shape, a shared-credentials section, and the one-line
+// footer stating what was compared and how.
+func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []sharedFinding, compared int) {
+	if len(findings) == 0 && len(shared) == 0 {
+		fmt.Fprintf(out, "No duplicates: every group's keys, origins and values are distinct.\n")
+		fmt.Fprintf(out, "%d %s compared under one unlock; values never left memory.\n",
+			compared, pluralWord(compared, "secret", "secrets"))
+		return
+	}
+	if len(findings) > 0 {
+		_, _ = cBold.Fprintf(out, "[duplicates]")
+		fmt.Fprintf(out, " %s across %d stored %s\n", countWord(len(findings), "finding", "findings"),
+			compared, pluralWord(compared, "secret", "secrets"))
+		for _, f := range findings {
+			fmt.Fprintln(out)
+			printDupFinding(out, f)
+		}
+	}
+	if len(shared) > 0 {
+		if len(findings) > 0 {
+			fmt.Fprintln(out)
+		}
+		_, _ = cBold.Fprintf(out, "[shared credentials]")
+		fmt.Fprintf(out, " %d · same value in independent tools, keep all\n", len(shared))
+		for _, f := range shared {
+			fmt.Fprintln(out)
+			_, _ = cOK.Fprintf(out, "%s ", glyphOK)
+			_, _ = cBold.Fprint(out, strings.Join(f.Keys, ", "))
+			fmt.Fprintf(out, " shared by %d profiles\n", len(f.Groups))
+			fmt.Fprintf(out, "  %s %s\n", glyphBranch, strings.Join(f.Groups, ", "))
+		}
+		fmt.Fprintln(out, "  removing any copy breaks its tool; when rotating, update every copy")
+	}
+	prunable := 0
+	for _, f := range findings {
+		if f.Prunable {
+			prunable++
+		}
+	}
+	fmt.Fprintln(out)
+	if prunable > 0 && !vaultDuplicatesPrune {
+		fmt.Fprint(out, hlCmds(fmt.Sprintf("%s can be deleted here (origin file gone, referenced by nothing): `jit vault duplicates --prune`\n",
+			countWord(prunable, "finding", "findings"))))
+	}
+	fmt.Fprintf(out, "%d %s compared under one unlock; values never left memory.\n",
+		compared, pluralWord(compared, "secret", "secrets"))
+}
+
+func printDupFinding(out io.Writer, f dupFinding) {
+	_, _ = cWarn.Fprintf(out, "%s ", glyphWarn)
+	_, _ = cBold.Fprint(out, strings.Join(f.Groups, ", "))
+	switch {
+	case f.SameOrigin:
+		fmt.Fprintln(out, ": one file, migrated more than once")
+	case f.ValuesMatch:
+		fmt.Fprintln(out, ": one file, migrated from two copies")
+	default:
+		fmt.Fprintln(out, ": copies that have diverged")
+	}
+	keysLabel := "keys"
+	if len(f.Keys) == 1 {
+		keysLabel = "key"
+	}
+	match := "identical values"
+	if !f.ValuesMatch {
+		match = "values DIFFER"
+	}
+	fmt.Fprintf(out, "  %s same %d %s (%s), %s\n", glyphBranch, len(f.Keys), keysLabel,
+		truncateList(f.Keys, 3), match)
+	wide := 0
+	for _, g := range f.Groups {
+		if len(g) > wide {
+			wide = len(g)
+		}
+	}
+	for i, g := range f.Groups {
+		fmt.Fprintf(out, "  %s %-*s  from %s\n", glyphBranch, wide, g, shortPath(f.Origins[i]))
+	}
+	switch {
+	case !f.ValuesMatch:
+		fmt.Fprintln(out, "  the copies no longer agree; compare the files before retiring either")
+	case f.RemoveCommand != "":
+		fmt.Fprintf(out, "  keep the copy your tools read; %s looks stale, retire it with:\n", f.RemoveGroup)
+		_, _ = cPath.Fprintf(out, "  %s %s\n", glyphAction, f.RemoveCommand)
+	}
+}
+
+// truncateList joins up to max names, summarizing the rest — variable
+// content is truncated rather than wrapped (house rule).
+func truncateList(names []string, max int) string {
+	if len(names) <= max {
+		return strings.Join(names, ", ")
+	}
+	return fmt.Sprintf("%s + %d more", strings.Join(names[:max], ", "), len(names)-max)
+}
+
+func init() {
+	vaultDuplicatesCmd.Flags().StringVar(&vaultDuplicatesFormat, "format", "text", `output format: "text" (default) or "json"`)
+	vaultDuplicatesCmd.Flags().BoolVar(&vaultDuplicatesPrune, "prune", false, "delete stale copies whose origin file is gone and which nothing references")
+	vaultDuplicatesCmd.Flags().BoolVarP(&vaultDuplicatesYes, "yes", "y", false, "skip the confirmation prompt (never the fingerprint)")
+	vaultCmd.AddCommand(vaultDuplicatesCmd)
+}

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+func dupTestGroup(name, origin string, originExists bool, profiles []string, kv map[string]string) *dupGroup {
+	g := &dupGroup{name: name, origin: origin, originExists: originExists, profiles: profiles, hashes: map[string]string{}}
+	for k, v := range kv {
+		g.keys = append(g.keys, k)
+		g.hashes[k] = "h:" + v // any injective mapping stands in for the digest
+	}
+	sort.Strings(g.keys)
+	return g
+}
+
+// TestSameFileFindings pins the same-file verdicts: a copied tree's two
+// migrations pair on (key set, origin tail) and matching values, the
+// removal pick prefers a gone origin then an unreferenced group then the
+// later name, the remedy routes to `jit migrate remove` only while the
+// origin file exists, and diverged values get no removal pick at all.
+func TestSameFileFindings(t *testing.T) {
+	// Copied workspace: both live and wired -> pick the later name, route
+	// to migrate remove of ITS origin.
+	groups := map[string]*dupGroup{
+		"mcp-caido":   dupTestGroup("mcp-caido", "/u/Documents/ws/.mcp.json", true, []string{"mcp-caido"}, map[string]string{"CAIDO_URL": "v1"}),
+		"mcp-caido-2": dupTestGroup("mcp-caido-2", "/u/Desktop/ws/.mcp.json", true, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "v1"}),
+	}
+	fs := sameFileFindings(groups)
+	if len(fs) != 1 {
+		t.Fatalf("want 1 finding, got %+v", fs)
+	}
+	f := fs[0]
+	if f.SameOrigin || !f.ValuesMatch {
+		t.Errorf("copied-tree finding flags = %+v", f)
+	}
+	if f.RemoveGroup != "mcp-caido-2" || f.RemoveCommand != "jit migrate remove /u/Desktop/ws/.mcp.json" {
+		t.Errorf("removal pick = %q / %q, want the later name via migrate remove", f.RemoveGroup, f.RemoveCommand)
+	}
+
+	if f.Prunable {
+		t.Errorf("a copy whose file still exists must never be prunable: %+v", f)
+	}
+
+	// A copy whose origin is gone and which nothing references is the pick,
+	// and is the ONE shape --prune may delete itself.
+	groups["mcp-caido-2"] = dupTestGroup("mcp-caido-2", "/u/Desktop/ws/.mcp.json", false, nil, map[string]string{"CAIDO_URL": "v1"})
+	fs = sameFileFindings(groups)
+	if len(fs) != 1 || fs[0].RemoveGroup != "mcp-caido-2" || fs[0].RemoveCommand != "jit vault duplicates --prune" {
+		t.Errorf("gone-origin pick = %+v, want mcp-caido-2 via duplicates --prune", fs)
+	}
+	if !fs[0].Prunable || strings.Join(fs[0].RemovePaths, ",") != "mcp-caido-2/CAIDO_URL" {
+		t.Errorf("gone-origin unreferenced finding must be prunable with its paths, got %+v", fs[0])
+	}
+
+	// Gone origin but still wired somewhere -> vault rm of the exact paths,
+	// and NOT prunable: deleting them would leave that manifest pointing at
+	// holes, which is a per-path decision.
+	groups["mcp-caido-2"] = dupTestGroup("mcp-caido-2", "/u/Desktop/ws/.mcp.json", false, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "v1"})
+	fs = sameFileFindings(groups)
+	if len(fs) != 1 || fs[0].RemoveCommand != "jit vault rm mcp-caido-2/CAIDO_URL" {
+		t.Errorf("gone-origin wired pick = %+v, want vault rm of the group's paths", fs)
+	}
+	if fs[0].Prunable {
+		t.Errorf("a still-referenced copy must never be prunable: %+v", fs[0])
+	}
+
+	// Diverged values -> reported, but no removal pick: which copy is right
+	// is the user's call.
+	groups["mcp-caido-2"] = dupTestGroup("mcp-caido-2", "/u/Desktop/ws/.mcp.json", true, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "v2"})
+	fs = sameFileFindings(groups)
+	if len(fs) != 1 || fs[0].ValuesMatch || fs[0].RemoveCommand != "" || fs[0].RemoveGroup != "" {
+		t.Errorf("diverged finding = %+v, want values_match=false and no removal pick", fs)
+	}
+
+	// Same key set from UNRELATED files (different tails) is not a
+	// same-file finding at all — that shape belongs to shared credentials.
+	groups = map[string]*dupGroup{
+		"export-a": dupTestGroup("export-a", "/u/scripts/inventory/.env", true, []string{"export-a"}, map[string]string{"JAMF_CLIENT_ID": "v1"}),
+		"export-b": dupTestGroup("export-b", "/u/scripts/computers/.env", true, []string{"export-b"}, map[string]string{"JAMF_CLIENT_ID": "v1"}),
+	}
+	if fs = sameFileFindings(groups); len(fs) != 0 {
+		t.Errorf("unrelated files must not pair as same-file, got %+v", fs)
+	}
+
+	// A re-migration fork: literally the same origin twice.
+	groups = map[string]*dupGroup{
+		"wiz":   dupTestGroup("wiz", "/u/scripts/.env", true, []string{"wiz"}, map[string]string{"A": "v1", "B": "v2"}),
+		"wiz-2": dupTestGroup("wiz-2", "/u/scripts/.env", true, nil, map[string]string{"A": "v1", "B": "v2"}),
+	}
+	fs = sameFileFindings(groups)
+	if len(fs) != 1 || !fs[0].SameOrigin || fs[0].RemoveGroup != "wiz-2" {
+		t.Errorf("same-origin fork = %+v, want SameOrigin with the unreferenced copy picked", fs)
+	}
+}
+
+// TestSharedCredentialFindings pins the shared-credential verdict: the same
+// value under the same key across independent groups clusters into ONE
+// finding per group set, config-named keys never count, and groups already
+// consumed by a same-file finding stay out.
+func TestSharedCredentialFindings(t *testing.T) {
+	jamfCreds := map[string]string{"JAMF_CLIENT_ID": "id", "JAMF_CLIENT_SECRET": "sec", "OUTPUT_FILE": "same-path"}
+	groups := map[string]*dupGroup{
+		"jamf":     dupTestGroup("jamf", "/u/a/.env", true, []string{"jamf"}, jamfCreds),
+		"jamf-2":   dupTestGroup("jamf-2", "/u/b/.env", true, []string{"jamf-2"}, jamfCreds),
+		"export-c": dupTestGroup("export-c", "/u/c/.env", true, []string{"export-c"}, jamfCreds),
+		"other":    dupTestGroup("other", "/u/d/.env", true, []string{"other"}, map[string]string{"API_KEY": "unrelated"}),
+	}
+	fs := sharedCredentialFindings(groups, nil)
+	if len(fs) != 1 {
+		t.Fatalf("want one merged finding, got %+v", fs)
+	}
+	if strings.Join(fs[0].Groups, ",") != "export-c,jamf,jamf-2" {
+		t.Errorf("groups = %v", fs[0].Groups)
+	}
+	// The two credential keys merge into one finding; OUTPUT_FILE (config
+	// by name) must not appear even though its value is shared too.
+	if strings.Join(fs[0].Keys, ",") != "JAMF_CLIENT_ID,JAMF_CLIENT_SECRET" {
+		t.Errorf("keys = %v, config-named keys must not count", fs[0].Keys)
+	}
+
+	// Groups consumed by a same-file finding don't re-report as shared.
+	consumed := []dupFinding{{Groups: []string{"jamf", "jamf-2"}}}
+	fs = sharedCredentialFindings(groups, consumed)
+	for _, f := range fs {
+		for _, g := range f.Groups {
+			if g == "jamf" || g == "jamf-2" {
+				t.Errorf("consumed group %s re-reported as shared: %+v", g, fs)
+			}
+		}
+	}
+}
+
+// TestPrintDuplicatesReport pins the text shapes: the findings section with
+// its evidence and remedy lines, the shared-credentials keep-all section,
+// the diverged caveat, and the empty state.
+func TestPrintDuplicatesReport(t *testing.T) {
+	var buf bytes.Buffer
+	printDuplicatesReport(&buf, []dupFinding{{
+		Groups: []string{"mcp-caido", "mcp-caido-2"}, Keys: []string{"CAIDO_URL"},
+		Origins:     []string{"/u/Documents/ws/.mcp.json", "/u/Desktop/ws/.mcp.json"},
+		ValuesMatch: true, RemoveGroup: "mcp-caido-2",
+		RemoveCommand: "jit migrate remove /u/Desktop/ws/.mcp.json",
+	}}, []sharedFinding{{
+		Keys: []string{"JAMF_CLIENT_ID"}, Groups: []string{"jamf", "jamf-2"},
+	}}, 118)
+	out := buf.String()
+	for _, want := range []string{
+		"[duplicates] 1 finding across 118 stored secrets",
+		"mcp-caido, mcp-caido-2: one file, migrated from two copies",
+		"same 1 key (CAIDO_URL), identical values",
+		"from /u/Documents/ws/.mcp.json",
+		"mcp-caido-2 looks stale, retire it with:",
+		"jit migrate remove /u/Desktop/ws/.mcp.json",
+		"[shared credentials] 1 · same value in independent tools, keep all",
+		"JAMF_CLIENT_ID",
+		"shared by 2 profiles",
+		"removing any copy breaks its tool; when rotating, update every copy",
+		"118 secrets compared under one unlock; values never left memory.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("report missing %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "vault rm") {
+		t.Errorf("a live-mounted copy must route to migrate remove, never rm, got:\n%s", out)
+	}
+
+	// Diverged: caveat instead of a remedy.
+	buf.Reset()
+	printDuplicatesReport(&buf, []dupFinding{{
+		Groups: []string{"a", "a-2"}, Keys: []string{"K"},
+		Origins: []string{"/u/x/.env", "/u/y/.env"},
+	}}, nil, 4)
+	if !strings.Contains(buf.String(), "copies that have diverged") ||
+		!strings.Contains(buf.String(), "compare the files before retiring either") {
+		t.Errorf("diverged report wrong, got:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "retire it with") {
+		t.Errorf("diverged copies must get no removal pick, got:\n%s", buf.String())
+	}
+
+	// Empty state.
+	buf.Reset()
+	printDuplicatesReport(&buf, nil, nil, 42)
+	if !strings.Contains(buf.String(), "No duplicates") || !strings.Contains(buf.String(), "42 secrets compared") {
+		t.Errorf("empty state wrong, got:\n%s", buf.String())
+	}
+}
+
+// TestPruneDuplicatesOnlyTouchesTheSafeShape is the guard that matters:
+// --prune must delete ONLY a stale copy whose origin file is gone and which
+// nothing references, must leave every other shape alone, and must say so
+// rather than reporting a clean sweep. Declining the confirmation deletes
+// nothing at all.
+func TestPruneDuplicatesOnlyTouchesTheSafeShape(t *testing.T) {
+	withFixtureHome(t)
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+	for _, p := range []string{"dead/KEY", "live/KEY", "wired/KEY"} {
+		if err := v.Set(p, []byte("value")); err != nil {
+			t.Fatalf("Set(%s): %v", p, err)
+		}
+	}
+	findings := []dupFinding{
+		{ // the safe shape
+			Groups: []string{"keep", "dead"}, RemoveGroup: "dead", ValuesMatch: true,
+			RemoveCommand: "jit vault duplicates --prune",
+			Prunable:      true, RemovePaths: []string{"dead/KEY"},
+		},
+		{ // file still on disk: migrate remove's job
+			Groups: []string{"keep2", "live"}, RemoveGroup: "live", ValuesMatch: true,
+			RemoveCommand: "jit migrate remove /x/live/.env",
+		},
+		{ // still referenced: a per-path rm decision
+			Groups: []string{"keep3", "wired"}, RemoveGroup: "wired", ValuesMatch: true,
+			RemoveCommand: "jit vault rm wired/KEY",
+		},
+		{ // diverged: never jit's call
+			Groups: []string{"a", "b"}, ValuesMatch: false,
+		},
+	}
+
+	// Declining the confirmation must delete nothing.
+	vaultDuplicatesYes, vaultDuplicatesFormat = false, "text"
+	cmd, buf := newDupPruneCmd(strings.NewReader("")) // EOF == declined
+	if err := pruneDuplicates(cmd, v, findings); err != nil {
+		t.Fatalf("pruneDuplicates (declined): %v", err)
+	}
+	if !strings.Contains(buf.String(), "Aborted. Nothing was deleted.") {
+		t.Errorf("declining must abort, got:\n%s", buf.String())
+	}
+	for _, p := range []string{"dead/KEY", "live/KEY", "wired/KEY"} {
+		if ok, _ := v.Exists(p); !ok {
+			t.Errorf("%s deleted despite a declined confirmation", p)
+		}
+	}
+
+	// The report names what it will delete, and only that.
+	out := buf.String()
+	if !strings.Contains(out, "dead/KEY") {
+		t.Errorf("prune plan must name the prunable path, got:\n%s", out)
+	}
+	for _, unsafe := range []string{"live/KEY", "wired/KEY"} {
+		if strings.Contains(out, "  "+glyphBullet+" "+unsafe) {
+			t.Errorf("prune plan must not list %s, got:\n%s", unsafe, out)
+		}
+	}
+	// And it accounts for what it left behind, with each command.
+	for _, want := range []string{
+		"Left alone, 3 findings need a command only you should run:",
+		"jit migrate remove /x/live/.env",
+		"jit vault rm wired/KEY",
+		"copies have diverged, compare them first",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("prune must report what it skipped (%q), got:\n%s", want, out)
+		}
+	}
+
+	// Nothing prunable at all -> says so plainly, still accounts for the rest.
+	cmd, buf = newDupPruneCmd(strings.NewReader(""))
+	if err := pruneDuplicates(cmd, v, findings[1:]); err != nil {
+		t.Fatalf("pruneDuplicates (nothing prunable): %v", err)
+	}
+	if !strings.Contains(buf.String(), "Nothing to prune") ||
+		!strings.Contains(buf.String(), "Left alone, 3 findings") {
+		t.Errorf("empty prune must explain, got:\n%s", buf.String())
+	}
+}
+
+// newDupPruneCmd builds a cobra command wired to a buffer and the given
+// stdin, for driving confirmPrompt without the real terminal.
+func newDupPruneCmd(stdin io.Reader) (*cobra.Command, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetIn(stdin)
+	return cmd, buf
+}
+
+// TestGatherDupGroups drives the gather stage against a real (fixture)
+// vault: values decrypt and digest per key, a uniform origin is kept while
+// mixed origins claim nothing, and a gone origin file reads as such.
+func TestGatherDupGroups(t *testing.T) {
+	withFixtureHome(t)
+	cwd := t.TempDir()
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+
+	origin := filepath.Join(t.TempDir(), ".env")
+	if err := os.WriteFile(origin, []byte("A=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	set := func(path, value, org string) {
+		t.Helper()
+		if err := v.SetWithMeta(path, []byte(value), vault.Meta{Class: vault.ClassDotenv, Origin: org}); err != nil {
+			t.Fatalf("SetWithMeta(%s): %v", path, err)
+		}
+	}
+	set("alpha/A", "one", origin)
+	set("alpha/B", "two", origin)
+	set("beta/A", "one", "/gone/elsewhere/.env")
+	set("mixed/X", "x", origin)
+	set("mixed/Y", "y", "/somewhere/else/.env")
+
+	groups, compared, err := gatherDupGroups(v, root, cwd,
+		[]string{"alpha/A", "alpha/B", "beta/A", "mixed/X", "mixed/Y"})
+	if err != nil {
+		t.Fatalf("gatherDupGroups: %v", err)
+	}
+	if compared != 5 {
+		t.Errorf("compared = %d, want 5", compared)
+	}
+	a := groups["alpha"]
+	if a == nil || a.origin != origin || !a.originExists {
+		t.Fatalf("alpha = %+v, want its uniform, existing origin", a)
+	}
+	b := groups["beta"]
+	if b == nil || b.originExists {
+		t.Fatalf("beta = %+v, want a gone origin", b)
+	}
+	// Same plaintext must digest identically across groups; different
+	// plaintext must not.
+	if a.hashes["A"] != b.hashes["A"] {
+		t.Errorf("identical values must share a digest")
+	}
+	if a.hashes["A"] == a.hashes["B"] {
+		t.Errorf("different values must not share a digest")
+	}
+	if m := groups["mixed"]; m == nil || m.origin != "" {
+		t.Errorf("mixed = %+v, mixed origins must claim nothing", m)
+	}
+}

--- a/internal/cli/vaultrefs.go
+++ b/internal/cli/vaultrefs.go
@@ -1,0 +1,131 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/profile"
+)
+
+// secretReference is one thing that points at a stored secret: a profile
+// (by name and store), possibly served live through a registered mount.
+type secretReference struct {
+	ProfileName string
+	Scope       profile.Scope
+	MountPath   string // the mounted file this profile feeds, "" when none
+}
+
+// referencesForPaths maps each requested vault path to whatever jit can see
+// pointing at it: profiles in the project-local (cwd) and global stores,
+// plus the profile behind every registered mount. The mirror image of
+// collectReferencedPaths with the opposite failure contract — that one is
+// STRICT because its caller deletes what looks unreferenced, this one is
+// LENIENT (an unloadable profile is skipped) because its callers only WARN:
+// a parse failure must not block `jit vault rm`, and a missed warning is
+// the pre-existing behavior, not a new hazard.
+func referencesForPaths(root, cwd string, paths []string) map[string][]secretReference {
+	wanted := map[string]bool{}
+	for _, p := range paths {
+		wanted[p] = true
+	}
+	refs := map[string][]secretReference{}
+	seen := map[string]bool{} // profile file path -> already consumed
+	add := func(profilePath, name string, scope profile.Scope, mountPath string) {
+		if seen[profilePath] {
+			// A mount whose profile was already listed still needs its
+			// MountPath attached to that profile's references.
+			if mountPath == "" {
+				return
+			}
+			for vaultPath, list := range refs {
+				if !wanted[vaultPath] {
+					continue
+				}
+				for i := range list {
+					if list[i].ProfileName == name && list[i].MountPath == "" {
+						list[i].MountPath = mountPath
+					}
+				}
+			}
+			return
+		}
+		seen[profilePath] = true
+		entries, err := profile.LoadFile(profilePath)
+		if err != nil {
+			return
+		}
+		for _, vaultPath := range entries {
+			if wanted[vaultPath] {
+				refs[vaultPath] = append(refs[vaultPath], secretReference{
+					ProfileName: name, Scope: scope, MountPath: mountPath,
+				})
+			}
+		}
+	}
+	if infos, err := profile.ListAll(cwd); err == nil {
+		for _, info := range infos {
+			add(info.Path, info.Name, info.Scope, "")
+		}
+	}
+	if entries, err := mount.LoadRegistry(mount.RegistryPath(root)); err == nil {
+		for _, e := range entries {
+			name := strings.TrimSuffix(filepath.Base(e.ProfilePath), filepath.Ext(e.ProfilePath))
+			add(e.ProfilePath, name, profile.ScopeGlobal, e.MountPath)
+		}
+	}
+	for _, list := range refs {
+		sort.Slice(list, func(i, j int) bool { return list[i].ProfileName < list[j].ProfileName })
+	}
+	return refs
+}
+
+// printRmReferenceWarnings tells the user, BEFORE the delete-confirmation,
+// which of the doomed paths something still points at — the gap that made
+// "rm the stale copy" advice dangerous: rm deletes only the envelope file,
+// so a wired secret's profile keeps naming it and its mount keeps serving a
+// FIFO no writer can fill. Purely advisory (the [y/N] and the fingerprint
+// still decide); the remedy routes to `jit migrate remove`, the command
+// that takes the file, the profile and the secrets down together.
+func printRmReferenceWarnings(out io.Writer, refs map[string][]secretReference) {
+	if len(refs) == 0 {
+		return
+	}
+	paths := make([]string, 0, len(refs))
+	for p := range refs {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	mounts := map[string]bool{}
+	var mountOrder []string
+	for _, p := range paths {
+		for _, r := range refs[p] {
+			_, _ = cWarnBold.Fprintf(out, "%s ", glyphMark)
+			fmt.Fprintf(out, "%s is wired to profile ", p)
+			_, _ = cBold.Fprint(out, r.ProfileName)
+			fmt.Fprintf(out, " (%s)\n", r.Scope)
+			if r.MountPath != "" && !mounts[r.MountPath] {
+				mounts[r.MountPath] = true
+				mountOrder = append(mountOrder, r.MountPath)
+				fmt.Fprintf(out, "  %s served by the mount at %s\n", glyphBranch, shortPath(r.MountPath))
+			}
+		}
+	}
+	if len(mountOrder) > 0 {
+		which := "that mount"
+		if len(mountOrder) > 1 {
+			which = "those mounts"
+		}
+		fmt.Fprintf(out, "  deleting only the secret leaves %s broken; to remove file,\n", which)
+		fmt.Fprintln(out, "  profile and secret together:")
+		for _, m := range mountOrder {
+			_, _ = cPath.Fprintf(out, "  %s jit migrate remove %s\n", glyphAction, shortPath(m))
+		}
+	}
+}

--- a/internal/cli/vaultrefs_test.go
+++ b/internal/cli/vaultrefs_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/mount"
+)
+
+// TestReferencesForPathsAndRmWarning pins the `jit vault rm` advisory: a
+// path wired to a profile is named before the confirmation, a mount served
+// from that profile attaches to the SAME reference (never a duplicate row),
+// the remedy routes to `jit migrate remove` for the mounted file, and an
+// unreferenced path stays silent. Also the lenient contract: an unloadable
+// profile is skipped, never an error, because a warning must not block rm.
+func TestReferencesForPathsAndRmWarning(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := t.TempDir()
+	root := t.TempDir()
+
+	// A project-local profile wiring one of the doomed paths.
+	pdir := filepath.Join(cwd, ".jit", "profiles")
+	if err := os.MkdirAll(pdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pdir, "svc.yaml"),
+		[]byte("API_KEY: svc/API_KEY\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A global profile that a registered mount serves.
+	gdir := filepath.Join(home, ".jit", "profiles")
+	if err := os.MkdirAll(gdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mountProfile := filepath.Join(gdir, "mcp-caido-2.yaml")
+	if err := os.WriteFile(mountProfile,
+		[]byte("CAIDO_URL: mcp-caido-2/CAIDO_URL\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := mount.AddMount(mount.RegistryPath(root), mount.Entry{
+		MountPath:   "/x/ws/.mcp.json",
+		ProfilePath: mountProfile,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// An unparseable profile must be skipped, not fatal.
+	if err := os.WriteFile(filepath.Join(pdir, "broken.yaml"),
+		[]byte(":\tnot yaml"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	refs := referencesForPaths(root, cwd,
+		[]string{"svc/API_KEY", "mcp-caido-2/CAIDO_URL", "unref/KEY"})
+
+	if got := refs["svc/API_KEY"]; len(got) != 1 || got[0].ProfileName != "svc" || got[0].MountPath != "" {
+		t.Errorf("svc/API_KEY refs = %+v, want one profile ref named svc with no mount", got)
+	}
+	got := refs["mcp-caido-2/CAIDO_URL"]
+	if len(got) != 1 {
+		t.Fatalf("mcp-caido-2/CAIDO_URL refs = %+v, want exactly one (mount must attach, not duplicate)", got)
+	}
+	if got[0].ProfileName != "mcp-caido-2" || got[0].MountPath != "/x/ws/.mcp.json" {
+		t.Errorf("mount-served ref = %+v, want profile mcp-caido-2 with its mount path", got[0])
+	}
+	if _, ok := refs["unref/KEY"]; ok {
+		t.Errorf("unreferenced path must not appear, got %+v", refs["unref/KEY"])
+	}
+
+	var buf bytes.Buffer
+	printRmReferenceWarnings(&buf, refs)
+	out := buf.String()
+	for _, want := range []string{
+		"svc/API_KEY is wired to profile",
+		"mcp-caido-2/CAIDO_URL is wired to profile",
+		"served by the mount at /x/ws/.mcp.json",
+		"jit migrate remove /x/ws/.mcp.json",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("rm warning missing %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "unref/KEY") {
+		t.Errorf("rm warning must not mention unreferenced paths, got:\n%s", out)
+	}
+
+	// No references at all -> total silence, the pre-existing rm experience.
+	buf.Reset()
+	printRmReferenceWarnings(&buf, map[string][]secretReference{})
+	if buf.Len() != 0 {
+		t.Errorf("no references must print nothing, got:\n%s", buf.String())
+	}
+}


### PR DESCRIPTION
## The bug

`jit vault list` closed with notes like:

```
note: claude-inventory-export, developer-secrets-export, jamf-2 hold the same
keys, a re-migrated file? jit vault rm the stale copy.
```

On a real 118-secret vault, all three such notes were wrong and the one real duplicate went unreported:

| Case | Flagged? | Actually |
|---|---|---|
| `mcp-caido` + `mcp-caido-2` (same value, two copies of `ai_security_workspace/.mcp.json`) | no, 1 key under the 3-key floor | the clearest true duplicate |
| `claude-inventory-export`, `developer-secrets-export`, `jamf-2` | yes, "rm the stale copy" | five separate export scripts legitimately sharing one Jamf API client |
| `jamf` (14 keys) vs `jamf-2` (8) | no, key sets differ | different files entirely, `-2` came from a name collision |

`printDuplicateGroupNudge` fingerprinted a group by **key names alone**. That cannot separate "one file stored twice" from "one credential used by many tools".

The remedy was wrong too: `jit vault rm` deletes envelope files only, so a wired secret leaves its profile naming a hole and its mount serving a FIFO no writer can fill. `rm` had no referenced-by check at all, so following the note broke a live mount silently.

Both existing duplicate surfaces missed the caido case for the same reason: `vault orphans` keys on "referenced by nothing", and `status`'s `DuplicateOf` only annotates *unreferenced* groups. Both caido groups are referenced, by their own live profiles.

## The fix

Origin is the discriminator, not the name and not the key set.

1. **Group headers carry provenance.** `sharedGroupNote` promotes a uniform `Origin` + age to the top-level header, per the house "shared fact on the group header" rule. Middle-truncated to the window, dropped below 12 columns, nested headers never restate it, uniformly-manual groups read `set directly`.

   ```
   [jamf] 14 · dotenv · from ~/custom_scripts/.env · 9d ago
   [jamf-2] 8 · dotenv · from ~/custom_scripts/computer_inventory/.env · 2d ago
   ```

2. **The note is origin-backed** (same path, or same origin tail in two directories), has no key-count floor, and routes to `jit vault duplicates` instead of recommending `rm`.

3. **`jit vault rm` warns** when a doomed path is wired, naming the profile and mount, and points at `jit migrate remove`. Advisory and fail-open.

4. **New `jit vault duplicates`** compares actual values under one unlock, in memory, persisting nothing. Five verdicts, each routed to the command that cleans it correctly: `migrate remove` while the file exists, `--prune`/`vault rm` once it is gone, and no removal pick at all for diverged or shared copies. `--format json` included.

5. **`jit migrate` discloses at birth** when it stores a value the vault already holds elsewhere. Disclosure only, per the annotate-never-collapse decision: merging copies means one later `rm` breaks every tool that shares it.

## Notable decisions

- **No envelope change.** Comparison needs plaintext, and a stored digest per secret would turn the vault directory into a guess-confirmation oracle for low-entropy values (`http://127.0.0.1:8080`, `true`, a file path) for exactly the attacker envelope encryption defends against. A command that may prompt can simply decrypt, as `vault export` already does.
- **`--prune`, not `--clean`.** `jit vault clean` already means "delete every secret", so `--clean` would read as "delete all the duplicates" when some findings are shared credentials that must be kept. `--prune` deletes only origin-gone-and-unreferenced copies, and reports what it left behind rather than skipping silently.
- **Identity, not deduplication.** Storage keeps N copies. Sharing by reference is already legal (manifests map a variable to any vault path); what was missing was jit noticing.

Full rationale in `design/vault-duplicates.md`.

## Testing

New tests cover the verdict engine, the removal-pick precedence, the `--prune` safe-shape guard (including that declining deletes nothing and still reports skips), the rm reference warning, header truncation, and the migrate disclosure. Full local gate passes: `gofmt`, `go vet`, `staticcheck`, `gosec`, `govulncheck`, `go mod tidy` no drift, `go test -race` across all packages, `docs-gen` no drift.

Not exercised on the real Mac with the 118-secret vault yet; the numbers above come from the reported `vault list` output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143e5FSR3EwcJXtphv3fieo