### PR TITLE
vault: duplicate detection missed the case it was built for

### DIFF
--- a/docs/reference/commands/jit_vault_duplicates.md
+++ b/docs/reference/commands/jit_vault_duplicates.md
@@ -4,9 +4,9 @@ Report groups that hold the same secrets, and which are safe to retire
 
 ### Synopsis
 
-Compares every stored secret's decrypted value in memory (one unlock, no
-value ever printed or written) and reports two things `jit vault list`
-cannot know from names alone:
+Compares every stored secret's decrypted value in memory (no value is ever
+printed or written) and reports two things `jit vault list` cannot know
+from names alone:
 
   Duplicated groups: the same key names migrated from the same file, or
   from two copies of it (a re-migrated project, a copied workspace tree).
@@ -32,6 +32,12 @@ and drops its profile — deleting just the secrets would leave a mount
 serving a file nothing can fill), a copy a profile still names is a
 per-path `jit vault rm` decision, and diverged or shared copies are never
 jit's call at all. --prune always reports what it left behind and why.
+
+Reading every value means unlocking the vault and, for each credential
+CLASS the per-process consent gate covers (aws, kube, git, shell_history,
+...), approving that class once. A vault holding two gated classes
+therefore asks about three times, not once: the unlock plus one per class.
+`jit service consent off` removes the per-class half.
 
 ```
 jit vault duplicates [flags]

--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -26,8 +26,8 @@ in progress.
 
 Answers "which of these look-alike groups can I safely delete?" - the
 question a listing can't, because it takes comparing the actual values.
-Under one unlock it decrypts every stored secret in memory (nothing is
-printed or written), then reports:
+It decrypts every stored secret in memory (nothing is printed or written),
+then reports:
 
 - **Duplicated groups**: the same key names migrated from the same file, or
   from two copies of it (a re-migrated project, a copied workspace tree).
@@ -50,6 +50,17 @@ printed or written), then reports:
   example one API client used by five export scripts. These are *not* stale
   copies - removing any breaks its tool - and the report lists every place
   a rotation has to reach.
+
+### Why it asks for Touch ID more than once
+
+Comparing values means reading every secret, so this command unlocks the
+vault **and** trips the
+[per-process consent gate](../service/consent.md) once for each credential
+*class* it touches (`aws`, `kube`, `git`, `shell_history`, and the rest -
+`dotenv`, `mcp` and `manual` are not gated). A vault holding two gated
+classes therefore prompts about three times: the unlock, plus one approval
+per class. That is the consent feature doing its job, not a retry loop.
+`jit service consent off` removes the per-class half.
 
 ### `--prune`
 

--- a/internal/cli/migrateduplicates.go
+++ b/internal/cli/migrateduplicates.go
@@ -22,18 +22,28 @@ import (
 // later removed), and the note routes to `jit vault duplicates` for the
 // full comparison and remedy.
 
-// buildVaultValueIndex digests every secret ALREADY stored before this run
-// writes anything, mapping value digest -> the first vault path holding it.
-// Values are hashed as read and never kept. Best-effort: an unreadable
-// envelope is skipped, and a nil index (a listing failure) simply disables
-// the notes — disclosure must never fail a migration.
-func buildVaultValueIndex(v *vault.Vault) map[string]string {
+// buildVaultValueIndex digests every stored secret, mapping value digest ->
+// every vault path holding it. Values are hashed as read and never kept.
+// Best-effort: an unreadable envelope is skipped, and a nil index (a listing
+// failure) simply disables the notes — disclosure must never fail a
+// migration.
+//
+// It maps a digest to EVERY path holding it, not just the first. The index
+// is built lazily, which means it is built AFTER the run's first file has
+// already been stored, so a value's own freshly-written path is in here
+// too — and with a single-path map the lookup could return that path
+// instead of the older copy, see itself, and stay silent about a real
+// duplicate. Keeping every path lets the lookup skip the migrating
+// profile's own and still find the older one. (Found by migrating a copied
+// folder on a real machine: the note never appeared, because
+// "ws-copy/CAIDO_URL" sorts before "ws/CAIDO_URL" and won the map slot.)
+func buildVaultValueIndex(v *vault.Vault) map[string][]string {
 	paths, err := v.List()
 	if err != nil {
 		return nil
 	}
 	secrets, _ := splitBackupPaths(paths)
-	idx := make(map[string]string, len(secrets))
+	idx := make(map[string][]string, len(secrets))
 	for _, p := range secrets {
 		value, err := v.Get(p)
 		if err != nil {
@@ -41,9 +51,7 @@ func buildVaultValueIndex(v *vault.Vault) map[string]string {
 		}
 		sum := sha256.Sum256(value)
 		key := fmt.Sprintf("%x", sum)
-		if _, ok := idx[key]; !ok {
-			idx[key] = p
-		}
+		idx[key] = append(idx[key], p)
 	}
 	return idx
 }
@@ -58,7 +66,7 @@ const minDuplicateValueLen = 6
 // already held. Key names that look like plain configuration are skipped on
 // sharedCredentialFindings' reasoning (two scripts sharing OUTPUT_FILE is
 // not a duplicate credential), as are very short values.
-func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string]string, profileName string, vars []string) {
+func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string][]string, profileName string, vars []string) {
 	if len(idx) == 0 {
 		return
 	}
@@ -73,13 +81,19 @@ func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string]string, p
 			continue
 		}
 		sum := sha256.Sum256(value)
-		existing, ok := idx[fmt.Sprintf("%x", sum)]
-		if !ok {
-			continue
-		}
-		if g := groupPrefix(existing); g != profileName {
-			dupCount++
+		counted := false
+		for _, existing := range idx[fmt.Sprintf("%x", sum)] {
+			// Skip the value's own group, including the copy this very
+			// migration just wrote (the index is built after the store).
+			g := groupPrefix(existing)
+			if g == profileName {
+				continue
+			}
 			groupSet[g] = true
+			if !counted {
+				dupCount++
+				counted = true
+			}
 		}
 	}
 	if dupCount == 0 {
@@ -99,10 +113,10 @@ func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string]string, p
 type dupIndexOnce struct {
 	v     *vault.Vault
 	built bool
-	idx   map[string]string
+	idx   map[string][]string
 }
 
-func (d *dupIndexOnce) get() map[string]string {
+func (d *dupIndexOnce) get() map[string][]string {
 	if !d.built {
 		d.built = true
 		d.idx = buildVaultValueIndex(d.v)

--- a/internal/cli/migrateduplicates_test.go
+++ b/internal/cli/migrateduplicates_test.go
@@ -66,3 +66,39 @@ func TestNoteDuplicateValues(t *testing.T) {
 		t.Errorf("nil index must print nothing, got:\n%s", buf.String())
 	}
 }
+
+// TestNoteDuplicateValuesIndexBuiltAfterTheWrite reproduces the ordering
+// migrate actually uses: the index is built LAZILY, i.e. after the file's
+// secrets are already stored, so the copy's own freshly-written path is in
+// the index alongside the original's. A digest->one-path index let the
+// new path win the slot and the note went silent on a real duplicate;
+// caught by migrating a copied folder on a real machine, where
+// "ws-copy/CAIDO_URL" sorts before "ws/CAIDO_URL".
+func TestNoteDuplicateValuesIndexBuiltAfterTheWrite(t *testing.T) {
+	withFixtureHome(t)
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+
+	// Both copies exist BEFORE the index is built, and the newer profile's
+	// path sorts first — exactly the shape that used to mask the duplicate.
+	if err := v.Set("ws/CAIDO_URL", []byte("http://127.0.0.1:8080")); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.Set("ws-copy/CAIDO_URL", []byte("http://127.0.0.1:8080")); err != nil {
+		t.Fatal(err)
+	}
+	idx := buildVaultValueIndex(v)
+
+	var buf bytes.Buffer
+	noteDuplicateValues(&buf, v, idx, "ws-copy", []string{"CAIDO_URL"})
+	out := buf.String()
+	if !strings.Contains(out, "1 value is already stored under ws") {
+		t.Errorf("the older copy must be named even though the new path sorts first, got:\n%s", out)
+	}
+	if strings.Contains(out, "ws-copy") {
+		t.Errorf("the migrating profile must never name itself, got:\n%s", out)
+	}
+}

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -128,6 +128,51 @@ func splitBackupPaths(paths []string) (secrets, backups []string) {
 	return secrets, backups
 }
 
+// applyProfileSourceFallback fills in a display Origin for secrets whose
+// envelope has none (pre-provenance v1/v2), taking the source file the
+// referencing PROFILE records. Group-scoped: every member of a group gets
+// the same fallback, so sharedGroupNote still sees one uniform origin and
+// states it once on the header. Silently does nothing when a group has no
+// referencing profile or the profile records no source — absence stays
+// absence rather than becoming a guess.
+func applyProfileSourceFallback(meta map[string]vault.SecretInfo, root, cwd string, secrets []string) {
+	if len(meta) == 0 || cwd == "" {
+		return
+	}
+	var missing []string
+	for _, p := range secrets {
+		if info, ok := meta[p]; ok && info.Origin == "" {
+			missing = append(missing, p)
+		}
+	}
+	if len(missing) == 0 {
+		return
+	}
+	refs := referencesForPaths(root, cwd, missing)
+	byGroup := map[string]string{}
+	for _, p := range missing {
+		g := groupPrefix(p)
+		if byGroup[g] != "" {
+			continue
+		}
+		for _, r := range refs[p] {
+			if r.OwnerConfig != "" {
+				byGroup[g] = r.OwnerConfig
+				break
+			}
+		}
+	}
+	for _, p := range missing {
+		src := byGroup[groupPrefix(p)]
+		if src == "" {
+			continue
+		}
+		info := meta[p]
+		info.Origin = src
+		meta[p] = info
+	}
+}
+
 // printVaultList renders jit vault list's text output. Piped (grouped
 // false), secrets stay one full path per line, grep/pipe-friendly with no
 // decoration; on a terminal (grouped true) they collapse under a
@@ -300,7 +345,7 @@ func originTail(origin string) string {
 // case is unchanged. Relies on List's naturally-sorted input keeping every
 // path that shares a prefix contiguous.
 func printGroupedSecrets(out io.Writer, secrets []string, meta map[string]vault.SecretInfo, long bool) {
-	printSecretTree(out, secrets, "", 0, meta, long)
+	printSecretTree(out, secrets, "", 0, meta, long, computeListColumns(secrets, meta))
 }
 
 // printSecretTree renders one level of the tree: paths are already stripped of
@@ -310,7 +355,7 @@ func printGroupedSecrets(out io.Writer, secrets []string, meta map[string]vault.
 // subtree recurses one level deeper; a leaf prints at the current indent,
 // -l-annotated when meta is set. Direct leaves at this level align their
 // metadata column to the widest of them.
-func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth int, meta map[string]vault.SecretInfo, long bool) {
+func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth int, meta map[string]vault.SecretInfo, long bool, cols listColumns) {
 	indent := strings.Repeat("  ", depth)
 
 	// Plain listing (no -l): this level's own keys flow into aligned columns
@@ -343,14 +388,17 @@ func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth i
 			if depth == 0 && wrote {
 				fmt.Fprintln(out)
 			}
-			printSecretGroupHeader(out, indent, paths[i][:slash], j-i,
-				sharedGroupNote(paths[i:j], ancestorPath, meta,
-					groupHeaderUsed(indent, paths[i][:slash], j-i), depth == 0))
+			note := sharedGroupNote(paths[i:j], ancestorPath, meta, depth == 0)
+			if depth == 0 {
+				printTopGroupHeader(out, paths[i][:slash], j-i, note, cols)
+			} else {
+				printSecretGroupHeader(out, indent, paths[i][:slash], j-i, note)
+			}
 			sub := make([]string, j-i)
 			for k := i; k < j; k++ {
 				sub[k-i] = paths[k][len(seg):]
 			}
-			printSecretTree(out, sub, ancestorPath+seg, depth+1, meta, long)
+			printSecretTree(out, sub, ancestorPath+seg, depth+1, meta, long, cols)
 			wrote = true
 			i = j
 		}
@@ -384,37 +432,117 @@ func printSecretTree(out io.Writer, paths []string, ancestorPath string, depth i
 		if depth == 0 && wrote {
 			fmt.Fprintln(out)
 		}
-		printSecretGroupHeader(out, indent, paths[i][:slash], j-i,
-			sharedGroupNote(paths[i:j], ancestorPath, meta,
-				groupHeaderUsed(indent, paths[i][:slash], j-i), depth == 0))
+		note := sharedGroupNote(paths[i:j], ancestorPath, meta, depth == 0)
+		if depth == 0 {
+			printTopGroupHeader(out, paths[i][:slash], j-i, note, cols)
+		} else {
+			printSecretGroupHeader(out, indent, paths[i][:slash], j-i, note)
+		}
 		sub := make([]string, j-i)
 		for k := i; k < j; k++ {
 			sub[k-i] = paths[k][len(seg):]
 		}
-		printSecretTree(out, sub, ancestorPath+seg, depth+1, meta, long)
+		printSecretTree(out, sub, ancestorPath+seg, depth+1, meta, long, cols)
 		wrote = true
 		i = j
 	}
+}
+
+// printCompactGroupHeader is the un-aligned fallback for a window too narrow
+// to carry the shared column grid: the same facts, each following the last
+// rather than starting at a fixed column, with the origin taking whatever
+// the line has left.
+func printCompactGroupHeader(out io.Writer, label string, n int, note groupNote) {
+	_, _ = cBold.Fprint(out, label)
+	countClass := " " + groupCountClass(n, note.class)
+	fmt.Fprint(out, countClass)
+	used := termtext.VisibleWidth(label) + termtext.VisibleWidth(countClass)
+	origin := note.origin
+	if origin != "" {
+		avail := outputWidth() - used - 3
+		if note.age != "" {
+			avail -= termtext.VisibleWidth(note.age) + 3
+		}
+		if avail < originMinWidth {
+			origin = ""
+		} else {
+			origin = promptEllipsis(origin, avail)
+		}
+	}
+	for _, part := range []string{origin, note.age} {
+		if part != "" {
+			fmt.Fprint(out, " · ", part)
+		}
+	}
+	fmt.Fprintln(out)
 }
 
 // printSecretGroupHeader renders a vault-tree segment header in the one house
 // header shape every jit section/group uses: a `[segment]` name (default
 // weight — the brackets delimit it, no bold) and a plain count, at the given
 // indent. The tree's indentation shows the nesting.
-func printSecretGroupHeader(out io.Writer, indent, name string, n int, note string) {
+func printSecretGroupHeader(out io.Writer, indent, name string, n int, note groupNote) {
 	fmt.Fprintf(out, "%s[%s]", indent, name)
-	if note != "" {
-		_, _ = fmt.Fprintf(out, " %d · %s\n", n, note)
+	if note.class != "" {
+		_, _ = fmt.Fprintf(out, " %d · %s\n", n, note.class)
 		return
 	}
 	_, _ = fmt.Fprintf(out, " %d\n", n)
 }
 
-// groupHeaderUsed is how many columns printSecretGroupHeader's own prefix
-// ("[name] N") occupies before the note starts — what sharedGroupNote
-// budgets the origin against.
-func groupHeaderUsed(indent, name string, n int) int {
-	return len(fmt.Sprintf("%s[%s] %d", indent, name, n))
+// printTopGroupHeader renders a TOP-LEVEL header on the shared column grid:
+// the bold "[name]" padded to the widest name, then "N · class" padded to
+// the widest of those, then the origin and age. Padding is written OUTSIDE
+// the bold span — bolding trailing spaces inverts them on some themes.
+// The origin gets whatever the window has left and is middle-truncated to
+// it (truncate, never wrap), and is dropped entirely below originMinWidth,
+// since a five-character sliver of a path identifies nothing.
+func printTopGroupHeader(out io.Writer, name string, n int, note groupNote, cols listColumns) {
+	label := "[" + name + "]"
+	if cols.name == 0 {
+		printCompactGroupHeader(out, label, n, note)
+		return
+	}
+	_, _ = cBold.Fprint(out, label)
+	pad := cols.name - termtext.VisibleWidth(label)
+	if pad < 0 {
+		pad = 0
+	}
+	fmt.Fprint(out, strings.Repeat(" ", pad), " ")
+
+	countClass := groupCountClass(n, note.class)
+	fmt.Fprint(out, countClass)
+	if note.origin == "" && note.age == "" {
+		fmt.Fprintln(out)
+		return
+	}
+	pad = cols.meta - termtext.VisibleWidth(countClass)
+	if pad < 0 {
+		pad = 0
+	}
+	fmt.Fprint(out, strings.Repeat(" ", pad), " ")
+
+	used := cols.name + 1 + cols.meta + 1
+	origin := note.origin
+	if origin != "" {
+		avail := outputWidth() - used
+		if note.age != "" {
+			avail -= termtext.VisibleWidth(note.age) + 3 // the " · " joiner
+		}
+		if avail < originMinWidth {
+			origin = "" // a sliver of a path identifies nothing
+		} else {
+			origin = promptEllipsis(origin, avail)
+		}
+	}
+	switch {
+	case origin != "" && note.age != "":
+		fmt.Fprintln(out, origin+" · "+note.age)
+	case origin != "":
+		fmt.Fprintln(out, origin)
+	default:
+		fmt.Fprintln(out, note.age)
+	}
 }
 
 // sharedGroupNote is the Tree shape's per-group note: one fact every member
@@ -455,9 +583,10 @@ func groupHeaderUsed(indent, name string, n int) int {
 //
 // paths are relative to ancestorPath (what printSecretTree has consumed so
 // far), so the two rejoin to the real vault path meta is keyed by.
-func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.SecretInfo, used int, topLevel bool) string {
+func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.SecretInfo, topLevel bool) groupNote {
+	var note groupNote
 	if len(meta) == 0 || len(paths) == 0 {
-		return ""
+		return note
 	}
 	class, origin := "", ""
 	classUniform, originUniform := true, true
@@ -465,7 +594,7 @@ func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.
 	for i, rel := range paths {
 		info, ok := meta[ancestorPath+rel]
 		if !ok {
-			return "" // a member we know nothing about: claim nothing
+			return groupNote{} // a member we know nothing about: claim nothing
 		}
 		if i == 0 {
 			class, origin = info.Class, info.Origin
@@ -481,42 +610,110 @@ func sharedGroupNote(paths []string, ancestorPath string, meta map[string]vault.
 			newest = info.UpdatedUnix
 		}
 	}
-	var parts []string
-	if classUniform && class != "" {
-		parts = append(parts, class)
+	if classUniform {
+		note.class = class
 	}
 	if !topLevel {
-		return strings.Join(parts, " · ")
+		return note
 	}
-	age := ""
 	if newest > 0 {
-		age = humanAgo(time.Since(time.Unix(newest, 0))) + " ago"
+		note.age = humanAgo(time.Since(time.Unix(newest, 0))) + " ago"
 	}
-	src := ""
 	switch {
 	case originUniform && origin != "":
-		src = "from " + shortPath(origin)
+		note.origin = shortPath(origin)
 	case classUniform && class == vault.ClassManual && originUniform && origin == "":
-		src = "set directly"
+		note.origin = "set directly"
 	}
-	if src != "" {
-		// Budget: prefix + " · " joins + this src + the age still to come.
-		avail := outputWidth() - used
-		for _, p := range parts {
-			avail -= len(p) + 3
+	return note
+}
+
+// groupNote is a top-level group's shared facts, kept as PARTS rather than
+// one joined string so the header can align them into columns: every
+// group's count+class starts at the same screen column, and so does every
+// origin. A ragged run of 28 headers is what the aligned layout replaced.
+type groupNote struct {
+	class  string
+	origin string // display-shortened, not yet truncated to the window
+	age    string
+}
+
+// listColumns are the shared column widths every top-level header aligns
+// to: the widest "[name]" and the widest "N · class". Both are capped so
+// one very long group name or class can't push the origin off the screen
+// for every other row.
+type listColumns struct {
+	name int
+	meta int
+}
+
+const (
+	maxNameColumn = 30
+	maxMetaColumn = 22
+)
+
+// computeListColumns measures every TOP-LEVEL group once, before anything
+// is printed, so the whole listing shares one set of columns. Nested
+// headers are excluded: they are indented under their parent and carry only
+// a class, so aligning them to the top-level grid would just push them out.
+func computeListColumns(paths []string, meta map[string]vault.SecretInfo) listColumns {
+	var cols listColumns
+	alignable := false
+	for i := 0; i < len(paths); {
+		slash := strings.Index(paths[i], "/")
+		if slash < 0 {
+			i++
+			continue
 		}
-		avail -= 3 // src's own " · "
-		if age != "" {
-			avail -= len(age) + 3
+		seg := paths[i][:slash+1]
+		j := i
+		for j < len(paths) && strings.HasPrefix(paths[j], seg) {
+			j++
 		}
-		if avail >= originMinWidth {
-			parts = append(parts, promptEllipsis(src, avail))
+		name := "[" + paths[i][:slash] + "]"
+		if w := termtext.VisibleWidth(name); w > cols.name {
+			cols.name = w
 		}
+		note := sharedGroupNote(paths[i:j], "", meta, true)
+		if w := termtext.VisibleWidth(groupCountClass(j-i, note.class)); w > cols.meta {
+			cols.meta = w
+		}
+		if note.origin != "" || note.age != "" {
+			alignable = true
+		}
+		i = j
 	}
-	if age != "" {
-		parts = append(parts, age)
+	// Alignment exists to line the ORIGIN column up. With nothing to line
+	// up — a vault with no recorded provenance at all — padding every name
+	// to a shared width just adds trailing space to "[wiz] 1".
+	if !alignable {
+		return listColumns{}
 	}
-	return strings.Join(parts, " · ")
+	if cols.name > maxNameColumn {
+		cols.name = maxNameColumn
+	}
+	if cols.meta > maxMetaColumn {
+		cols.meta = maxMetaColumn
+	}
+	// Alignment is a wide-window luxury: padding every name out to the
+	// widest one costs columns that a narrow terminal needs for the origin,
+	// and a 26-column name plus a 17-column "3 · shell_history" already
+	// overruns an 50-column window on its own. When the grid cannot leave
+	// room for a useful origin, drop back to the compact inline header —
+	// a zero name column is the signal for that.
+	if cols.name+cols.meta+2+originMinWidth > outputWidth() {
+		return listColumns{}
+	}
+	return cols
+}
+
+// groupCountClass is the second column: the member count, plus the shared
+// class when every member agrees on one.
+func groupCountClass(n int, class string) string {
+	if class == "" {
+		return strconv.Itoa(n)
+	}
+	return strconv.Itoa(n) + " · " + class
 }
 
 // originMinWidth is the narrowest rendering of a group's origin worth
@@ -993,6 +1190,7 @@ var vaultListCmd = &cobra.Command{
 			return fmt.Errorf("jit vault list: %w", err)
 		}
 		secrets, backups := splitBackupPaths(paths)
+		cwd, _ := os.Getwd()
 
 		grouped := term.IsTerminal(int(os.Stdout.Fd()))
 		axis := vaultListBy
@@ -1042,6 +1240,19 @@ var vaultListCmd = &cobra.Command{
 			return writeJSON(cmd.OutOrStdout(), out)
 		}
 
+		// DISPLAY-ONLY provenance fallback, deliberately after the JSON
+		// branch above: a pre-provenance (v1/v2) envelope carries no Origin
+		// at all, so the header and the duplicate note would say nothing
+		// about the very secrets most likely to BE a stale copy. The
+		// referencing profile's recorded source is the evidence that does
+		// exist for them, and is what `jit vault get`'s "migrated from"
+		// footer has always shown. --format json keeps reporting the
+		// envelope's own truth, so nothing scripted sees a synthesized
+		// value. Prompt-free: profile manifests and their .source sidecars
+		// are plain files, no decryption and no agent call.
+		if grouped {
+			applyProfileSourceFallback(meta, root, cwd, secrets)
+		}
 		printVaultList(cmd.OutOrStdout(), secrets, backups, vaultListAll, grouped, vaultListLong, meta, axis)
 		return nil
 	},

--- a/internal/cli/vault_test.go
+++ b/internal/cli/vault_test.go
@@ -844,23 +844,55 @@ func TestGroupHeaderProvenance(t *testing.T) {
 	printVaultList(&buf, secrets, nil, false, true, false, meta, "path")
 	out := buf.String()
 
-	if !strings.Contains(out, "[jamf] 2 · dotenv · from /x/scripts/jamf/.env · 3d ago") {
+	// Aligned layout (option A): every top-level name is padded to the
+	// widest, so the count+class column and then the origin start at the
+	// same screen column on every row. The facts are the same; only their
+	// placement is shared.
+	if !strings.Contains(out, "[jamf]") || !strings.Contains(out, "2 · dotenv") ||
+		!strings.Contains(out, "/x/scripts/jamf/.env · 3d ago") {
 		t.Errorf("uniform-origin group must carry origin + newest age on its header, got:\n%s", out)
 	}
-	if !strings.Contains(out, "[manual-grp] 2 · manual · set directly · 1h ago") {
+	if !strings.Contains(out, "set directly · 1h ago") {
 		t.Errorf("uniformly manual group must read \"set directly\", got:\n%s", out)
 	}
+	// The alignment itself: the widest label here is "[manual-grp]" (12),
+	// so every header's second column starts at the same offset.
+	var starts []int
 	for _, line := range strings.Split(out, "\n") {
-		if strings.Contains(line, "[mixed]") && strings.Contains(line, "from ") {
+		if !strings.HasPrefix(line, "[") {
+			continue
+		}
+		idx := strings.Index(line, "] ")
+		if idx < 0 {
+			continue
+		}
+		// column offset of the first non-space after the label
+		off := idx + 2
+		for off < len(line) && line[off] == ' ' {
+			off++
+		}
+		starts = append(starts, off)
+	}
+	if len(starts) < 2 {
+		t.Fatalf("expected several top-level headers, got:\n%s", out)
+	}
+	for _, s := range starts[1:] {
+		if s != starts[0] {
+			t.Errorf("top-level headers must share one column grid, offsets %v, got:\n%s", starts, out)
+			break
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "[mixed]") && strings.Contains(line, "/x/") {
 			t.Errorf("mixed-origin group must not claim an origin, got line:\n%s", line)
 		}
 		// The nested [sub] header must not restate what [nested] already
 		// carries.
-		if strings.Contains(line, "[sub]") && (strings.Contains(line, "from ") || strings.Contains(line, "ago")) {
+		if strings.Contains(line, "[sub]") && (strings.Contains(line, "/x/") || strings.Contains(line, "ago")) {
 			t.Errorf("nested header must not restate provenance, got line:\n%s", line)
 		}
 	}
-	if !strings.Contains(out, "[nested] 1 · mcp · from /x/n/.mcp.json") {
+	if !strings.Contains(out, "/x/n/.mcp.json") {
 		t.Errorf("top-level header of a nested group carries the provenance, got:\n%s", out)
 	}
 

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -104,6 +104,11 @@ type dupFinding struct {
 	Prunable bool `json:"prunable"`
 	// RemovePaths are the stale copy's vault paths, what --prune deletes.
 	RemovePaths []string `json:"remove_paths,omitempty"`
+	// ExtraKeys are keys present in some copies but not all: the same file
+	// migrated twice and edited since. Their presence blocks any removal
+	// pick, because retiring a copy holding a key the others lack would
+	// silently drop that secret.
+	ExtraKeys []string `json:"extra_keys,omitempty"`
 }
 
 // sharedFinding is one shared-credential verdict: the same value stored
@@ -124,9 +129,9 @@ var (
 var vaultDuplicatesCmd = &cobra.Command{
 	Use:   "duplicates",
 	Short: "Report groups that hold the same secrets, and which are safe to retire",
-	Long: "Compares every stored secret's decrypted value in memory (one unlock, no\n" +
-		"value ever printed or written) and reports two things `jit vault list`\n" +
-		"cannot know from names alone:\n\n" +
+	Long: "Compares every stored secret's decrypted value in memory (no value is ever\n" +
+		"printed or written) and reports two things `jit vault list` cannot know\n" +
+		"from names alone:\n\n" +
 		"  " + "Duplicated groups: the same key names migrated from the same file, or\n" +
 		"  from two copies of it (a re-migrated project, a copied workspace tree).\n" +
 		"  When the values still match, the report names the copy that looks stale\n" +
@@ -148,7 +153,12 @@ var vaultDuplicatesCmd = &cobra.Command{
 		"and drops its profile — deleting just the secrets would leave a mount\n" +
 		"serving a file nothing can fill), a copy a profile still names is a\n" +
 		"per-path `jit vault rm` decision, and diverged or shared copies are never\n" +
-		"jit's call at all. --prune always reports what it left behind and why.",
+		"jit's call at all. --prune always reports what it left behind and why.\n\n" +
+		"Reading every value means unlocking the vault and, for each credential\n" +
+		"CLASS the per-process consent gate covers (aws, kube, git, shell_history,\n" +
+		"...), approving that class once. A vault holding two gated classes\n" +
+		"therefore asks about three times, not once: the unlock plus one per class.\n" +
+		"`jit service consent off` removes the per-class half.",
 	Example: "  jit vault duplicates\n" +
 		"  jit vault duplicates --prune\n" +
 		"  jit vault duplicates --format json",
@@ -365,60 +375,166 @@ func gatherDupGroups(v *vault.Vault, root, cwd string, secrets []string) (map[st
 // claimNamespace "-2" fork is the later arrival). No pick at all when
 // values differ.
 func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
-	byEvidence := map[string][]*dupGroup{}
+	// Cluster on the origin TAIL only. Requiring an identical key set as
+	// well was too strict for the most ordinary real shape: copy a
+	// workspace, then edit one copy. A real vault had
+	// .../okta-mcp-server/.env migrated from two trees where one copy had
+	// since gained OKTA_PRIVATE_KEY — same file, four identical values, and
+	// the exact-set rule paired neither.
+	byTail := map[string][]*dupGroup{}
+	var tails []string
 	for _, g := range groups {
 		if g.sourceFile() == "" || len(g.keys) == 0 {
 			continue
 		}
-		sig := strings.Join(g.keys, "\x00") + "\x00\x00" + originTail(g.sourceFile())
-		byEvidence[sig] = append(byEvidence[sig], g)
+		t := originTail(g.sourceFile())
+		if _, ok := byTail[t]; !ok {
+			tails = append(tails, t)
+		}
+		byTail[t] = append(byTail[t], g)
 	}
+	sort.Strings(tails)
+
 	var findings []dupFinding
-	for _, cluster := range byEvidence {
+	for _, tail := range tails {
+		cluster := byTail[tail]
 		if len(cluster) < 2 {
 			continue
 		}
-		sort.Slice(cluster, func(i, j int) bool { return cluster[i].name < cluster[j].name })
-		f := dupFinding{Keys: cluster[0].keys, SameOrigin: true, ValuesMatch: true}
-		for _, g := range cluster {
-			f.Groups = append(f.Groups, g.name)
-			f.Origins = append(f.Origins, g.sourceFile())
-			if g.sourceFile() != cluster[0].sourceFile() {
-				f.SameOrigin = false
+		// One .mcp.json yields one profile PER SERVER, so a shared tail
+		// alone is not duplication: mcp-caido-2 and mcp-okta-mcp-server
+		// both come from ai_security_workspace/.mcp.json and share no key
+		// at all. Groups pair only when their keys actually overlap and
+		// every shared value matches (relatedGroups).
+		//
+		// Widest first, so a subset attaches to its superset rather than
+		// seeding its own finding.
+		sort.Slice(cluster, func(i, j int) bool {
+			if len(cluster[i].keys) != len(cluster[j].keys) {
+				return len(cluster[i].keys) > len(cluster[j].keys)
 			}
-			for _, k := range f.Keys {
-				if g.hashes[k] == "" || g.hashes[k] != cluster[0].hashes[k] {
-					f.ValuesMatch = false
+			return cluster[i].name < cluster[j].name
+		})
+		var buckets [][]*dupGroup
+		for _, g := range cluster {
+			placed := false
+			for i := range buckets {
+				if relatedGroups(buckets[i][0], g) {
+					buckets[i] = append(buckets[i], g)
+					placed = true
+					break
 				}
 			}
-		}
-		if f.ValuesMatch {
-			pick := pickRemoval(cluster)
-			f.RemoveGroup = pick.name
-			f.RemovePaths = groupSecretPaths(pick)
-			switch {
-			case pick.sourceFile() != "" && pick.originExists:
-				// The file is still there, so retiring this copy means
-				// un-migrating it: restore its plaintext, deregister its
-				// mount, drop its profile. That is `jit migrate remove`'s
-				// whole job — --prune must not reimplement it, and must
-				// not delete the secrets out from under a mount that is
-				// still serving the file.
-				f.RemoveCommand = "jit migrate remove " + shortPath(pick.sourceFile())
-			case len(pick.profiles) == 0:
-				f.RemoveCommand = "jit vault duplicates --prune"
-				f.Prunable = true
-			default:
-				// Origin gone but a profile still names these paths:
-				// deleting them leaves that manifest pointing at holes.
-				// Worth doing, but as a decision the user makes per path.
-				f.RemoveCommand = "jit vault rm " + strings.Join(f.RemovePaths, " ")
+			if !placed {
+				buckets = append(buckets, []*dupGroup{g})
 			}
 		}
-		findings = append(findings, f)
+		for _, bucket := range buckets {
+			if len(bucket) < 2 {
+				continue
+			}
+			findings = append(findings, buildDupFinding(bucket))
+		}
 	}
 	sort.Slice(findings, func(i, j int) bool { return findings[i].Groups[0] < findings[j].Groups[0] })
 	return findings
+}
+
+// relatedGroups reports whether b looks like a descendant of the same file
+// as a: their keys overlap substantially (b's keys are a subset of a's, or
+// they share at least half of the wider set). Sharing an origin tail alone
+// is not enough — one .mcp.json produces one profile PER SERVER, and those
+// siblings share the tail while holding disjoint keys.
+//
+// Value equality is deliberately NOT a gate here. It is the VERDICT
+// (ValuesMatch), not the evidence of common ancestry: two copies of one
+// file whose values have since diverged are still copies, and are exactly
+// what the user most needs told about. Gating on it made diverged copies
+// vanish from the report entirely.
+func relatedGroups(a, b *dupGroup) bool {
+	shared := 0
+	for _, k := range b.keys {
+		if _, ok := a.hashes[k]; ok {
+			shared++
+		}
+	}
+	if shared == 0 {
+		return false
+	}
+	wider := len(a.keys)
+	if len(b.keys) > wider {
+		wider = len(b.keys)
+	}
+	return shared == len(b.keys) || shared == len(a.keys) || shared*2 >= wider
+}
+
+// buildDupFinding turns one bucket of related groups into a finding. Keys
+// are the SHARED set; a copy that has since gained or lost a key is still
+// the same file's descendant, but it gets no removal pick, because retiring
+// a copy holding a key the survivor lacks would silently drop that secret.
+func buildDupFinding(bucket []*dupGroup) dupFinding {
+	sort.Slice(bucket, func(i, j int) bool { return bucket[i].name < bucket[j].name })
+	sharedKeys := append([]string(nil), bucket[0].keys...)
+	for _, g := range bucket[1:] {
+		var keep []string
+		for _, k := range sharedKeys {
+			if _, ok := g.hashes[k]; ok {
+				keep = append(keep, k)
+			}
+		}
+		sharedKeys = keep
+	}
+	sort.Strings(sharedKeys)
+
+	f := dupFinding{Keys: sharedKeys, SameOrigin: true, ValuesMatch: true}
+	sameKeySet := true
+	for _, g := range bucket {
+		f.Groups = append(f.Groups, g.name)
+		f.Origins = append(f.Origins, g.sourceFile())
+		if g.sourceFile() != bucket[0].sourceFile() {
+			f.SameOrigin = false
+		}
+		if len(g.keys) != len(sharedKeys) {
+			sameKeySet = false
+			f.ExtraKeys = append(f.ExtraKeys, extraKeys(g, sharedKeys)...)
+		}
+		for _, k := range sharedKeys {
+			if g.hashes[k] == "" || g.hashes[k] != bucket[0].hashes[k] {
+				f.ValuesMatch = false
+			}
+		}
+	}
+	sort.Strings(f.ExtraKeys)
+	f.ExtraKeys = slices.Compact(f.ExtraKeys)
+	if !f.ValuesMatch || !sameKeySet {
+		// Diverged in value, or one copy carries a key the others don't:
+		// either way jit must not nominate a copy to delete.
+		return f
+	}
+	pick := pickRemoval(bucket)
+	f.RemoveGroup = pick.name
+	f.RemovePaths = groupSecretPaths(pick)
+	switch {
+	case pick.sourceFile() != "" && pick.originExists:
+		f.RemoveCommand = "jit migrate remove " + shortPath(pick.sourceFile())
+	case len(pick.profiles) == 0:
+		f.RemoveCommand = "jit vault duplicates --prune"
+		f.Prunable = true
+	default:
+		f.RemoveCommand = "jit vault rm " + strings.Join(f.RemovePaths, " ")
+	}
+	return f
+}
+
+// extraKeys are g's keys outside the shared set.
+func extraKeys(g *dupGroup, shared []string) []string {
+	var extra []string
+	for _, k := range g.keys {
+		if !slices.Contains(shared, k) {
+			extra = append(extra, k)
+		}
+	}
+	return extra
 }
 
 // pickRemoval chooses which copy of a matching cluster the report suggests
@@ -513,7 +629,7 @@ func sharedCredentialFindings(groups map[string]*dupGroup, consumed []dupFinding
 func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []sharedFinding, compared int) {
 	if len(findings) == 0 && len(shared) == 0 {
 		fmt.Fprintf(out, "No duplicates: every group's keys, origins and values are distinct.\n")
-		fmt.Fprintf(out, "%d %s compared under one unlock; values never left memory.\n",
+		fmt.Fprintf(out, "%d %s compared in memory; no value was printed or written.\n",
 			compared, pluralWord(compared, "secret", "secrets"))
 		return
 	}
@@ -560,7 +676,7 @@ func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []shared
 		fmt.Fprint(out, hlCmds(fmt.Sprintf("%s can be deleted here (origin file gone, referenced by nothing): `jit vault duplicates --prune`\n",
 			countWord(prunable, "finding", "findings"))))
 	}
-	fmt.Fprintf(out, "%d %s compared under one unlock; values never left memory.\n",
+	fmt.Fprintf(out, "%d %s compared in memory; no value was printed or written.\n",
 		compared, pluralWord(compared, "secret", "secrets"))
 }
 
@@ -570,6 +686,8 @@ func printDupFinding(out io.Writer, f dupFinding) {
 	switch {
 	case f.SameOrigin:
 		fmt.Fprintln(out, ": one file, migrated more than once")
+	case len(f.ExtraKeys) > 0:
+		fmt.Fprintln(out, ": one file, migrated twice and edited since")
 	case f.ValuesMatch:
 		fmt.Fprintln(out, ": one file, migrated from two copies")
 	default:
@@ -583,8 +701,11 @@ func printDupFinding(out io.Writer, f dupFinding) {
 	if !f.ValuesMatch {
 		match = "values DIFFER"
 	}
-	fmt.Fprintf(out, "  %s same %d %s (%s), %s\n", glyphBranch, len(f.Keys), keysLabel,
+	fmt.Fprintf(out, "  %s %d shared %s (%s), %s\n", glyphBranch, len(f.Keys), keysLabel,
 		truncateList(f.Keys, 3), match)
+	if len(f.ExtraKeys) > 0 {
+		fmt.Fprintf(out, "  %s not in every copy: %s\n", glyphBranch, truncateList(f.ExtraKeys, 3))
+	}
 	wide := 0
 	for _, g := range f.Groups {
 		if len(g) > wide {
@@ -597,6 +718,8 @@ func printDupFinding(out io.Writer, f dupFinding) {
 	switch {
 	case !f.ValuesMatch:
 		fmt.Fprintln(out, "  the copies no longer agree; compare the files before retiring either")
+	case len(f.ExtraKeys) > 0:
+		fmt.Fprintln(out, "  one copy holds keys the other doesn't; retiring either would lose them")
 	case f.RemoveCommand != "":
 		fmt.Fprintf(out, "  keep the copy your tools read; %s looks stale, retire it with:\n", f.RemoveGroup)
 		_, _ = cPath.Fprintf(out, "  %s %s\n", glyphAction, f.RemoveCommand)

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -18,6 +18,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jitpass/jit/internal/vault"
+	"github.com/jitpass/jit/internal/wrap"
 )
 
 // jit vault duplicates is the answer to "which of these look-alike groups
@@ -53,12 +54,32 @@ import (
 // a per-key digest of its decrypted values.
 type dupGroup struct {
 	name         string
-	keys         []string          // sorted key names
-	origin       string            // uniform recorded origin, "" when absent/mixed
-	originExists bool              // stat of origin, false when origin == ""
-	profiles     []string          // referencing profile names (deduped)
-	mountPath    string            // a mount serving this group's profile, "" when none
-	hashes       map[string]string // key -> value digest
+	keys         []string // sorted key names
+	origin       string   // uniform recorded origin, "" when absent/mixed
+	originExists bool     // stat of origin, false when origin == ""
+	profiles     []string // referencing profile names (deduped)
+	mountPath    string   // a mount serving this group's profile, "" when none
+	// ownerConfig is the source file the referencing PROFILE records, the
+	// fallback provenance for a pre-provenance secret whose envelope has no
+	// Origin. See sourceFile.
+	ownerConfig string
+	hashes      map[string]string // key -> value digest
+}
+
+// sourceFile is the group's best evidence of which file it came from: the
+// envelope's recorded Origin, or — for a PRE-PROVENANCE secret, whose
+// envelope has no Origin field at all — the source config the referencing
+// profile records. Without the fallback every secret migrated before
+// provenance shipped is invisible to duplicate detection, which is exactly
+// how a real vault's clearest duplicate went unreported: the older copy
+// (`mcp-caido`) predated provenance and was skipped, so its newer twin
+// (`mcp-caido-2`) had nothing to pair with and both landed in the
+// shared-credentials bucket as "keep all".
+func (g *dupGroup) sourceFile() string {
+	if g.origin != "" {
+		return g.origin
+	}
+	return g.ownerConfig
 }
 
 // dupFinding is one same-file verdict: two or more groups holding the same
@@ -302,6 +323,9 @@ func gatherDupGroups(v *vault.Vault, root, cwd string, secrets []string) (map[st
 			if r.MountPath != "" && g.mountPath == "" {
 				g.mountPath = r.MountPath
 			}
+			if r.OwnerConfig != "" && g.ownerConfig == "" {
+				g.ownerConfig = r.OwnerConfig
+			}
 		}
 
 		value, err := v.Get(p)
@@ -312,11 +336,21 @@ func gatherDupGroups(v *vault.Vault, root, cwd string, secrets []string) (map[st
 		g.hashes[key] = fmt.Sprintf("%x", sum)
 		compared++
 	}
+	home, _ := os.UserHomeDir()
 	for _, g := range groups {
 		sort.Strings(g.keys)
 		sort.Strings(g.profiles)
-		if g.origin != "" {
-			_, statErr := os.Stat(g.origin)
+		if g.sourceFile() != "" {
+			// Origin is stored ALREADY tilde-shortened ("~/proj/.env", see
+			// newProvenance), so it must be expanded before it can be
+			// stat'ed. Statting it raw always failed, which made
+			// originExists permanently false: the `jit migrate remove`
+			// branch below became dead code and every live duplicate was
+			// routed to `jit vault rm` instead — the precise advice this
+			// command exists to stop giving. Caught end to end on a real
+			// vault, not by a unit test, because the tests supplied
+			// absolute origins that no real migration ever writes.
+			_, statErr := os.Stat(wrap.ExpandHome(home, g.sourceFile()))
 			g.originExists = statErr == nil
 		}
 	}
@@ -333,10 +367,10 @@ func gatherDupGroups(v *vault.Vault, root, cwd string, secrets []string) (map[st
 func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
 	byEvidence := map[string][]*dupGroup{}
 	for _, g := range groups {
-		if g.origin == "" || len(g.keys) == 0 {
+		if g.sourceFile() == "" || len(g.keys) == 0 {
 			continue
 		}
-		sig := strings.Join(g.keys, "\x00") + "\x00\x00" + originTail(g.origin)
+		sig := strings.Join(g.keys, "\x00") + "\x00\x00" + originTail(g.sourceFile())
 		byEvidence[sig] = append(byEvidence[sig], g)
 	}
 	var findings []dupFinding
@@ -348,8 +382,8 @@ func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
 		f := dupFinding{Keys: cluster[0].keys, SameOrigin: true, ValuesMatch: true}
 		for _, g := range cluster {
 			f.Groups = append(f.Groups, g.name)
-			f.Origins = append(f.Origins, g.origin)
-			if g.origin != cluster[0].origin {
+			f.Origins = append(f.Origins, g.sourceFile())
+			if g.sourceFile() != cluster[0].sourceFile() {
 				f.SameOrigin = false
 			}
 			for _, k := range f.Keys {
@@ -363,14 +397,14 @@ func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
 			f.RemoveGroup = pick.name
 			f.RemovePaths = groupSecretPaths(pick)
 			switch {
-			case pick.origin != "" && pick.originExists:
+			case pick.sourceFile() != "" && pick.originExists:
 				// The file is still there, so retiring this copy means
 				// un-migrating it: restore its plaintext, deregister its
 				// mount, drop its profile. That is `jit migrate remove`'s
 				// whole job — --prune must not reimplement it, and must
 				// not delete the secrets out from under a mount that is
 				// still serving the file.
-				f.RemoveCommand = "jit migrate remove " + shortPath(pick.origin)
+				f.RemoveCommand = "jit migrate remove " + shortPath(pick.sourceFile())
 			case len(pick.profiles) == 0:
 				f.RemoveCommand = "jit vault duplicates --prune"
 				f.Prunable = true
@@ -391,7 +425,7 @@ func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
 // retiring. It is a suggestion, printed under a caveat — never acted on.
 func pickRemoval(cluster []*dupGroup) *dupGroup {
 	for _, g := range cluster {
-		if g.origin != "" && !g.originExists {
+		if g.sourceFile() != "" && !g.originExists {
 			return g
 		}
 	}
@@ -482,6 +516,14 @@ func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []shared
 		fmt.Fprintf(out, "%d %s compared under one unlock; values never left memory.\n",
 			compared, pluralWord(compared, "secret", "secrets"))
 		return
+	}
+	// The zero-findings header still prints when there ARE shared
+	// credentials: without it the report opens on "[shared credentials]"
+	// and there is no way to tell whether duplicates were checked and none
+	// found, or the check never ran.
+	if len(findings) == 0 {
+		_, _ = cBold.Fprintf(out, "[duplicates]")
+		fmt.Fprintf(out, " none across %d stored %s\n", compared, pluralWord(compared, "secret", "secrets"))
 	}
 	if len(findings) > 0 {
 		_, _ = cBold.Fprintf(out, "[duplicates]")

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -163,7 +163,7 @@ func TestPrintDuplicatesReport(t *testing.T) {
 	for _, want := range []string{
 		"[duplicates] 1 finding across 118 stored secrets",
 		"mcp-caido, mcp-caido-2: one file, migrated from two copies",
-		"same 1 key (CAIDO_URL), identical values",
+		"1 shared key (CAIDO_URL), identical values",
 		"from /u/Documents/ws/.mcp.json",
 		"mcp-caido-2 looks stale, retire it with:",
 		"jit migrate remove /u/Desktop/ws/.mcp.json",
@@ -171,7 +171,7 @@ func TestPrintDuplicatesReport(t *testing.T) {
 		"JAMF_CLIENT_ID",
 		"shared by 2 profiles",
 		"removing any copy breaks its tool; when rotating, update every copy",
-		"118 secrets compared under one unlock; values never left memory.",
+		"118 secrets compared in memory; no value was printed or written.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("report missing %q, got:\n%s", want, out)
@@ -309,6 +309,54 @@ func TestSameFileFindingsUsesProfileSourceForPreProvenance(t *testing.T) {
 				t.Errorf("a paired duplicate must not also read as a shared credential: %+v", shared)
 			}
 		}
+	}
+}
+
+// TestSameFileFindingsCopiedThenEdited covers the ordinary real shape an
+// exact-key-set rule missed: a workspace copied and migrated from both
+// trees, then edited so one copy carries a key the other lacks. On a real
+// vault that was .../okta-mcp-server/.env in two trees, one of which had
+// gained OKTA_PRIVATE_KEY — same file, four identical values, and neither
+// copy reported. It must pair, must say which keys are not in every copy,
+// and must offer NO removal pick: retiring either would drop a secret.
+func TestSameFileFindingsCopiedThenEdited(t *testing.T) {
+	wide := dupTestGroup("okta-mcp-server", "~/Desktop/Share/ws/mcp_servers/okta-mcp-server/.env",
+		true, []string{"okta-mcp-server"}, map[string]string{
+			"OKTA_CLIENT_ID": "id", "OKTA_KEY_ID": "kid", "OKTA_ORG_URL": "url",
+			"OKTA_SCOPES": "scopes", "OKTA_PRIVATE_KEY": "pem",
+		})
+	narrow := dupTestGroup("okta-mcp-server-2", "~/Documents/ws/mcp_servers/okta-mcp-server/.env",
+		true, []string{"okta-mcp-server-2"}, map[string]string{
+			"OKTA_CLIENT_ID": "id", "OKTA_KEY_ID": "kid", "OKTA_ORG_URL": "url",
+			"OKTA_SCOPES": "scopes",
+		})
+	fs := sameFileFindings(map[string]*dupGroup{
+		"okta-mcp-server": wide, "okta-mcp-server-2": narrow,
+	})
+	if len(fs) != 1 {
+		t.Fatalf("a copied-then-edited pair must still report, got %+v", fs)
+	}
+	f := fs[0]
+	if len(f.Keys) != 4 {
+		t.Errorf("Keys must be the SHARED set, got %v", f.Keys)
+	}
+	if strings.Join(f.ExtraKeys, ",") != "OKTA_PRIVATE_KEY" {
+		t.Errorf("ExtraKeys = %v, want the key only one copy holds", f.ExtraKeys)
+	}
+	if f.RemoveGroup != "" || f.RemoveCommand != "" || f.Prunable {
+		t.Errorf("no removal pick when a copy holds keys the other lacks, got %+v", f)
+	}
+
+	// Siblings from ONE file (one .mcp.json, one profile per server) share
+	// the origin tail but no keys: they must never pair.
+	caido := dupTestGroup("mcp-caido-2", "~/Documents/ws/.mcp.json", true, nil,
+		map[string]string{"CAIDO_URL": "u"})
+	okta := dupTestGroup("mcp-okta-mcp-server", "~/Documents/ws/.mcp.json", true, nil,
+		map[string]string{"OKTA_ORG_URL": "o", "OKTA_SCOPES": "s"})
+	if fs = sameFileFindings(map[string]*dupGroup{
+		"mcp-caido-2": caido, "mcp-okta-mcp-server": okta,
+	}); len(fs) != 0 {
+		t.Errorf("servers from one config file are siblings, not copies, got %+v", fs)
 	}
 }
 

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -203,6 +203,115 @@ func TestPrintDuplicatesReport(t *testing.T) {
 	}
 }
 
+// TestGatherDupGroupsExpandsTildeOrigins pins the form real migrations
+// write. Origin is stored ALREADY tilde-shortened ("~/proj/.env"), so
+// statting it raw always failed and originExists was permanently false:
+// the `jit migrate remove` remedy became dead code and every live
+// duplicate was routed to `jit vault rm`, the precise advice this command
+// exists to stop giving. The earlier tests missed it by supplying absolute
+// origins no migration ever records.
+func TestGatherDupGroupsExpandsTildeOrigins(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := t.TempDir()
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+
+	// A real file under the fixture home, recorded the way migrate records
+	// it: relative to home, with a leading "~/".
+	if err := os.MkdirAll(filepath.Join(home, "proj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	livePath := filepath.Join(home, "proj", ".env")
+	if err := os.WriteFile(livePath, []byte("A=1\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.SetWithMeta("live/A", []byte("secret-value"),
+		vault.Meta{Class: vault.ClassDotenv, Origin: "~/proj/.env"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := v.SetWithMeta("gone/A", []byte("secret-value"),
+		vault.Meta{Class: vault.ClassDotenv, Origin: "~/deleted/.env"}); err != nil {
+		t.Fatal(err)
+	}
+
+	groups, _, err := gatherDupGroups(v, root, cwd, []string{"live/A", "gone/A"})
+	if err != nil {
+		t.Fatalf("gatherDupGroups: %v", err)
+	}
+	if g := groups["live"]; g == nil || !g.originExists {
+		t.Errorf("a tilde origin whose file EXISTS must stat true, got %+v", g)
+	}
+	if g := groups["gone"]; g == nil || g.originExists {
+		t.Errorf("a tilde origin whose file is gone must stat false, got %+v", g)
+	}
+
+	// End to end: the live copy must be routed to migrate remove, never rm.
+	groups["live"].keys = []string{"A"}
+	groups["gone"].keys = []string{"A"}
+	groups["gone"].origin = "~/proj/.env" // same tail, so they cluster
+	groups["gone"].originExists = false
+	fs := sameFileFindings(groups)
+	if len(fs) != 1 {
+		t.Fatalf("want one finding, got %+v", fs)
+	}
+	if fs[0].RemoveGroup != "gone" {
+		t.Errorf("the copy whose file is gone must be the pick, got %+v", fs[0])
+	}
+	// And with the live one picked instead, the remedy must be migrate remove.
+	groups["gone"].originExists = true
+	fs = sameFileFindings(groups)
+	if len(fs) != 1 || !strings.HasPrefix(fs[0].RemoveCommand, "jit migrate remove ") {
+		t.Errorf("a copy whose file exists must route to migrate remove, got %+v", fs)
+	}
+}
+
+// TestSameFileFindingsUsesProfileSourceForPreProvenance is the miss that
+// made v0.92.0 useless on the vault it was built for. A pre-provenance
+// (v1/v2) envelope carries NO Origin, so keying on Origin alone skipped the
+// older copy entirely, its newer twin had nothing to pair with, and both
+// landed in "shared credentials, keep all" — the report calling a real
+// duplicate a credential to keep. The referencing profile's recorded source
+// is the evidence that does exist for those secrets, and is what
+// `jit vault get`'s own "migrated from" footer has always shown.
+func TestSameFileFindingsUsesProfileSourceForPreProvenance(t *testing.T) {
+	// The older copy: no Origin at all, only a profile-recorded source.
+	old := dupTestGroup("mcp-caido", "", true, []string{"mcp-caido"}, map[string]string{"CAIDO_URL": "v1"})
+	old.ownerConfig = "~/Documents/ai_security_workspace/.mcp.json"
+	// The newer twin, migrated after provenance shipped.
+	newer := dupTestGroup("mcp-caido-2", "~/Desktop/Share/ai_security_workspace/.mcp.json",
+		true, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "v1"})
+
+	groups := map[string]*dupGroup{"mcp-caido": old, "mcp-caido-2": newer}
+	fs := sameFileFindings(groups)
+	if len(fs) != 1 {
+		t.Fatalf("a pre-provenance copy must still pair with its twin, got %+v", fs)
+	}
+	if strings.Join(fs[0].Groups, ",") != "mcp-caido,mcp-caido-2" {
+		t.Errorf("groups = %v", fs[0].Groups)
+	}
+	// Its origin column must show the profile-recorded source, not blank.
+	if fs[0].Origins[0] != "~/Documents/ai_security_workspace/.mcp.json" {
+		t.Errorf("origins = %v, want the profile source for the pre-provenance copy", fs[0].Origins)
+	}
+	if !fs[0].ValuesMatch {
+		t.Errorf("identical values must still compare equal, got %+v", fs[0])
+	}
+
+	// And it must be excluded from the shared-credentials bucket, which is
+	// where it wrongly showed up before.
+	shared := sharedCredentialFindings(groups, fs)
+	for _, f := range shared {
+		for _, g := range f.Groups {
+			if g == "mcp-caido" || g == "mcp-caido-2" {
+				t.Errorf("a paired duplicate must not also read as a shared credential: %+v", shared)
+			}
+		}
+	}
+}
+
 // TestPruneDuplicatesOnlyTouchesTheSafeShape is the guard that matters:
 // --prune must delete ONLY a stale copy whose origin file is gone and which
 // nothing references, must leave every other shape alone, and must say so

--- a/internal/cli/vaultrefs.go
+++ b/internal/cli/vaultrefs.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
 	"github.com/jitpass/jit/internal/profile"
 )
@@ -20,6 +21,13 @@ type secretReference struct {
 	ProfileName string
 	Scope       profile.Scope
 	MountPath   string // the mounted file this profile feeds, "" when none
+	// OwnerConfig is the config file the referencing profile records as its
+	// source (migrate.ProfileOwnerConfig). It is the ONLY provenance a
+	// pre-provenance (v1/v2) secret has: those envelopes carry no Origin
+	// field at all, so anything keying on Origin alone is blind to every
+	// secret migrated before provenance shipped. `jit vault get`'s
+	// "migrated from" footer has always read this rather than Origin.
+	OwnerConfig string
 }
 
 // referencesForPaths maps each requested vault path to whatever jit can see
@@ -36,7 +44,8 @@ func referencesForPaths(root, cwd string, paths []string) map[string][]secretRef
 		wanted[p] = true
 	}
 	refs := map[string][]secretReference{}
-	seen := map[string]bool{} // profile file path -> already consumed
+	seen := map[string]bool{}    // profile file path -> already consumed
+	owner := map[string]string{} // profile file path -> its recorded source config
 	add := func(profilePath, name string, scope profile.Scope, mountPath string) {
 		if seen[profilePath] {
 			// A mount whose profile was already listed still needs its
@@ -61,10 +70,16 @@ func referencesForPaths(root, cwd string, paths []string) map[string][]secretRef
 		if err != nil {
 			return
 		}
+		src, ok := owner[profilePath]
+		if !ok {
+			src = migrate.ProfileOwnerConfig(profilePath)
+			owner[profilePath] = src
+		}
 		for _, vaultPath := range entries {
 			if wanted[vaultPath] {
 				refs[vaultPath] = append(refs[vaultPath], secretReference{
 					ProfileName: name, Scope: scope, MountPath: mountPath,
+					OwnerConfig: src,
 				})
 			}
 		}


### PR DESCRIPTION
Follow-up to #53. Running v0.92.0 against a real 118-secret vault (rather than only unit tests) surfaced three defects. Together they meant the clearest duplicate on that machine — one `.mcp.json` in a workspace folder copied and migrated twice — was reported as a **shared credential to keep**:

```
● CAIDO_URL shared by 2 profiles
  └ mcp-caido, mcp-caido-2
  removing any copy breaks its tool; when rotating, update every copy
