### PR TITLE
vault duplicates: a remedy must not do more than the finding it fixes

### DIFF
--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -37,7 +37,7 @@ then reports:
 
   | The stale copy's origin file | Command | What it does |
   |---|---|---|
-  | still there | [`jit migrate remove <file>`](../migrate/undo-and-remove.md) | un-migrates that one file: **writes its values back as plaintext**, then deletes its profile, its secrets and its backups. Delete the file or folder yourself afterwards if you don't want it. |
+  | still there | [`jit migrate remove <file>`](../migrate/undo-and-remove.md) | un-migrates the **whole project** that owns the file, not just this copy: **writes its values back as plaintext**, then deletes its profiles, their secrets and their backups. Delete the files or folder yourself afterwards if you don't want them. |
   | already gone, nothing references it | `jit vault duplicates --prune` | deletes those secrets for you (see below) |
   | gone, but a profile still names it | `jit vault rm <paths>` | deletes exactly those secrets, leaving you to fix the profile |
 
@@ -46,6 +46,13 @@ then reports:
   cannot break a tool that shares the credential. Copies that have diverged
   (same ancestry, different values now) are reported without a removal pick:
   which copy is right is your call.
+
+  Because `migrate remove` is scoped to the whole project, the report names
+  the other groups a remedy would take with it, and **withholds the remedy
+  entirely** when one of them is a copy the report itself declined to
+  nominate (for example one holding a key its twin lacks). Without that
+  guard, following one finding's advice could execute what another finding
+  had just forbidden.
 - **Shared credentials**: the same value stored by independent files, for
   example one API client used by five export scripts. These are *not* stale
   copies - removing any breaks its tool - and the report lists every place

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -105,6 +105,11 @@ type dupFinding struct {
 	Prunable bool `json:"prunable"`
 	// RemovePaths are the stale copy's vault paths, what --prune deletes.
 	RemovePaths []string `json:"remove_paths,omitempty"`
+	// DifferKeys are the shared keys whose values do NOT agree across the
+	// copies. "values DIFFER" alone left the reader unable to judge whether
+	// two groups are really one file's descendants; naming them says what
+	// to compare, and how much of the overlap actually diverged.
+	DifferKeys []string `json:"differ_keys,omitempty"`
 	// ExtraKeys are keys present in some copies but not all: the same file
 	// migrated twice and edited since. Their presence blocks any removal
 	// pick, because retiring a copy holding a key the others lack would
@@ -558,13 +563,29 @@ func underRoot(origin, root, home string) bool {
 // what the user most needs told about. Gating on it made diverged copies
 // vanish from the report entirely.
 func relatedGroups(a, b *dupGroup) bool {
-	shared := 0
+	shared, agreeing := 0, 0
 	for _, k := range b.keys {
-		if _, ok := a.hashes[k]; ok {
-			shared++
+		ha, ok := a.hashes[k]
+		if !ok {
+			continue
+		}
+		shared++
+		if ha != "" && ha == b.hashes[k] {
+			agreeing++
 		}
 	}
 	if shared == 0 {
+		return false
+	}
+	// Two DIFFERENT files that merely share an origin tail need at least
+	// one identical value to be called copies of each other. A tail like
+	// "jamf/.env" is generic — a real vault had one under
+	// ai_security_workspace and another under Repos/Security, unrelated
+	// projects that happened to name a directory the same thing. When the
+	// origin path is IDENTICAL the file is provably the same one, so no
+	// value evidence is needed (a re-migration fork may have rotated
+	// everything since).
+	if a.sourceFile() != b.sourceFile() && agreeing == 0 {
 		return false
 	}
 	wider := len(a.keys)
@@ -607,11 +628,15 @@ func buildDupFinding(bucket []*dupGroup) dupFinding {
 		for _, k := range sharedKeys {
 			if g.hashes[k] == "" || g.hashes[k] != bucket[0].hashes[k] {
 				f.ValuesMatch = false
+				if !slices.Contains(f.DifferKeys, k) {
+					f.DifferKeys = append(f.DifferKeys, k)
+				}
 			}
 		}
 	}
 	sort.Strings(f.ExtraKeys)
 	f.ExtraKeys = slices.Compact(f.ExtraKeys)
+	sort.Strings(f.DifferKeys)
 	if !f.ValuesMatch || !sameKeySet {
 		// Diverged in value, or one copy carries a key the others don't:
 		// either way jit must not nominate a copy to delete.
@@ -805,7 +830,8 @@ func printDupFinding(out io.Writer, f dupFinding) {
 	}
 	match := "identical values"
 	if !f.ValuesMatch {
-		match = "values DIFFER"
+		match = fmt.Sprintf("%d of %d differ: %s",
+			len(f.DifferKeys), len(f.Keys), truncateList(f.DifferKeys, 3))
 	}
 	fmt.Fprintf(out, "  %s %d shared %s (%s), %s\n", glyphBranch, len(f.Keys), keysLabel,
 		truncateList(f.Keys, 3), match)

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"slices"
 	"sort"
 	"strings"
@@ -109,6 +110,15 @@ type dupFinding struct {
 	// pick, because retiring a copy holding a key the others lack would
 	// silently drop that secret.
 	ExtraKeys []string `json:"extra_keys,omitempty"`
+	// AlsoRemoves names the OTHER vault groups the RemoveCommand would take
+	// with it. `jit migrate remove` is scoped to the project that owns the
+	// file, not to this finding, so naming one file un-migrates every
+	// profile under that project root.
+	AlsoRemoves []string `json:"also_removes,omitempty"`
+	// RemoveBlockedBy is set when the RemoveCommand's project scope covers a
+	// group belonging to a finding this report deliberately refused to
+	// nominate for removal. The remedy is then withheld entirely.
+	RemoveBlockedBy string `json:"remove_blocked_by,omitempty"`
 }
 
 // sharedFinding is one shared-credential verdict: the same value stored
@@ -437,7 +447,103 @@ func sameFileFindings(groups map[string]*dupGroup) []dupFinding {
 		}
 	}
 	sort.Slice(findings, func(i, j int) bool { return findings[i].Groups[0] < findings[j].Groups[0] })
+	annotateRemoveScope(findings, groups)
 	return findings
+}
+
+// annotateRemoveScope is the guard for the hazard that a per-finding remedy
+// cannot see on its own: `jit migrate remove <file>` resolves UP to the
+// .jit project that owns the file and un-migrates EVERYTHING under it, not
+// just this finding's copy.
+//
+// That turned one finding's safe advice into another finding's forbidden
+// action on a real vault. Retiring the stale `mcp-caido-2` meant naming
+// ~/Desktop/Share/ai_security_workspace/.mcp.json, whose project also owned
+// `okta-mcp-server` — the copy holding an OKTA_PRIVATE_KEY its twin lacks,
+// which this same report had just refused to nominate for removal because
+// retiring it would lose that key. Running the caido remedy deleted it.
+//
+// So: every migrate-remove remedy now names the other groups it would take
+// with it, and is WITHHELD outright when one of them belongs to a finding
+// that has no removal pick.
+func annotateRemoveScope(findings []dupFinding, groups map[string]*dupGroup) {
+	home, _ := os.UserHomeDir()
+	// Groups this report has deliberately declined to nominate: diverged
+	// values, or copies holding keys the others lack.
+	protected := map[string]bool{} // groups no finding would nominate
+	for _, f := range findings {
+		if f.RemoveGroup != "" {
+			continue
+		}
+		for _, g := range f.Groups {
+			protected[g] = true
+		}
+	}
+	for i := range findings {
+		f := &findings[i]
+		if !strings.HasPrefix(f.RemoveCommand, "jit migrate remove ") {
+			continue
+		}
+		pick := groups[f.RemoveGroup]
+		if pick == nil {
+			continue
+		}
+		root := migrateRemoveRoot(pick.sourceFile(), home)
+		if root == "" {
+			continue
+		}
+		var also []string
+		blocked := ""
+		for name, g := range groups {
+			if name == f.RemoveGroup || g.sourceFile() == "" {
+				continue
+			}
+			if !underRoot(g.sourceFile(), root, home) {
+				continue
+			}
+			also = append(also, name)
+			if protected[name] && blocked == "" {
+				blocked = name
+			}
+		}
+		sort.Strings(also)
+		f.AlsoRemoves = also
+		if blocked != "" {
+			// RemoveGroup survives: it still names the copy that looks
+			// stale, which the withheld-remedy message has to say. Only
+			// the COMMAND goes, because there isn't a safe one.
+			f.RemoveBlockedBy = blocked
+			f.RemoveCommand = ""
+			f.RemovePaths = nil
+			f.Prunable = false
+		}
+	}
+}
+
+// migrateRemoveRoot is the directory `jit migrate remove <origin>` would
+// actually operate on: the nearest ancestor of origin holding a .jit
+// project directory. Falls back to the file's own directory when no
+// project is found (already removed, or never one), and never walks past
+// $HOME.
+func migrateRemoveRoot(origin, home string) string {
+	abs := wrap.ExpandHome(home, origin)
+	dir := filepath.Dir(abs)
+	for d := dir; d != "" && d != "/" && d != home; d = filepath.Dir(d) {
+		if fi, err := os.Stat(filepath.Join(d, ".jit")); err == nil && fi.IsDir() {
+			return d
+		}
+		if parent := filepath.Dir(d); parent == d {
+			break
+		}
+	}
+	return dir
+}
+
+// underRoot reports whether a group's source file lives inside root.
+func underRoot(origin, root, home string) bool {
+	abs := wrap.ExpandHome(home, origin)
+	rel, err := filepath.Rel(root, abs)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // relatedGroups reports whether b looks like a descendant of the same file
@@ -716,6 +822,14 @@ func printDupFinding(out io.Writer, f dupFinding) {
 		fmt.Fprintf(out, "  %s %-*s  from %s\n", glyphBranch, wide, g, shortPath(f.Origins[i]))
 	}
 	switch {
+	case f.RemoveBlockedBy != "":
+		// The only command that could retire this copy would also take a
+		// group this report just refused to nominate. Withheld, and said
+		// out loud: a remedy that silently does more than it claims is
+		// worse than no remedy.
+		fmt.Fprintf(out, "  no safe one-command fix: retiring %s needs jit migrate remove,\n", f.RemoveGroup)
+		fmt.Fprintf(out, "  which un-migrates that whole project, taking %s with it\n", f.RemoveBlockedBy)
+		fmt.Fprintln(out, "  and that copy holds keys no other copy has")
 	case !f.ValuesMatch:
 		fmt.Fprintln(out, "  the copies no longer agree; compare the files before retiring either")
 	case len(f.ExtraKeys) > 0:
@@ -723,6 +837,16 @@ func printDupFinding(out io.Writer, f dupFinding) {
 	case f.RemoveCommand != "":
 		fmt.Fprintf(out, "  keep the copy your tools read; %s looks stale, retire it with:\n", f.RemoveGroup)
 		_, _ = cPath.Fprintf(out, "  %s %s\n", glyphAction, f.RemoveCommand)
+		if strings.HasPrefix(f.RemoveCommand, "jit migrate remove ") {
+			// Two consequences the command name does not convey: it is
+			// scoped to the whole project, and it un-migrates rather than
+			// deletes, so the files come back as PLAINTEXT.
+			if len(f.AlsoRemoves) > 0 {
+				fmt.Fprintf(out, "    that project also holds %s, which go with it\n",
+					truncateList(f.AlsoRemoves, 3))
+			}
+			fmt.Fprintln(out, "    its files return to plaintext on disk; delete them after")
+		}
 	}
 }
 

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -357,6 +358,118 @@ func TestSameFileFindingsCopiedThenEdited(t *testing.T) {
 		"mcp-caido-2": caido, "mcp-okta-mcp-server": okta,
 	}); len(fs) != 0 {
 		t.Errorf("servers from one config file are siblings, not copies, got %+v", fs)
+	}
+}
+
+// TestRemedyScopeWithheldWhenItWouldTakeAProtectedGroup reproduces the
+// incident this guard exists for. `jit migrate remove <file>` resolves up
+// to the .jit project owning the file and un-migrates EVERYTHING under it.
+// On a real vault, retiring the stale mcp-caido-2 meant naming
+// ~/Desktop/Share/ai_security_workspace/.mcp.json — whose project also
+// owned okta-mcp-server, the copy holding an OKTA_PRIVATE_KEY its twin
+// lacked, which the SAME report had just refused to nominate for removal.
+// Running the caido remedy deleted it. The remedy must now be withheld.
+func TestRemedyScopeWithheldWhenItWouldTakeAProtectedGroup(t *testing.T) {
+	home := withFixtureHome(t)
+	ws := filepath.Join(home, "Share", "ai_security_workspace")
+	nested := filepath.Join(ws, "ai_tooling", "mcp_servers", "okta-mcp-server")
+	if err := os.MkdirAll(filepath.Join(ws, ".jit"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel := func(p string) string { return "~" + strings.TrimPrefix(p, home) }
+
+	// The caido pair: identical values, so it would normally get a pick.
+	caidoOld := dupTestGroup("mcp-caido", "~/Documents/ai_security_workspace/.mcp.json",
+		true, []string{"mcp-caido"}, map[string]string{"CAIDO_URL": "u"})
+	caidoNew := dupTestGroup("mcp-caido-2", rel(filepath.Join(ws, ".mcp.json")),
+		true, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "u"})
+	// The okta pair, under the SAME project: one copy holds a key the other
+	// lacks, so it gets no pick — and must not be collateral damage.
+	oktaWide := dupTestGroup("okta-mcp-server", rel(filepath.Join(nested, ".env")),
+		true, []string{"okta-mcp-server"}, map[string]string{
+			"OKTA_CLIENT_ID": "id", "OKTA_ORG_URL": "url", "OKTA_PRIVATE_KEY": "pem",
+		})
+	oktaNarrow := dupTestGroup("okta-mcp-server-2", "~/Documents/ai_security_workspace/ai_tooling/mcp_servers/okta-mcp-server/.env",
+		true, []string{"okta-mcp-server-2"}, map[string]string{
+			"OKTA_CLIENT_ID": "id", "OKTA_ORG_URL": "url",
+		})
+
+	fs := sameFileFindings(map[string]*dupGroup{
+		"mcp-caido": caidoOld, "mcp-caido-2": caidoNew,
+		"okta-mcp-server": oktaWide, "okta-mcp-server-2": oktaNarrow,
+	})
+	var caido *dupFinding
+	for i := range fs {
+		if fs[i].Groups[0] == "mcp-caido" {
+			caido = &fs[i]
+		}
+	}
+	if caido == nil {
+		t.Fatalf("expected a caido finding, got %+v", fs)
+	}
+	if caido.RemoveCommand != "" || caido.Prunable {
+		t.Errorf("remedy must be withheld when its project scope covers a protected group, got %+v", caido)
+	}
+	if caido.RemoveGroup != "mcp-caido-2" {
+		t.Errorf("the stale copy is still named, only the command goes, got %q", caido.RemoveGroup)
+	}
+	if caido.RemoveBlockedBy != "okta-mcp-server" {
+		t.Errorf("the blocking GROUP must be named, got %q", caido.RemoveBlockedBy)
+	}
+	if !slices.Contains(caido.AlsoRemoves, "okta-mcp-server") {
+		t.Errorf("AlsoRemoves must list the group the command would take, got %v", caido.AlsoRemoves)
+	}
+
+	// Rendering says why, and offers no command to run.
+	var buf bytes.Buffer
+	printDupFinding(&buf, *caido)
+	out := buf.String()
+	if !strings.Contains(out, "no safe one-command fix") || !strings.Contains(out, "okta-mcp-server") {
+		t.Errorf("report must explain the withheld remedy, got:\n%s", out)
+	}
+	// The prose may NAME the command while explaining; what must never
+	// appear is the runnable directive line with a path to copy.
+	if strings.Contains(out, glyphAction+" jit migrate remove") {
+		t.Errorf("no runnable migrate remove line may be offered, got:\n%s", out)
+	}
+}
+
+// TestRemedyNamesWhatElseItTakes: when the project scope is safe, the
+// remedy still has to say what else goes with it and that the files come
+// back as plaintext — neither is conveyed by the command name.
+func TestRemedyNamesWhatElseItTakes(t *testing.T) {
+	home := withFixtureHome(t)
+	ws := filepath.Join(home, "proj")
+	if err := os.MkdirAll(filepath.Join(ws, ".jit"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel := func(p string) string { return "~" + strings.TrimPrefix(p, home) }
+
+	a := dupTestGroup("app", "~/Documents/proj/.env", true, []string{"app"},
+		map[string]string{"API_KEY": "k"})
+	b := dupTestGroup("app-2", rel(filepath.Join(ws, ".env")), true, []string{"app-2"},
+		map[string]string{"API_KEY": "k"})
+	// An unrelated group under the same project, in no finding of its own.
+	side := dupTestGroup("sidecar", rel(filepath.Join(ws, "sub", ".env")), true, nil,
+		map[string]string{"OTHER": "v"})
+
+	fs := sameFileFindings(map[string]*dupGroup{"app": a, "app-2": b, "sidecar": side})
+	if len(fs) != 1 {
+		t.Fatalf("want one finding, got %+v", fs)
+	}
+	if !slices.Contains(fs[0].AlsoRemoves, "sidecar") {
+		t.Errorf("AlsoRemoves must name the co-located group, got %v", fs[0].AlsoRemoves)
+	}
+	var buf bytes.Buffer
+	printDupFinding(&buf, fs[0])
+	out := buf.String()
+	for _, want := range []string{"jit migrate remove", "also holds sidecar", "return to plaintext"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("remedy missing %q, got:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -81,12 +81,27 @@ func TestSameFileFindings(t *testing.T) {
 		t.Errorf("a still-referenced copy must never be prunable: %+v", fs[0])
 	}
 
-	// Diverged values -> reported, but no removal pick: which copy is right
-	// is the user's call.
+	// Two DIFFERENT files whose only shared key disagrees are not evidenced
+	// copies at all: the matching tail is the sole link, and it is generic.
+	// See TestGenericTailNeedsValueEvidence.
 	groups["mcp-caido-2"] = dupTestGroup("mcp-caido-2", "/u/Desktop/ws/.mcp.json", true, []string{"mcp-caido-2"}, map[string]string{"CAIDO_URL": "v2"})
+	if fs = sameFileFindings(groups); len(fs) != 0 {
+		t.Errorf("no agreeing value across different files must not pair, got %+v", fs)
+	}
+
+	// Diverged values under ONE identical origin path -> still reported
+	// (the path proves it is one file), but no removal pick: which copy is
+	// right is the user's call.
+	groups = map[string]*dupGroup{
+		"fork":   dupTestGroup("fork", "/u/scripts/.env", true, []string{"fork"}, map[string]string{"A": "v1", "B": "same"}),
+		"fork-2": dupTestGroup("fork-2", "/u/scripts/.env", true, []string{"fork-2"}, map[string]string{"A": "v2", "B": "same"}),
+	}
 	fs = sameFileFindings(groups)
 	if len(fs) != 1 || fs[0].ValuesMatch || fs[0].RemoveCommand != "" || fs[0].RemoveGroup != "" {
 		t.Errorf("diverged finding = %+v, want values_match=false and no removal pick", fs)
+	}
+	if strings.Join(fs[0].DifferKeys, ",") != "A" {
+		t.Errorf("DifferKeys = %v, want only the key that disagrees", fs[0].DifferKeys)
 	}
 
 	// Same key set from UNRELATED files (different tails) is not a
@@ -358,6 +373,48 @@ func TestSameFileFindingsCopiedThenEdited(t *testing.T) {
 		"mcp-caido-2": caido, "mcp-okta-mcp-server": okta,
 	}); len(fs) != 0 {
 		t.Errorf("servers from one config file are siblings, not copies, got %+v", fs)
+	}
+}
+
+// TestGenericTailNeedsValueEvidence: an origin tail like "jamf/.env" is
+// generic, and a real vault had one under ai_security_workspace and another
+// under Repos/Security — unrelated projects that happened to name a
+// directory the same thing. Two DIFFERENT files therefore need at least one
+// identical value before the report calls them copies. The SAME file
+// migrated twice needs no such evidence, since its identity is proven by
+// the path.
+func TestGenericTailNeedsValueEvidence(t *testing.T) {
+	// Different files, generic tail, nothing agreeing -> not a pair.
+	a := dupTestGroup("jamf", "~/Documents/ws/custom_scripts/jamf/.env", true, nil,
+		map[string]string{"JAMF_CLIENT_ID": "one", "JAMF_URL": "two"})
+	b := dupTestGroup("jamf-2", "~/Repos/Security/jamf/.env", true, nil,
+		map[string]string{"JAMF_CLIENT_ID": "three", "JAMF_URL": "four"})
+	if fs := sameFileFindings(map[string]*dupGroup{"jamf": a, "jamf-2": b}); len(fs) != 0 {
+		t.Errorf("unrelated projects sharing a generic tail must not pair, got %+v", fs)
+	}
+
+	// One value in common is enough evidence of shared ancestry.
+	b.hashes["JAMF_URL"] = a.hashes["JAMF_URL"]
+	fs := sameFileFindings(map[string]*dupGroup{"jamf": a, "jamf-2": b})
+	if len(fs) != 1 {
+		t.Fatalf("a shared value is evidence of ancestry, got %+v", fs)
+	}
+	// And the report says WHICH values diverged, not just that some did.
+	if strings.Join(fs[0].DifferKeys, ",") != "JAMF_CLIENT_ID" {
+		t.Errorf("DifferKeys = %v, want the one key that disagrees", fs[0].DifferKeys)
+	}
+	var buf bytes.Buffer
+	printDupFinding(&buf, fs[0])
+	if !strings.Contains(buf.String(), "1 of 2 differ: JAMF_CLIENT_ID") {
+		t.Errorf("report must quantify and name the divergence, got:\n%s", buf.String())
+	}
+
+	// The SAME file migrated twice pairs even with everything rotated: the
+	// path proves identity, so no value evidence is required.
+	c := dupTestGroup("wiz", "~/scripts/.env", true, nil, map[string]string{"A": "old"})
+	d := dupTestGroup("wiz-2", "~/scripts/.env", true, nil, map[string]string{"A": "new"})
+	if fs = sameFileFindings(map[string]*dupGroup{"wiz": c, "wiz-2": d}); len(fs) != 1 {
+		t.Errorf("one identical origin path is proof enough, got %+v", fs)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #54, found by running v0.92.1 on a real vault and acting on its advice.

## The incident

The report offered, for a stale duplicate:

```
keep the copy your tools read; mcp-caido-2 looks stale, retire it with:
→ jit migrate remove ~/Desktop/Share/ai_security_workspace/.mcp.json
```

`jit migrate remove <file>` resolves **up to the .jit project that owns the file** and un-migrates everything under it. Running it removed **10 profiles and 37 secrets**, not one group.

Among them was `okta-mcp-server` — the copy holding an `OKTA_PRIVATE_KEY` that its twin `okta-mcp-server-2` does not have. The very same report had refused to nominate that copy for removal:

```
○ okta-mcp-server, okta-mcp-server-2: one file, migrated twice and edited since
  └ not in every copy: OKTA_PRIVATE_KEY
  one copy holds keys the other doesn't; retiring either would lose them
```

So one finding's advice executed what another finding had just forbidden. The key survived only because un-migration writes values back to disk as plaintext.

## The fix

`annotateRemoveScope` runs after findings are built and, for every `migrate remove` remedy:

1. Resolves the **real project root** (nearest ancestor holding a `.jit` directory, never past `$HOME`).
2. Collects every other vault group whose source file lives under that root → `AlsoRemoves`.
3. **Withholds the remedy entirely** when one of those groups belongs to a finding with no removal pick, replacing it with an explanation and no runnable command:

```
no safe one-command fix: retiring mcp-caido-2 needs jit migrate remove,
which un-migrates that whole project, taking okta-mcp-server with it
and that copy holds keys no other copy has
```

Remedies that survive the guard now state the two consequences the command name never conveyed:

```
→ jit migrate remove ~/proj/.env
  that project also holds sidecar, which go with it
  its files return to plaintext on disk; delete them after
```

## Tests

`TestRemedyScopeWithheldWhenItWouldTakeAProtectedGroup` reconstructs the exact incident (nested `.jit` projects, a protected okta pair under the caido project root) and asserts the remedy is withheld, the blocking group is named, and no runnable `→ jit migrate remove` line is printed. `TestRemedyNamesWhatElseItTakes` covers the safe case.

Full local gate passes: gofmt, vet, staticcheck, `go test -race` across all packages, docs-gen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143e5FSR3EwcJXtphv3fieo