### PR TITLE
vault duplicates: honest --prune accounting, and stop showing what needs no action

### DIFF
--- a/design/vault-duplicates.md
+++ b/design/vault-duplicates.md
@@ -68,8 +68,12 @@ The remedy differs per verdict, and routing it correctly is most of the value:
 - origin gone, nothing references it -> `jit vault orphans --prune`
 - origin gone, still wired -> `jit vault rm <paths>`
 - values diverged -> **no removal pick**; which copy is right is the user's call
-- shared credential -> no removal at all, plus the list of places a rotation
-  must reach
+- shared credential -> no removal at all. Collapsed to a count by default,
+  since the answer is "nothing to do"; `--shared` expands it into the list of
+  every place a rotation must reach. That list must name EVERY holder,
+  including groups already reported as a same-file finding: excluding them
+  under-reported JAMF_CLIENT_ID from six profiles to four on a real vault,
+  which would have left two copies stale after a rotation
 
 ## Identity, not deduplication
 

--- a/docs/reference/commands/jit_vault_duplicates.md
+++ b/docs/reference/commands/jit_vault_duplicates.md
@@ -18,9 +18,9 @@ from names alone:
   without a removal pick.
 
   Shared credentials: the same value stored by independent files, e.g.
-  one API client used by five export scripts. These are NOT stale copies,
-  removing any breaks its tool, and the report lists every place a
-  rotation has to reach.
+  one API client used by five export scripts. These are NOT stale copies
+  and there is nothing to fix, so they collapse to a count; --shared
+  lists them with every place a rotation would have to reach.
 
 Reporting only by default. --prune deletes the ONE shape that is pure
 vault garbage: a stale copy whose origin file is already gone AND that no
@@ -47,6 +47,7 @@ jit vault duplicates [flags]
 
 ```
   jit vault duplicates
+  jit vault duplicates --shared
   jit vault duplicates --prune
   jit vault duplicates --format json
 ```
@@ -56,6 +57,7 @@ jit vault duplicates [flags]
 ```
       --format string   output format: "text" (default) or "json" (default "text")
       --prune           delete stale copies whose origin file is gone and which nothing references
+      --shared          list the shared credentials instead of collapsing them to a count
   -y, --yes             skip the confirmation prompt (never the fingerprint)
 ```
 

--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -58,13 +58,16 @@ then reports:
   copies and there is nothing to fix, so they collapse to a count:
 
   ```
-  [shared credentials] 4 · one credential in several tools each, nothing to fix
-    jit vault duplicates --shared to list them
+  [shared credentials] 4 · credentials each in several tools, nothing to fix
+    jit vault duplicates --shared lists them (re-reads the vault)
   ```
 
   `--shared` expands them, naming every place a rotation would have to
-  reach. They stay out of the default view because this command's question
-  is "what can I safely delete", and the answer for these is "nothing".
+  reach - every holder, including any group also reported as a duplicate
+  above, since a rotation that misses one leaves a live copy stale. They
+  stay out of the default view because this command's question is "what can
+  I safely delete", and the answer for these is "nothing". Expanding costs
+  another run, so it re-reads the vault and re-prompts per credential class.
 
 ### Why it asks for Touch ID more than once
 
@@ -90,10 +93,15 @@ reporting a clean sweep:
 ```
 Deleted 2 duplicated secrets.
 
-Left alone, 2 findings need a command only you should run:
-  └ mcp-caido-2: jit migrate remove ~/Desktop/Share/ai_security_workspace/.mcp.json
-  └ a, b: copies have diverged, compare them first
+Left alone, 3 findings are not safe to delete here:
+  └ jamf, jamf-2: copies have diverged, compare them first
+  └ mcp-caido, mcp-caido-2: retiring mcp-caido-2 needs jit migrate remove, which would take okta-mcp-server too
+  └ okta-mcp-server, okta-mcp-server-2: one copy holds keys the other lacks
 ```
+
+Every finding it did not delete is listed with its own reason, including
+the ones that have no command to offer. A cleanup that mentions some of
+what it skipped reads as though it handled the rest.
 
 A copy whose file still exists has to be un-migrated by `jit migrate
 remove`, which restores the plaintext, deregisters the mount and drops the

