### PR TITLE
doctor: route the vault hygiene sweeps in as advisory findings

### DIFF
--- a/docs/reference/commands/jit_doctor.md
+++ b/docs/reference/commands/jit_doctor.md
@@ -27,9 +27,14 @@ secret missing, corrupt, or unparseable; the whole vault unreadable
 because this Mac's master key is gone from the keychain or a master-key
 rotation never finished; or a wrapped tool's installation damaged, which
 means that tool now runs unwrapped or not at all. Everything else it
-reports is an advisory warning: an orphaned secret (with --orphans), a
-profile name shadowed across scopes, a mount whose profile won't load, a
-stopped service, a stale or missing vault backup, more than one jit
+reports is an advisory warning: orphaned secrets no profile references
+(a count by default; --orphans lists each, `jit vault orphans` adds
+origins and can prune), vault groups that look like the same file stored
+twice (name-level evidence only — `jit vault duplicates` compares the
+values, which doctor never decrypts), a referenced secret whose recorded
+origin file is gone from disk, a profile name shadowed across scopes, a
+mount whose profile won't load or whose project was deleted without
+unmounting, a stopped service, a stale or missing vault backup, more than one jit
 installed on PATH (a Homebrew copy and a tarball copy each answering to
 the name, with which copy runs decided by PATH order), and any shim
 complaint that is only true of the shell you happen to be in — a CI job
@@ -56,7 +61,7 @@ jit doctor [flags]
 
 ```
   jit doctor
-  jit doctor --verbose --orphans   # also what passed, and unreferenced secrets
+  jit doctor --verbose --orphans   # also what passed, and each unreferenced secret
   jit doctor --wrap                # only the shims, no vault access
   jit doctor --strict              # advisory warnings gate too, for CI
 ```