```

## 1. Pre-provenance secrets were invisible (the headline miss)

A v1/v2 envelope carries **no `Origin` field at all**. Keying duplicate evidence on `Origin` alone skipped every secret migrated before provenance shipped: the older copy was excluded, its newer twin had nothing to pair with, and both fell through to the shared-credentials bucket.

Groups now fall back to the source the referencing **profile** records (`migrate.ProfileOwnerConfig`) — the evidence that does exist for those secrets, and exactly what `jit vault get`'s own "migrated from" footer has always read. My original assumption that the footer proved `Origin` was set is what hid this.

## 2. Tilde origins made the correct remedy dead code

`Origin` is stored already shortened (`~/proj/.env`), so `os.Stat` on it always failed and `originExists` was permanently false. The `jit migrate remove` branch could never be reached, and **every live duplicate was routed to `jit vault rm`** — the precise advice this command exists to stop giving, since `rm` leaves the profile naming a hole and the mount serving a FIFO nothing can fill.

The unit tests missed it by supplying absolute origins that no real migration ever writes.

## 3. Migrate's disclosure never fired

The value index is built lazily, i.e. *after* the run's file is stored, so a copy's own freshly-written path could win the digest slot (`ws-copy/CAIDO_URL` sorts before `ws/CAIDO_URL`) and the lookup saw itself instead of the older copy. The index now keeps every path per digest and skips the migrating profile's own.

## Also

`[duplicates] none across N stored secrets` now prints when there are shared credentials but no duplicates, so a clean check is distinguishable from a check that never ran.

## Verification

Each fix has a regression test in the shape production actually produces: tilde origins, an index built after the write, and an origin-less group paired via its profile source. Beyond that, all three were reproduced and then confirmed fixed **end to end on a real vault with real Touch ID**, including the exact `mcp-caido`/`mcp-caido-2` shape:

```
[duplicates] 2 findings across 24 stored secrets

○ mcp-caido, mcp-caido-2: one file, migrated from two copies
  └ same 1 key (CAIDO_URL), identical values
  └ mcp-caido    from ~/mcptest/aiws/.mcp.json
  └ mcp-caido-2  from ~/mcptest2/aiws/.mcp.json
  keep the copy your tools read; mcp-caido-2 looks stale, retire it with:
  → jit migrate remove ~/mcptest2/aiws/.mcp.json
```

The `jit vault rm` reference warning and the migrate-time disclosure note were both observed firing live. Full local gate passes: gofmt, vet, staticcheck, gosec, `go test -race` across all packages, docs-gen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143e5FSR3EwcJXtphv3fieo