--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -55,8 +55,16 @@ then reports:
   had just forbidden.
 - **Shared credentials**: the same value stored by independent files, for
   example one API client used by five export scripts. These are *not* stale
-  copies - removing any breaks its tool - and the report lists every place
-  a rotation has to reach.
+  copies and there is nothing to fix, so they collapse to a count:
+
+  ```
+  [shared credentials] 4 · one credential in several tools each, nothing to fix
+    jit vault duplicates --shared to list them
+  ```
+
+  `--shared` expands them, naming every place a rotation would have to
+  reach. They stay out of the default view because this command's question
+  is "what can I safely delete", and the answer for these is "nothing".
 
 ### Why it asks for Touch ID more than once
 

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -252,25 +252,37 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 			prunableGroups++
 			continue
 		}
-		if f.RemoveCommand != "" || !f.ValuesMatch {
-			left = append(left, f)
-		}
+		// EVERY finding --prune did not delete is accounted for. An earlier
+		// cut listed only those with a command or diverged values, which
+		// silently dropped the two shapes that have neither: a remedy
+		// withheld by its project scope, and a copy holding keys the others
+		// lack. A cleanup that lists 1 of 3 skipped findings reads as
+		// "handled the rest", which is the opposite of the truth.
+		left = append(left, f)
 	}
 	reportLeft := func() {
 		if len(left) == 0 {
 			return
 		}
-		fmt.Fprintf(out, "\nLeft alone, %s %s a command only you should run:\n",
+		fmt.Fprintf(out, "\nLeft alone, %s %s not safe to delete here:\n",
 			countWord(len(left), "finding", "findings"),
-			pluralWord(len(left), "needs", "need"))
+			pluralWord(len(left), "is", "are"))
 		for _, f := range left {
-			if !f.ValuesMatch {
-				fmt.Fprintf(out, "  %s %s: copies have diverged, compare them first\n",
-					glyphBranch, strings.Join(f.Groups, ", "))
-				continue
+			label := strings.Join(f.Groups, ", ")
+			switch {
+			case f.RemoveBlockedBy != "":
+				fmt.Fprintf(out, "  %s %s: no safe one-command fix, it would take %s too\n",
+					glyphBranch, label, f.RemoveBlockedBy)
+			case !f.ValuesMatch:
+				fmt.Fprintf(out, "  %s %s: copies have diverged, compare them first\n", glyphBranch, label)
+			case len(f.ExtraKeys) > 0:
+				fmt.Fprintf(out, "  %s %s: one copy holds keys the other lacks\n", glyphBranch, label)
+			case f.RemoveCommand != "":
+				fmt.Fprintf(out, "  %s %s: ", glyphBranch, f.RemoveGroup)
+				_, _ = cPath.Fprintln(out, f.RemoveCommand)
+			default:
+				fmt.Fprintf(out, "  %s %s: no removal pick\n", glyphBranch, label)
 			}
-			fmt.Fprintf(out, "  %s %s: ", glyphBranch, f.RemoveGroup)
-			_, _ = cPath.Fprintln(out, f.RemoveCommand)
 		}
 	}
 	if len(paths) == 0 {

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -246,12 +246,13 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 		out = cmd.ErrOrStderr() // stdout already carries the machine output
 	}
 	var paths []string
-	var left []dupFinding
+	var left, prunable []dupFinding
 	prunableGroups := 0
 	for _, f := range findings {
 		if f.Prunable {
 			paths = append(paths, f.RemovePaths...)
 			prunableGroups++
+			prunable = append(prunable, f)
 			continue
 		}
 		// EVERY finding --prune did not delete is accounted for. An earlier
@@ -262,19 +263,32 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 		// "handled the rest", which is the opposite of the truth.
 		left = append(left, f)
 	}
-	reportLeft := func() {
-		if len(left) == 0 {
+	// declined is true on the abort path, where the prunable findings were
+	// not deleted either and so belong in the tally. Leaving them out said
+	// "2 findings left alone" after aborting a run that left 3 — and the
+	// omitted one was the only one that HAD been safe to delete.
+	reportLeft := func(declined bool) {
+		all := left
+		if declined {
+			all = append(append([]dupFinding{}, prunable...), left...)
+		}
+		if len(all) == 0 {
 			return
 		}
 		fmt.Fprintf(out, "\nLeft alone, %s %s not safe to delete here:\n",
-			countWord(len(left), "finding", "findings"),
-			pluralWord(len(left), "is", "are"))
-		for _, f := range left {
+			countWord(len(all), "finding", "findings"),
+			pluralWord(len(all), "is", "are"))
+		for _, f := range all {
 			label := strings.Join(f.Groups, ", ")
 			switch {
+			case f.Prunable:
+				fmt.Fprintf(out, "  %s %s: you declined the deletion\n", glyphBranch, label)
 			case f.RemoveBlockedBy != "":
-				fmt.Fprintf(out, "  %s %s: no safe one-command fix, it would take %s too\n",
-					glyphBranch, label, f.RemoveBlockedBy)
+				// Names the command, because this trailer (unlike the report
+				// above) prints none — "it would take X too" had no
+				// antecedent for a reader who ran only --prune.
+				fmt.Fprintf(out, "  %s %s: retiring %s needs jit migrate remove, which would take %s too\n",
+					glyphBranch, label, f.RemoveGroup, f.RemoveBlockedBy)
 			case !f.ValuesMatch:
 				fmt.Fprintf(out, "  %s %s: copies have diverged, compare them first\n", glyphBranch, label)
 			case len(f.ExtraKeys) > 0:
@@ -289,7 +303,7 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 	}
 	if len(paths) == 0 {
 		fmt.Fprintln(out, "\nNothing to prune: no duplicate's stale copy is both file-less and unreferenced.")
-		reportLeft()
+		reportLeft(false)
 		return nil
 	}
 	fmt.Fprintf(out, "\nPruning %s from %s whose origin file is gone and which nothing references:\n",
@@ -305,7 +319,7 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 		"Permanently delete %s? This removes duplicated secret values, not `jit migrate`'s file backups. This can't be undone. [y/N] ",
 		countWord(len(paths), "duplicated secret", "duplicated secrets"))) {
 		fmt.Fprintln(out, "Aborted. Nothing was deleted.")
-		reportLeft()
+		reportLeft(true)
 		return nil
 	}
 	// Fresh biometric gate, same idiom as rm/orphans/prune: Remove only
@@ -321,7 +335,7 @@ func pruneDuplicates(cmd *cobra.Command, v *vault.Vault, findings []dupFinding) 
 		}
 	}
 	fmt.Fprintf(out, "Deleted %s.\n", countWord(len(paths), "duplicated secret", "duplicated secrets"))
-	reportLeft()
+	reportLeft(false)
 	return nil
 }
 
@@ -843,8 +857,13 @@ func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []shared
 		// carries is real but belongs where a rotation happens, not here.
 		_, _ = cBold.Fprintf(out, "[shared credentials]")
 		if !vaultDuplicatesShared {
-			fmt.Fprintf(out, " %d · one credential in several tools each, nothing to fix\n", len(shared))
-			fmt.Fprint(out, hlCmds("  `jit vault duplicates --shared` to list them\n"))
+			fmt.Fprintf(out, " %d · %s in several tools, nothing to fix\n",
+				len(shared), pluralWord(len(shared), "one credential", "credentials each"))
+			// Naming the cost: expanding means running this command again,
+			// which unlocks the vault and re-approves each gated credential
+			// class. Cheap-looking hints that cost three Touch ID prompts
+			// are how a reader learns to distrust the hint.
+			fmt.Fprint(out, hlCmds("  `jit vault duplicates --shared` lists them (re-reads the vault)\n"))
 		} else {
 			fmt.Fprintf(out, " %d · same value in independent tools, keep all\n", len(shared))
 			for _, f := range shared {

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -713,18 +713,28 @@ func groupSecretPaths(g *dupGroup) []string {
 // writing to the same output path is not a shared credential, and
 // reporting it would bury the ones that are.
 func sharedCredentialFindings(groups map[string]*dupGroup, consumed []dupFinding) []sharedFinding {
-	inFinding := map[string]bool{}
+	// Group sets already told as same-file findings, so a shared entry that
+	// merely restates one can be suppressed at EMIT time. It must not be
+	// suppressed at COUNT time: a value held by both a consumed group and
+	// others belongs to all of them, and dropping the consumed holders
+	// under-reports where a rotation has to reach.
+	//
+	// That was a real wrong answer. Once jamf/jamf-2 became a same-file
+	// finding, JAMF_CLIENT_ID went from "shared by 6 profiles" to "shared
+	// by 4" on the same vault — the two copies that also hold it silently
+	// vanished from the rotation list, which is the one thing this section
+	// exists to get right.
+	consumedSets := make([]map[string]bool, 0, len(consumed))
 	for _, f := range consumed {
+		set := make(map[string]bool, len(f.Groups))
 		for _, g := range f.Groups {
-			inFinding[g] = true
+			set[g] = true
 		}
+		consumedSets = append(consumedSets, set)
 	}
-	// (key, digest) -> group names sharing it.
+	// (key, digest) -> group names sharing it, over EVERY group.
 	sharing := map[string][]string{}
 	for _, g := range groups {
-		if inFinding[g.name] {
-			continue
-		}
 		for k, h := range g.hashes {
 			if h == "" || looksLikeConfig(k) {
 				continue
@@ -749,6 +759,9 @@ func sharedCredentialFindings(groups map[string]*dupGroup, consumed []dupFinding
 			continue
 		}
 		sort.Strings(names)
+		if restatesFinding(names, consumedSets) {
+			continue // the same-file finding above already covers exactly these
+		}
 		setKey := strings.Join(names, "\x00")
 		f := byGroupSet[setKey]
 		if f == nil {
@@ -766,6 +779,27 @@ func sharedCredentialFindings(groups map[string]*dupGroup, consumed []dupFinding
 		findings = append(findings, *f)
 	}
 	return findings
+}
+
+// restatesFinding reports whether every group sharing a value is already
+// contained in ONE same-file finding — in which case the shared-credentials
+// entry would just repeat it. A set spanning a finding AND other groups is
+// NOT a restatement: those other holders are exactly what a rotation would
+// otherwise miss.
+func restatesFinding(names []string, consumedSets []map[string]bool) bool {
+	for _, set := range consumedSets {
+		all := true
+		for _, n := range names {
+			if !set[n] {
+				all = false
+				break
+			}
+		}
+		if all {
+			return true
+		}
+	}
+	return false
 }
 
 // printDuplicatesReport renders the text report: a findings section in the

--- a/internal/cli/vaultduplicates.go
+++ b/internal/cli/vaultduplicates.go
@@ -139,6 +139,7 @@ var (
 	vaultDuplicatesFormat string
 	vaultDuplicatesPrune  bool
 	vaultDuplicatesYes    bool
+	vaultDuplicatesShared bool
 )
 
 var vaultDuplicatesCmd = &cobra.Command{
@@ -156,9 +157,9 @@ var vaultDuplicatesCmd = &cobra.Command{
 		"  Diverged copies (same file ancestry, different values now) are reported\n" +
 		"  without a removal pick.\n\n" +
 		"  Shared credentials: the same value stored by independent files, e.g.\n" +
-		"  one API client used by five export scripts. These are NOT stale copies,\n" +
-		"  removing any breaks its tool, and the report lists every place a\n" +
-		"  rotation has to reach.\n\n" +
+		"  one API client used by five export scripts. These are NOT stale copies\n" +
+		"  and there is nothing to fix, so they collapse to a count; --shared\n" +
+		"  lists them with every place a rotation would have to reach.\n\n" +
 		"Reporting only by default. --prune deletes the ONE shape that is pure\n" +
 		"vault garbage: a stale copy whose origin file is already gone AND that no\n" +
 		"profile jit can see references, after a [y/N] confirmation and a fresh\n" +
@@ -175,6 +176,7 @@ var vaultDuplicatesCmd = &cobra.Command{
 		"therefore asks about three times, not once: the unlock plus one per class.\n" +
 		"`jit service consent off` removes the per-class half.",
 	Example: "  jit vault duplicates\n" +
+		"  jit vault duplicates --shared\n" +
 		"  jit vault duplicates --prune\n" +
 		"  jit vault duplicates --format json",
 	Args:         cobra.NoArgs,
@@ -797,16 +799,29 @@ func printDuplicatesReport(out io.Writer, findings []dupFinding, shared []shared
 		if len(findings) > 0 {
 			fmt.Fprintln(out)
 		}
+		// Collapsed by default. This section answers a question the command
+		// was not asked: it lists groups that are FINE, in a report whose
+		// only question is what can be deleted. It earned its space when
+		// `jit vault list`'s nudge was telling users to rm these exact
+		// groups and the section existed to contradict that; the nudge is
+		// origin-based now and never flags them, so the rebuttal became a
+		// dozen lines of "do nothing" on every run. The rotation map it
+		// carries is real but belongs where a rotation happens, not here.
 		_, _ = cBold.Fprintf(out, "[shared credentials]")
-		fmt.Fprintf(out, " %d · same value in independent tools, keep all\n", len(shared))
-		for _, f := range shared {
-			fmt.Fprintln(out)
-			_, _ = cOK.Fprintf(out, "%s ", glyphOK)
-			_, _ = cBold.Fprint(out, strings.Join(f.Keys, ", "))
-			fmt.Fprintf(out, " shared by %d profiles\n", len(f.Groups))
-			fmt.Fprintf(out, "  %s %s\n", glyphBranch, strings.Join(f.Groups, ", "))
+		if !vaultDuplicatesShared {
+			fmt.Fprintf(out, " %d · one credential in several tools each, nothing to fix\n", len(shared))
+			fmt.Fprint(out, hlCmds("  `jit vault duplicates --shared` to list them\n"))
+		} else {
+			fmt.Fprintf(out, " %d · same value in independent tools, keep all\n", len(shared))
+			for _, f := range shared {
+				fmt.Fprintln(out)
+				_, _ = cOK.Fprintf(out, "%s ", glyphOK)
+				_, _ = cBold.Fprint(out, strings.Join(f.Keys, ", "))
+				fmt.Fprintf(out, " shared by %d profiles\n", len(f.Groups))
+				fmt.Fprintf(out, "  %s %s\n", glyphBranch, strings.Join(f.Groups, ", "))
+			}
+			fmt.Fprintln(out, "  removing any copy breaks its tool; when rotating, update every copy")
 		}
-		fmt.Fprintln(out, "  removing any copy breaks its tool; when rotating, update every copy")
 	}
 	prunable := 0
 	for _, f := range findings {
@@ -899,6 +914,7 @@ func truncateList(names []string, max int) string {
 
 func init() {
 	vaultDuplicatesCmd.Flags().StringVar(&vaultDuplicatesFormat, "format", "text", `output format: "text" (default) or "json"`)
+	vaultDuplicatesCmd.Flags().BoolVar(&vaultDuplicatesShared, "shared", false, "list the shared credentials instead of collapsing them to a count")
 	vaultDuplicatesCmd.Flags().BoolVar(&vaultDuplicatesPrune, "prune", false, "delete stale copies whose origin file is gone and which nothing references")
 	vaultDuplicatesCmd.Flags().BoolVarP(&vaultDuplicatesYes, "yes", "y", false, "skip the confirmation prompt (never the fingerprint)")
 	vaultCmd.AddCommand(vaultDuplicatesCmd)

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -195,7 +195,7 @@ func TestPrintDuplicatesReport(t *testing.T) {
 		"from /u/Documents/ws/.mcp.json",
 		"mcp-caido-2 looks stale, retire it with:",
 		"jit migrate remove /u/Desktop/ws/.mcp.json",
-		"[shared credentials] 1 · one credential in several tools each, nothing to fix",
+		"[shared credentials] 1 · one credential in several tools, nothing to fix",
 		"jit vault duplicates --shared",
 		"118 secrets compared in memory; no value was printed or written.",
 	} {
@@ -636,11 +636,12 @@ func TestPruneDuplicatesOnlyTouchesTheSafeShape(t *testing.T) {
 	// And it accounts for EVERY finding it did not delete, each with its
 	// own reason — including the two shapes that have no command at all.
 	for _, want := range []string{
-		"Left alone, 5 findings are not safe to delete here:",
+		"Left alone, 6 findings are not safe to delete here:",
+		"keep, dead: you declined the deletion",
 		"jit migrate remove /x/live/.env",
 		"jit vault rm wired/KEY",
 		"copies have diverged, compare them first",
-		"no safe one-command fix, it would take okta too",
+		"which would take okta too",
 		"one copy holds keys the other lacks",
 	} {
 		if !strings.Contains(out, want) {

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -150,15 +150,27 @@ func TestSharedCredentialFindings(t *testing.T) {
 		t.Errorf("keys = %v, config-named keys must not count", fs[0].Keys)
 	}
 
-	// Groups consumed by a same-file finding don't re-report as shared.
+	// A shared entry covering EXACTLY one same-file finding's groups is a
+	// restatement and is suppressed.
 	consumed := []dupFinding{{Groups: []string{"jamf", "jamf-2"}}}
+	only := map[string]*dupGroup{
+		"jamf":   groups["jamf"],
+		"jamf-2": groups["jamf-2"],
+	}
+	if fs = sharedCredentialFindings(only, consumed); len(fs) != 0 {
+		t.Errorf("a shared entry that only restates a finding must be suppressed, got %+v", fs)
+	}
+
+	// But a value held by a consumed group AND others must still list ALL
+	// holders. Dropping the consumed ones under-reported where a rotation
+	// has to reach: on a real vault JAMF_CLIENT_ID went from "shared by 6
+	// profiles" to "shared by 4" the moment jamf/jamf-2 became a finding.
 	fs = sharedCredentialFindings(groups, consumed)
-	for _, f := range fs {
-		for _, g := range f.Groups {
-			if g == "jamf" || g == "jamf-2" {
-				t.Errorf("consumed group %s re-reported as shared: %+v", g, fs)
-			}
-		}
+	if len(fs) != 1 {
+		t.Fatalf("want one finding spanning the finding and the others, got %+v", fs)
+	}
+	if strings.Join(fs[0].Groups, ",") != "export-c,jamf,jamf-2" {
+		t.Errorf("every holder must be listed for rotation, got %v", fs[0].Groups)
 	}
 }
 

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -564,6 +564,14 @@ func TestPruneDuplicatesOnlyTouchesTheSafeShape(t *testing.T) {
 		{ // diverged: never jit's call
 			Groups: []string{"a", "b"}, ValuesMatch: false,
 		},
+		{ // remedy withheld because its project scope covers another finding
+			Groups: []string{"caido", "caido-2"}, RemoveGroup: "caido-2", ValuesMatch: true,
+			RemoveBlockedBy: "okta",
+		},
+		{ // a copy holds keys the others lack
+			Groups: []string{"okta", "okta-2"}, ValuesMatch: true,
+			ExtraKeys: []string{"OKTA_PRIVATE_KEY"},
+		},
 	}
 
 	// Declining the confirmation must delete nothing.
@@ -591,12 +599,15 @@ func TestPruneDuplicatesOnlyTouchesTheSafeShape(t *testing.T) {
 			t.Errorf("prune plan must not list %s, got:\n%s", unsafe, out)
 		}
 	}
-	// And it accounts for what it left behind, with each command.
+	// And it accounts for EVERY finding it did not delete, each with its
+	// own reason — including the two shapes that have no command at all.
 	for _, want := range []string{
-		"Left alone, 3 findings need a command only you should run:",
+		"Left alone, 5 findings are not safe to delete here:",
 		"jit migrate remove /x/live/.env",
 		"jit vault rm wired/KEY",
 		"copies have diverged, compare them first",
+		"no safe one-command fix, it would take okta too",
+		"one copy holds keys the other lacks",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("prune must report what it skipped (%q), got:\n%s", want, out)
@@ -609,7 +620,7 @@ func TestPruneDuplicatesOnlyTouchesTheSafeShape(t *testing.T) {
 		t.Fatalf("pruneDuplicates (nothing prunable): %v", err)
 	}
 	if !strings.Contains(buf.String(), "Nothing to prune") ||
-		!strings.Contains(buf.String(), "Left alone, 3 findings") {
+		!strings.Contains(buf.String(), "Left alone, 5 findings") {
 		t.Errorf("empty prune must explain, got:\n%s", buf.String())
 	}
 }

--- a/internal/cli/vaultduplicates_test.go
+++ b/internal/cli/vaultduplicates_test.go
@@ -183,10 +183,8 @@ func TestPrintDuplicatesReport(t *testing.T) {
 		"from /u/Documents/ws/.mcp.json",
 		"mcp-caido-2 looks stale, retire it with:",
 		"jit migrate remove /u/Desktop/ws/.mcp.json",
-		"[shared credentials] 1 · same value in independent tools, keep all",
-		"JAMF_CLIENT_ID",
-		"shared by 2 profiles",
-		"removing any copy breaks its tool; when rotating, update every copy",
+		"[shared credentials] 1 · one credential in several tools each, nothing to fix",
+		"jit vault duplicates --shared",
 		"118 secrets compared in memory; no value was printed or written.",
 	} {
 		if !strings.Contains(out, want) {
@@ -196,6 +194,30 @@ func TestPrintDuplicatesReport(t *testing.T) {
 	if strings.Contains(out, "vault rm") {
 		t.Errorf("a live-mounted copy must route to migrate remove, never rm, got:\n%s", out)
 	}
+
+	// A report whose only question is "what can I delete" must not spend a
+	// dozen lines on groups that are fine: the shared section collapses to
+	// a count unless --shared asks for it.
+	if strings.Contains(out, "shared by 2 profiles") {
+		t.Errorf("shared credentials must collapse by default, got:\n%s", out)
+	}
+	vaultDuplicatesShared = true
+	defer func() { vaultDuplicatesShared = false }()
+	buf.Reset()
+	printDuplicatesReport(&buf, nil, []sharedFinding{{
+		Keys: []string{"JAMF_CLIENT_ID"}, Groups: []string{"jamf", "jamf-2"},
+	}}, 118)
+	for _, want := range []string{
+		"same value in independent tools, keep all",
+		"shared by 2 profiles",
+		"jamf, jamf-2",
+		"when rotating, update every copy",
+	} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("--shared must list them, missing %q, got:\n%s", want, buf.String())
+		}
+	}
+	vaultDuplicatesShared = false
 
 	// Diverged: caveat instead of a remedy.
 	buf.Reset()


### PR DESCRIPTION
Two fixes found by running v0.92.2 on a real 118-secret vault.

## 1. `--prune` under-reported what it skipped

With three findings and nothing prunable, it said:

```
Left alone, 1 finding needs a command only you should run:
  └ jamf, jamf-2: copies have diverged, compare them first
```

Two findings were missing. The accounting loop was `if f.RemoveCommand != "" || !f.ValuesMatch`, which drops the two shapes that have neither a command nor diverged values:

- a remedy **withheld** because its project scope covers another finding (added in #55)
- a copy holding **keys the others lack**

Listing 1 of 3 skipped findings reads as "handled the other two" — precisely the failure this section exists to prevent. Every non-pruned finding is now listed with its own reason:

```
Left alone, 3 findings are not safe to delete here:
  └ jamf, jamf-2: copies have diverged, compare them first
  └ mcp-caido, mcp-caido-2: no safe one-command fix, it would take okta-mcp-server too
  └ okta-mcp-server, okta-mcp-server-2: one copy holds keys the other lacks
```

## 2. Shared credentials collapse behind `--shared`

The section spent ~15 lines per run listing groups that are fine, in a report whose only question is what can be deleted.

It earned that space when `jit vault list`'s nudge was telling users to `rm` those exact groups and the section existed to contradict it. The nudge is origin-based now and never flags them, so the rebuttal has nothing to rebut. The rotation map it carries is real but belongs where a rotation happens, not in a duplicate hunt.

```
[shared credentials] 4 · one credential in several tools each, nothing to fix
  jit vault duplicates --shared to list them
```

`--shared` prints the full list unchanged. `--format json` is untouched, so scripts still receive everything.

Full local gate passes: gofmt, vet, staticcheck, `go test -race` across all packages, docs-gen no drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143e5FSR3EwcJXtphv3fieo