@@ -65,7 +70,7 @@ jit doctor [flags]
 
 ```
       --format string          output format: "text" (default) or "json" (default "text")
-      --orphans                also warn about vault secrets no profile references (advisory, never a failure)
+      --orphans                list each unreferenced vault secret; without it the count alone is reported
       --profile string         check only this profile, and skip the service/backup/wrap health sections
       --strict                 exit non-zero on advisory warnings too, for a pipeline that wants them to gate
       --verbose                also list every check that passed, not just the ones that failed

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -96,9 +96,14 @@ var doctorCmd = &cobra.Command{
 		"because this Mac's master key is gone from the keychain or a master-key\n" +
 		"rotation never finished; or a wrapped tool's installation damaged, which\n" +
 		"means that tool now runs unwrapped or not at all. Everything else it\n" +
-		"reports is an advisory warning: an orphaned secret (with --orphans), a\n" +
-		"profile name shadowed across scopes, a mount whose profile won't load, a\n" +
-		"stopped service, a stale or missing vault backup, more than one jit\n" +
+		"reports is an advisory warning: orphaned secrets no profile references\n" +
+		"(a count by default; --orphans lists each, `jit vault orphans` adds\n" +
+		"origins and can prune), vault groups that look like the same file stored\n" +
+		"twice (name-level evidence only — `jit vault duplicates` compares the\n" +
+		"values, which doctor never decrypts), a referenced secret whose recorded\n" +
+		"origin file is gone from disk, a profile name shadowed across scopes, a\n" +
+		"mount whose profile won't load or whose project was deleted without\n" +
+		"unmounting, a stopped service, a stale or missing vault backup, more than one jit\n" +
 		"installed on PATH (a Homebrew copy and a tarball copy each answering to\n" +
 		"the name, with which copy runs decided by PATH order), and any shim\n" +
 		"complaint that is only true of the shell you happen to be in — a CI job\n" +
@@ -115,7 +120,7 @@ var doctorCmd = &cobra.Command{
 		"check that passed, not just the ones that failed, and --format json prints a\n" +
 		"machine-readable snapshot.",
 	Example: "  jit doctor\n" +
-		"  jit doctor --verbose --orphans   # also what passed, and unreferenced secrets\n" +
+		"  jit doctor --verbose --orphans   # also what passed, and each unreferenced secret\n" +
 		"  jit doctor --wrap                # only the shims, no vault access\n" +
 		"  jit doctor --strict              # advisory warnings gate too, for CI",
 	Args: cobra.NoArgs,
@@ -162,11 +167,19 @@ var doctorCmd = &cobra.Command{
 		// plaintext) and cheap, and a "doctor" that couldn't tell a
 		// truncated secret from a healthy one would be missing the failure
 		// most likely to look like a jit bug at runtime.
+		// Orphans is always on now — the count is the finding, and hiding it
+		// behind a flag meant the run where you'd learn you have eleven never
+		// showed it. --orphans only chooses between the one-line count and
+		// the per-path listing (see collapseOrphanFindings). Duplicates and
+		// Origins are the other always-on hygiene sweeps; all three stay
+		// auth-free (List/Info/stat, never a decrypt).
 		outcome, err = runProfileCheck(cwd, v, checkOptions{
-			Root:      root,
-			Profile:   doctorProfile,
-			Integrity: true,
-			Orphans:   doctorOrphans,
+			Root:       root,
+			Profile:    doctorProfile,
+			Integrity:  true,
+			Orphans:    true,
+			Duplicates: true,
+			Origins:    true,
 		})
 		if err != nil {
 			return fmt.Errorf("jit doctor: %w", err)
@@ -187,8 +200,45 @@ var doctorCmd = &cobra.Command{
 			outcome.OKChecks = wrapOK
 		}
 
+		if !doctorOrphans {
+			outcome.Findings = collapseOrphanFindings(outcome.Findings)
+		}
+
 		return renderDoctorOutcome(cmd, outcome)
 	},
+}
+
+// collapseOrphanFindings folds the per-path [orphan] findings into one
+// summary finding carrying only the count — the default view now that the
+// sweep always runs. The full listing (with each path) is one `--orphans`
+// away here, or `jit vault orphans` with origins and ages. Applied to text
+// and JSON alike: the two must say the same thing, and a JSON consumer that
+// wants every path passes --orphans exactly like a human would.
+func collapseOrphanFindings(findings []checkFinding) []checkFinding {
+	count := 0
+	at := -1
+	var out []checkFinding
+	for _, f := range findings {
+		if f.Kind != kindOrphan {
+			out = append(out, f)
+			continue
+		}
+		if at < 0 {
+			// Placeholder keeps the summary where the first orphan appeared,
+			// so the group order still reflects what the run found first.
+			at = len(out)
+			out = append(out, checkFinding{})
+		}
+		count++
+	}
+	if at >= 0 {
+		out[at] = checkFinding{
+			Kind:   kindOrphan,
+			Detail: fmt.Sprintf("%s in the vault referenced by no profile jit can see", countWord(count, "secret", "secrets")),
+			Action: "`jit vault orphans` to list them with origins, or `jit vault orphans --prune` to delete",
+		}
+	}
+	return out
 }
 
 // doctorProblemsExitCode is deliberately not 1, matching `jit scan --fail-on`
@@ -550,6 +600,10 @@ func findingLabel(f checkFinding) string {
 		return "[bad path]"
 	case kindOrphan:
 		return "[orphan]"
+	case kindDuplicates:
+		return "[duplicates]"
+	case kindOriginGone:
+		return "[origin gone]"
 	case kindShadowed:
 		return "[shadowed]"
 	case kindService:
@@ -565,6 +619,11 @@ func findingLabel(f checkFinding) string {
 		return "[wrap: this shell]"
 	case kindMount:
 		return "[mount]"
+	case kindMountStale:
+		// Names the cause on the header, as "[wrap: this shell]" does: a
+		// stale registration is leftover state from a deleted project, and a
+		// bare "[mount]" beside it would read as two of the same problem.
+		return "[mount: stale]"
 	case kindVaultKey:
 		return "[vault key]"
 	case kindRekey:
@@ -599,7 +658,7 @@ func findingLabel(f checkFinding) string {
 // that identifies the file off the first line (rule 6).
 func formatFinding(f checkFinding) string {
 	switch f.Kind {
-	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit, kindMCP, kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion:
+	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindMountStale, kindDuplicates, kindOriginGone, kindVaultKey, kindRekey, kindAudit, kindMCP, kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion:
 		return shortHome(f.Detail)
 	case kindMissing:
 		return fmt.Sprintf("%s: %s "+glyphAction+" %s, not in the vault", profileRef(f), f.Variable, f.Path)
@@ -613,6 +672,11 @@ func formatFinding(f checkFinding) string {
 		}
 		return fmt.Sprintf("%s: %s "+glyphAction+" %s: %s", profileRef(f), f.Variable, f.Path, shortHome(f.Detail))
 	case kindOrphan:
+		// The collapsed default carries only a count in Detail and no Path;
+		// the --orphans listing names each path.
+		if f.Path == "" {
+			return f.Detail
+		}
 		return fmt.Sprintf("%s — %s", f.Path, f.Detail)
 	case kindShadowed:
 		return fmt.Sprintf("%s: %s", profileRef(f), f.Detail)
@@ -638,7 +702,7 @@ func init() {
 	_ = doctorCmd.RegisterFlagCompletionFunc("profile", completeProfileNames)
 	doctorCmd.Flags().StringVar(&doctorFormat, "format", "text", `output format: "text" (default) or "json"`)
 	doctorCmd.Flags().BoolVar(&doctorVerbose, "verbose", false, "also list every check that passed, not just the ones that failed")
-	doctorCmd.Flags().BoolVar(&doctorOrphans, "orphans", false, "also warn about vault secrets no profile references (advisory, never a failure)")
+	doctorCmd.Flags().BoolVar(&doctorOrphans, "orphans", false, "list each unreferenced vault secret; without it the count alone is reported")
 	doctorCmd.Flags().BoolVar(&doctorWrap, "wrap", false, "check only the wrapped-tool shims, without opening the vault (replaces `jit wrap doctor`)")
 	doctorCmd.Flags().BoolVar(&doctorStrict, "strict", false, "exit non-zero on advisory warnings too, for a pipeline that wants them to gate")
 	doctorCmd.MarkFlagsMutuallyExclusive("wrap", "profile")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -69,6 +70,16 @@ func plantVaultSecret(t *testing.T, home, path string) {
 func plantCorruptSecret(t *testing.T, home, path string) {
 	t.Helper()
 	writeVaultEnc(t, home, path, `{"version":999,"recipients":{"test":"00"},"payload":"00"}`)
+}
+
+// plantOriginSecret is plantVaultSecret with birth-time provenance: a v3
+// envelope recording the file the secret was migrated from, for the
+// duplicates and origin-gone sweeps (which read Origin via the auth-free
+// Vault.Info, exactly as doctor does).
+func plantOriginSecret(t *testing.T, home, path, origin string) {
+	t.Helper()
+	writeVaultEnc(t, home, path,
+		`{"version":3,"origin":`+strconv.Quote(origin)+`,"recipients":{"test":"00"},"payload":"00"}`)
 }
 
 func writeVaultEnc(t *testing.T, home, path, content string) {
@@ -380,9 +391,11 @@ func TestDoctorOrphansAreAdvisory(t *testing.T) {
 	}
 }
 
-// TestDoctorOrphansOffByDefault confirms the sweep is opt-in: without
-// --orphans, an unreferenced secret is silent.
-func TestDoctorOrphansOffByDefault(t *testing.T) {
+// TestDoctorOrphanCountOnByDefault confirms the sweep always runs: without
+// --orphans the unreferenced secret shows as a one-line COUNT (routing to
+// `jit vault orphans`), never as a per-path listing — that detail is what
+// the flag now selects. Still advisory: the run must not fail.
+func TestDoctorOrphanCountOnByDefault(t *testing.T) {
 	home := withFixtureHome(t)
 	cwd := withFixtureCwd(t)
 	writeFixtureProfile(t, cwd, "aws-admin", "AWS_ACCESS_KEY_ID: aws/s3-access-key\n")
@@ -391,10 +404,13 @@ func TestDoctorOrphansOffByDefault(t *testing.T) {
 
 	out, err := execDoctor(t)
 	if err != nil {
-		t.Fatalf("jit doctor: %v", err)
+		t.Fatalf("the orphan count is advisory and must not fail the run: %v", err)
 	}
-	if strings.Contains(out, "orphan") {
-		t.Errorf("expected no orphan output without --orphans, got:\n%s", out)
+	if !strings.Contains(out, "[orphan]") || !strings.Contains(out, "1 secret in the vault referenced by no profile") {
+		t.Errorf("expected the default run to carry the orphan count, got:\n%s", out)
+	}
+	if strings.Contains(out, "stripe/unused-key") {
+		t.Errorf("the per-path listing is --orphans' job, not the default's, got:\n%s", out)
 	}
 }
 
@@ -529,6 +545,108 @@ func TestDoctorUnloadableMountProfileIsAdvisory(t *testing.T) {
 	}
 	if strings.Contains(out, "[orphan]") {
 		t.Errorf("the orphan sweep must be suppressed when a mount manifest is unreadable, got:\n%s", out)
+	}
+}
+
+// TestDoctorStaleMountDoesNotSuppressOrphans: a registry entry whose manifest
+// is GONE (project deleted without `jit unmount`) is a different state from
+// one that won't parse — a missing file names no references, so skipping it
+// cannot make the orphan sweep under-count. Doctor used to lump both into
+// [mount] and suppress the sweep, hiding the orphan count in exactly the
+// cleanup that state calls for. Same split `jit vault orphans` v0.93.0 made.
+func TestDoctorStaleMountDoesNotSuppressOrphans(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	writeFixtureProfile(t, cwd, "app", "APP_KEY: app/key\n")
+	plantVaultSecret(t, home, "app/key")
+
+	gone := filepath.Join(t.TempDir(), "deleted-project", ".jit", "profiles", "npmrc.yaml")
+	registerFixtureMount(t, home, filepath.Join(home, ".npmrc"), gone)
+	plantVaultSecret(t, home, "npm/token") // the deleted project's leftover
+
+	out, err := execDoctor(t)
+	if err != nil {
+		t.Fatalf("a stale mount registration is advisory and must not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "[mount: stale]") || !strings.Contains(out, "vault orphans --prune") {
+		t.Errorf("expected a stale-mount warning routing to `jit vault orphans --prune`, got:\n%s", out)
+	}
+	if !strings.Contains(out, "[orphan]") {
+		t.Errorf("a missing manifest names no references, so the orphan sweep must still run, got:\n%s", out)
+	}
+}
+
+// TestDoctorDuplicatesHint: two groups holding the same key set with the same
+// recorded origin — `jit vault list`'s nudge evidence, via the shared
+// duplicateGroupClusters — surface as an advisory [duplicates] finding
+// routing to `jit vault duplicates`. Name-level evidence only: doctor must
+// hint at the comparison, never nominate a copy to delete.
+func TestDoctorDuplicatesHint(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	origin := filepath.Join(t.TempDir(), "ws", ".mcp.json")
+	writeProfileAt(t, origin, "{}") // the origin file still exists
+	writeFixtureProfile(t, cwd, "mcp",
+		"CAIDO_TOKEN: mcp-caido/CAIDO_TOKEN\nCAIDO_TOKEN_2: mcp-caido-2/CAIDO_TOKEN\n")
+	plantOriginSecret(t, home, "mcp-caido/CAIDO_TOKEN", origin)
+	plantOriginSecret(t, home, "mcp-caido-2/CAIDO_TOKEN", origin)
+
+	out, err := execDoctor(t)
+	if err != nil {
+		t.Fatalf("a duplicates hint is advisory and must not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "[duplicates]") || !strings.Contains(out, "migrated from the same file") {
+		t.Errorf("expected a [duplicates] warning naming the shared origin, got:\n%s", out)
+	}
+	if !strings.Contains(out, "jit vault duplicates") {
+		t.Errorf("expected the finding to route to `jit vault duplicates`, got:\n%s", out)
+	}
+}
+
+// TestDoctorOriginGoneForReferencedSecret: a secret a profile still uses,
+// whose recorded origin file has been deleted, gets an advisory [origin gone]
+// line — while a sibling whose origin still exists stays silent. Nothing is
+// broken (the vault copy is the live one), so the run must not fail.
+func TestDoctorOriginGoneForReferencedSecret(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	alive := filepath.Join(t.TempDir(), "proj", ".env")
+	writeProfileAt(t, alive, "X=1")
+	writeFixtureProfile(t, cwd, "app", "ACME_TOKEN: acme/TOKEN\nBETA_TOKEN: beta/TOKEN\n")
+	plantOriginSecret(t, home, "acme/TOKEN", filepath.Join(t.TempDir(), "gone-project", ".env"))
+	plantOriginSecret(t, home, "beta/TOKEN", alive)
+
+	out, err := execDoctor(t)
+	if err != nil {
+		t.Fatalf("a gone origin is advisory and must not fail the run: %v", err)
+	}
+	if !strings.Contains(out, "[origin gone]") || !strings.Contains(out, "acme was migrated from") {
+		t.Errorf("expected an [origin gone] warning naming the group, got:\n%s", out)
+	}
+	if strings.Contains(out, "beta was migrated") {
+		t.Errorf("a secret whose origin still exists must not be flagged, got:\n%s", out)
+	}
+}
+
+// TestDoctorOriginGoneSkipsUnreferencedSecrets: origin gone AND referenced by
+// nothing is the orphan definition — that count already carries it, and a
+// second line about the same secret would state one fact twice.
+func TestDoctorOriginGoneSkipsUnreferencedSecrets(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	writeFixtureProfile(t, cwd, "app", "APP_KEY: app/key\n")
+	plantVaultSecret(t, home, "app/key")
+	plantOriginSecret(t, home, "stray/TOKEN", filepath.Join(t.TempDir(), "gone", ".env"))
+
+	out, err := execDoctor(t)
+	if err != nil {
+		t.Fatalf("jit doctor: %v", err)
+	}
+	if !strings.Contains(out, "[orphan]") {
+		t.Errorf("expected the unreferenced secret in the orphan count, got:\n%s", out)
+	}
+	if strings.Contains(out, "[origin gone]") {
+		t.Errorf("an unreferenced secret is an orphan, not an [origin gone] finding, got:\n%s", out)
 	}
 }
 

--- a/internal/cli/profilecheck.go
+++ b/internal/cli/profilecheck.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/jitpass/jit/internal/mount"
 	"github.com/jitpass/jit/internal/profile"
 	"github.com/jitpass/jit/internal/vault"
+	"github.com/jitpass/jit/internal/wrap"
 )
 
 // checkKind classifies one doctor finding so a --format json consumer can
@@ -54,6 +56,21 @@ const (
 	// (see warning): dead weight and audit surface worth surfacing, never a
 	// reason to fail the run.
 	kindOrphan checkKind = "orphan"
+	// kindDuplicates: two or more vault groups that look like the same file
+	// stored twice — identical key sets with agreeing recorded origins, the
+	// same auth-free evidence behind `jit vault list`'s nudge. Advisory, and
+	// deliberately name-level only: confirming the VALUES match (and which
+	// copy is safe to retire) takes a decrypt, which is `jit vault
+	// duplicates`' job, never doctor's. The finding routes there.
+	kindDuplicates checkKind = "duplicates"
+	// kindOriginGone: a secret a profile still references whose recorded
+	// origin file no longer exists on disk. Advisory: nothing is broken (the
+	// vault copy is the live one; that is the product working), but the file
+	// this credential was born from being gone is worth one line — a deleted
+	// project whose profile survived looks exactly like this. The
+	// UNREFERENCED half of the same situation needs no kind of its own: it is
+	// already an orphan.
+	kindOriginGone checkKind = "origin_gone"
 	// kindShadowed: a profile name exists in BOTH project and global scope.
 	// Load resolves to the project one, so the global profile of the same
 	// name is silently ignored — the exact "why is my global profile not
@@ -87,6 +104,15 @@ const (
 	// asked about is, and the registry can outlive a project directory
 	// legitimately (see reconcileSecrets, which tolerates the same state).
 	kindMount checkKind = "mount"
+	// kindMountStale: a registered mount whose profile manifest is GONE — the
+	// project directory was deleted without `jit unmount` first. Split from
+	// kindMount because the two must behave differently, the same distinction
+	// `jit vault orphans` draws (GAPS.md #67): a manifest that exists but
+	// won't parse leaves that profile's references UNKNOWN and so suppresses
+	// the orphan sweep, while a missing manifest names nothing — skipping it
+	// cannot under-count, the deleted project's secrets really are orphaned,
+	// and `jit vault orphans --prune` clears the registration without auth.
+	kindMountStale checkKind = "mount_stale"
 	// kindVaultKey: the vault holds secrets but this Mac's master key is gone
 	// from the keychain. Every envelope still passes Verify — structure and
 	// recipient are intact — and not one of them can be decrypted. A hard
@@ -171,9 +197,10 @@ const (
 // Add new kinds here.
 var allCheckKinds = []checkKind{
 	kindParse, kindNotFound, kindMissing, kindCorrupt, kindVaultError,
-	kindBadPath, kindOrphan, kindShadowed, kindService, kindBackup,
-	kindWrap, kindWrapEnv, kindMount, kindVaultKey, kindRekey, kindAudit,
-	kindMCP, kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion,
+	kindBadPath, kindOrphan, kindDuplicates, kindOriginGone, kindShadowed,
+	kindService, kindBackup, kindWrap, kindWrapEnv, kindMount,
+	kindMountStale, kindVaultKey, kindRekey, kindAudit, kindMCP,
+	kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion,
 }
 
 // warning reports whether a finding of this kind is advisory (does not fail
@@ -189,7 +216,7 @@ var allCheckKinds = []checkKind{
 // one process and must never fail a CI run.
 func (k checkKind) warning() bool {
 	switch k {
-	case kindOrphan, kindShadowed, kindService, kindBackup, kindMount, kindWrapEnv, kindAudit, kindInstall, kindJitPathUpgrade, kindCompletion:
+	case kindOrphan, kindDuplicates, kindOriginGone, kindShadowed, kindService, kindBackup, kindMount, kindMountStale, kindWrapEnv, kindAudit, kindInstall, kindJitPathUpgrade, kindCompletion:
 		return true
 	default:
 		return false
@@ -250,6 +277,16 @@ type checkOptions struct {
 	// needs the whole profile picture to be meaningful, so it is ignored
 	// when Profile is set (a single profile can't tell you what's unused).
 	Orphans bool
+	// Duplicates additionally reports look-alike duplicate groups: identical
+	// key sets whose recorded origins agree, the same name-level evidence
+	// `jit vault list`'s nudge uses. Still auth-free (List + Info only, no
+	// decrypt), so still no prompt. Ignored when Profile is set — the
+	// evidence is a whole-vault property, not one profile's.
+	Duplicates bool
+	// Origins additionally stats each referenced secret's recorded origin
+	// file and reports the ones that no longer exist on disk. Ignored when
+	// Profile is set, like the other whole-picture sweeps.
+	Origins bool
 }
 
 // checkOutcome is the structured result both jit doctor and jit status build
@@ -451,36 +488,139 @@ func runProfileCheck(cwd string, v *vault.Vault, opts checkOptions) (checkOutcom
 		}
 	}
 
-	// Orphan detection needs the WHOLE profile picture to be truthful, so it
-	// runs only across all profiles (not --profile), only when at least one
-	// profile actually loaded (a zero-profile directory would otherwise call
-	// the entire vault orphaned), and only when every manifest parsed (an
-	// unreadable one leaves `referenced` incomplete — see parseFailed).
-	if opts.Orphans && opts.Profile == "" && len(entries) > 0 && !parseFailed {
+	// The whole-vault hygiene sweeps, all sharing one vault listing. Each
+	// needs the WHOLE profile picture to be truthful, so none runs under
+	// --profile. Orphan detection carries two extra guards of its own: at
+	// least one profile actually loaded (a zero-profile directory would
+	// otherwise call the entire vault orphaned), and every manifest parsed
+	// (an unreadable one leaves `referenced` incomplete — see parseFailed).
+	// The duplicates and origin sweeps make only POSITIVE claims about
+	// secrets they can see, so an incomplete picture can hide a finding but
+	// never invent one, and neither needs those guards.
+	wantOrphans := opts.Orphans && len(entries) > 0 && !parseFailed
+	if opts.Profile == "" && (wantOrphans || opts.Duplicates || opts.Origins) {
 		paths, err := v.List()
 		if err != nil {
-			// The orphan sweep is a bonus; a vault it can't list is still a
+			// The sweeps are a bonus; a vault it can't list is still a
 			// reportable problem, not a reason to lose the checks above.
-			out.Findings = append(out.Findings, checkFinding{Kind: kindVaultError, Detail: fmt.Sprintf("listing the vault for orphan detection: %v", err)})
+			out.Findings = append(out.Findings, checkFinding{Kind: kindVaultError, Detail: fmt.Sprintf("listing the vault for the hygiene sweeps: %v", err)})
 			return out, nil
 		}
 		secrets, _ := splitBackupPaths(paths)
-		for _, p := range secrets {
-			if !referenced[p] {
-				out.Findings = append(out.Findings, checkFinding{
-					Kind:   kindOrphan,
-					Path:   p,
-					Detail: "in the vault but referenced by no profile",
-					// Identical for every orphan, which is exactly why the
-					// renderer states a group's shared action once rather
-					// than repeating it under each of twenty lines.
-					Action: "`jit vault orphans --prune` to delete, or `jit vault list` to inspect first",
-				})
+		if wantOrphans {
+			for _, p := range secrets {
+				if !referenced[p] {
+					out.Findings = append(out.Findings, checkFinding{
+						Kind:   kindOrphan,
+						Path:   p,
+						Detail: "in the vault but referenced by no profile",
+						// Identical for every orphan, which is exactly why the
+						// renderer states a group's shared action once rather
+						// than repeating it under each of twenty lines.
+						Action: "`jit vault orphans --prune` to delete, or `jit vault list` to inspect first",
+					})
+				}
+			}
+		}
+		if opts.Duplicates || opts.Origins {
+			// Info never touches the KeyWrapper (same contract as List), so
+			// the metadata pass keeps doctor's never-prompts guarantee. A
+			// secret whose envelope won't parse is simply absent from meta:
+			// the integrity check above already reported it if referenced,
+			// and evidence built on it would be guesswork.
+			meta := map[string]vault.SecretInfo{}
+			for _, p := range secrets {
+				if info, err := v.Info(p); err == nil {
+					meta[p] = info
+				}
+			}
+			if opts.Duplicates {
+				out.Findings = append(out.Findings, duplicateFindings(secrets, meta)...)
+			}
+			if opts.Origins {
+				out.Findings = append(out.Findings, originGoneFindings(secrets, meta, referenced)...)
 			}
 		}
 	}
 
 	return out, nil
+}
+
+// duplicateFindings turns the duplicate-evidence clusters — the exact ones
+// `jit vault list`'s nudge prints, via the shared duplicateGroupClusters —
+// into advisory findings. The action routes to `jit vault duplicates` rather
+// than naming a copy to delete: name-level evidence must never nominate a
+// removal, only the value comparison behind an unlock may (a surviving copy
+// can lack a key the retired one held).
+func duplicateFindings(secrets []string, meta map[string]vault.SecretInfo) []checkFinding {
+	var out []checkFinding
+	for _, c := range duplicateGroupClusters(secrets, meta) {
+		out = append(out, checkFinding{
+			Kind:   kindDuplicates,
+			Detail: describeDuplicateCluster(c),
+			Action: "`jit vault duplicates` compares the stored values and names the copy safe to retire",
+		})
+	}
+	return out
+}
+
+// originGoneFindings reports each REFERENCED secret whose recorded origin
+// file no longer exists on disk — one finding per origin file, naming the
+// vault groups born from it. Only os.IsNotExist counts as gone: a
+// permission error is not evidence of absence, and a false "your file is
+// gone" costs more trust than the missed finding. Unreferenced secrets are
+// skipped on purpose — origin gone plus referenced-by-nothing IS the orphan
+// definition, and that count already carries them.
+//
+// No action line, following kindShadowed's reasoning: a deliberately deleted
+// source file (the product working as intended) and a half-deleted project
+// look identical from here, so any command would be advice, not a next step.
+func originGoneFindings(secrets []string, meta map[string]vault.SecretInfo, referenced map[string]bool) []checkFinding {
+	home, _ := os.UserHomeDir()
+	groupsByOrigin := map[string][]string{}
+	var order []string
+	gone := map[string]bool{}
+	for _, p := range secrets {
+		if !referenced[p] {
+			continue
+		}
+		info, ok := meta[p]
+		if !ok || info.Origin == "" {
+			continue
+		}
+		g, seen := gone[info.Origin]
+		if !seen {
+			_, statErr := os.Stat(wrap.ExpandHome(home, info.Origin))
+			g = os.IsNotExist(statErr)
+			gone[info.Origin] = g
+		}
+		if !g {
+			continue
+		}
+		group := p
+		if i := strings.IndexByte(p, '/'); i >= 0 {
+			group = p[:i]
+		}
+		if _, ok := groupsByOrigin[info.Origin]; !ok {
+			order = append(order, info.Origin)
+		}
+		// secrets is sorted, so one group's members are contiguous — the
+		// last-element check is a full dedupe.
+		if members := groupsByOrigin[info.Origin]; len(members) == 0 || members[len(members)-1] != group {
+			groupsByOrigin[info.Origin] = append(members, group)
+		}
+	}
+	var out []checkFinding
+	for _, origin := range order {
+		groups := groupsByOrigin[origin]
+		out = append(out, checkFinding{
+			Kind: kindOriginGone,
+			Path: origin,
+			Detail: fmt.Sprintf("%s %s migrated from %s, which no longer exists on disk",
+				strings.Join(groups, ", "), pluralWord(len(groups), "was", "were"), shortPath(origin)),
+		})
+	}
+	return out
 }
 
 // secretAction is the one runnable step for a broken secret reference.
@@ -547,6 +687,22 @@ func mountCheckTargets(root string, seen map[string]bool) (targets []mountTarget
 			continue
 		}
 		seen[clean] = true
+		// A manifest that is GONE is a different finding from one that won't
+		// parse, and crucially does NOT set parseFailed: a missing file names
+		// no references, so skipping it cannot make the orphan sweep
+		// under-count — the deleted project's secrets really are orphans, and
+		// suppressing the sweep here hid the count in exactly the cleanup
+		// this state calls for. Same split `collectReferencedPaths` makes.
+		if _, statErr := os.Stat(e.ProfilePath); os.IsNotExist(statErr) {
+			findings = append(findings, checkFinding{
+				Kind:   kindMountStale,
+				Scope:  scopeMount,
+				Path:   e.MountPath,
+				Detail: fmt.Sprintf("the mount at %s is still registered, but its profile is gone: project deleted without unmounting first", shortPath(e.MountPath)),
+				Action: "`jit vault orphans --prune` clears it (no secret is touched), or `jit unmount " + shortPath(e.MountPath) + "`",
+			})
+			continue
+		}
 		p, err := profile.LoadFile(e.ProfilePath)
 		if err != nil {
 			parseFailed = true

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -244,6 +244,42 @@ func printVaultList(out io.Writer, secrets, backups []string, showBackups, group
 // (which compares actual values under an unlock) rather than telling anyone
 // to delete on filename evidence alone.
 func printDuplicateGroupNudge(out io.Writer, secrets []string, meta map[string]vault.SecretInfo) {
+	for _, c := range duplicateGroupClusters(secrets, meta) {
+		fmt.Fprint(out, hlCmds("note: "+describeDuplicateCluster(c)+", see `jit vault duplicates`.\n"))
+	}
+}
+
+// dupEvidenceCluster is one set of top-level groups that look like the same
+// file stored more than once, on name-level evidence alone. Shared by `jit
+// vault list`'s nudge and `jit doctor`'s [duplicates] finding, so the two
+// surfaces can never disagree on what counts as evidence.
+type dupEvidenceCluster struct {
+	groups  []string
+	origins []string // parallel to groups
+	// sameOrigin: every member records literally the same path (a
+	// re-migration that forked a namespace) rather than the same file in two
+	// directories (a copied project tree).
+	sameOrigin bool
+}
+
+// describeDuplicateCluster names the evidence in one clause — what the nudge
+// prints after "note:" and what doctor carries as the finding's detail.
+func describeDuplicateCluster(c dupEvidenceCluster) string {
+	names := strings.Join(c.groups, ", ")
+	if c.sameOrigin {
+		return fmt.Sprintf("%s were migrated from the same file (%s)", names, shortPath(c.origins[0]))
+	}
+	copies := "two copies"
+	if len(c.groups) > 2 {
+		copies = fmt.Sprintf("%d copies", len(c.groups))
+	}
+	return fmt.Sprintf("%s hold the same keys from %s of %s", names, copies, originTail(c.origins[0]))
+}
+
+// duplicateGroupClusters computes the evidence clusters described on
+// printDuplicateGroupNudge, from a sorted secret listing and its Info
+// metadata — auth-free by construction, since both inputs are.
+func duplicateGroupClusters(secrets []string, meta map[string]vault.SecretInfo) []dupEvidenceCluster {
 	members := map[string][]string{} // top-level group -> its sub-paths
 	var order []string
 	for _, p := range secrets {
@@ -278,11 +314,7 @@ func printDuplicateGroupNudge(out io.Writer, secrets []string, meta map[string]v
 	// copied tree keeps the tail while the prefix moves. One extra segment
 	// beyond the basename on purpose — every project has a ".mcp.json", so
 	// the bare basename would call two unrelated projects' configs copies.
-	type cluster struct {
-		groups  []string
-		origins []string
-	}
-	byEvidence := map[string]*cluster{}
+	byEvidence := map[string]*dupEvidenceCluster{}
 	var clusterOrder []string
 	for _, g := range order {
 		origin := groupOrigin(g)
@@ -293,37 +325,28 @@ func printDuplicateGroupNudge(out io.Writer, secrets []string, meta map[string]v
 		sort.Strings(keys)
 		sig := strings.Join(keys, "\x00") + "\x00\x00" + originTail(origin)
 		if _, ok := byEvidence[sig]; !ok {
-			byEvidence[sig] = &cluster{}
+			byEvidence[sig] = &dupEvidenceCluster{}
 			clusterOrder = append(clusterOrder, sig)
 		}
 		byEvidence[sig].groups = append(byEvidence[sig].groups, g)
 		byEvidence[sig].origins = append(byEvidence[sig].origins, origin)
 	}
+	var clusters []dupEvidenceCluster
 	for _, sig := range clusterOrder {
 		c := byEvidence[sig]
 		if len(c.groups) < 2 {
 			continue
 		}
-		sameOrigin := true
+		c.sameOrigin = true
 		for _, o := range c.origins[1:] {
 			if o != c.origins[0] {
-				sameOrigin = false
+				c.sameOrigin = false
 				break
 			}
 		}
-		names := strings.Join(c.groups, ", ")
-		if sameOrigin {
-			fmt.Fprint(out, hlCmds(fmt.Sprintf("note: %s were migrated from the same file (%s), see `jit vault duplicates`.\n",
-				names, shortPath(c.origins[0]))))
-			continue
-		}
-		copies := "two copies"
-		if len(c.groups) > 2 {
-			copies = fmt.Sprintf("%d copies", len(c.groups))
-		}
-		fmt.Fprint(out, hlCmds(fmt.Sprintf("note: %s hold the same keys from %s of %s, see `jit vault duplicates`.\n",
-			names, copies, originTail(c.origins[0]))))
+		clusters = append(clusters, *c)
 	}
+	return clusters
 }
 
 // originTail is an origin path's identifying suffix — its final segment

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -2206,9 +2206,14 @@ var vaultOrphansCmd = &cobra.Command{
 					"Run `jit vault orphans --prune` to delete %s, or `jit vault rm <path>` one at a time.\n", countWord(len(orphans), "orphaned secret", "orphaned secrets"), pluralWord(len(orphans), "it", "them"))
 			}
 			if len(staleMounts) > 0 {
+				// Not countWord: it renders "1 the stale mount registration".
+				// The article belongs to the sentence, the count to the noun.
+				phrase := "the stale mount registration"
+				if len(staleMounts) > 1 {
+					phrase = fmt.Sprintf("the %d stale mount registrations", len(staleMounts))
+				}
 				fmt.Fprint(out, hlCmds(fmt.Sprintf("\n`jit vault orphans --prune` also clears %s\n"+
-					"(no secret is touched), or run `jit unmount <path>` on each.\n",
-					countWord(len(staleMounts), "the stale mount registration", "the stale mount registrations"))))
+					"(no secret is touched), or run `jit unmount <path>` on each.\n", phrase)))
 			}
 			return nil
 		}


### PR DESCRIPTION
`jit doctor` now runs the auth-free half of the vault cleanup surface on every full sweep and routes each finding to the command that acts on it, keeping both of doctor's standing guarantees: it never decrypts (so it never prompts) and it reports, never deletes. The scan/migrate-style report/act boundary stays intact — `jit vault orphans` and `jit vault duplicates` remain the acting halves.

## What changed

- **`[orphan]` count on by default.** The orphan sweep always runs; without `--orphans` it collapses to one count line routing to `jit vault orphans`. `--orphans` now selects the per-path listing instead of switching the sweep on — the run where you'd learn you have eleven orphans was exactly the run that hid them. Applied to text and JSON alike.
- **`[mount: stale]` split out of `[mount]`.** A registered mount whose manifest is GONE (project deleted without `jit unmount`) routes to `jit vault orphans --prune` and no longer sets `parseFailed`: a missing file names no references, so skipping it cannot make the orphan sweep under-count. Same distinction `jit vault orphans` drew in v0.93.0 (GAPS.md #67); doctor still suppressed the orphan count in exactly the cleanup that state calls for. A manifest that exists but won't parse keeps today's behavior.
- **`[duplicates]` hint.** Groups that look like the same file stored twice, on the same name-level evidence as `jit vault list`'s nudge — the clustering is extracted into a shared `duplicateGroupClusters` so the two surfaces can never drift. The action routes to `jit vault duplicates`; name evidence never nominates a copy to delete, since a surviving copy can lack a key the retired one held.
- **`[origin gone]`.** A secret a profile still references whose recorded Origin file no longer exists on disk. Stat only, and only `os.IsNotExist` counts as gone — a permission error is not evidence of absence. The unreferenced half of that state needs no kind of its own: it is the orphan definition, and the count already carries it. No action line (kindShadowed's reasoning: a deliberately deleted source file and a half-deleted project look identical from here).

All four are warnings: `ok` and the default exit are untouched, they gate only under `--strict`, and the JSON change is additive (no schema bump). Also fixes a pre-existing wording glitch in `jit vault orphans` ("clears 1 the stale mount registration").

## Verified on a real machine

The dev VM genuinely had the stale-mount state plus 9 orphaned secrets. Installed v0.90.0 rendered the stale mount as a raw "no such file or directory" `[mount]` warning with the action "fix the manifest" (of a deleted project) and showed nothing about the orphans; this branch renders `[mount: stale]` with the prune route plus the 9-orphan count, in exact agreement with `jit vault orphans`. No auth prompt at any point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ugtBevcdhHM42LCTNCEFb