### PR TITLE
fix: redact caller argv before it reaches the agent session history

### DIFF
--- a/internal/agent/caller.go
+++ b/internal/agent/caller.go
@@ -79,6 +79,23 @@ func (c *caller) command() string {
 	return fmt.Sprintf("pid %d", c.pid)
 }
 
+// rawCommand is the caller's invocation UNREDACTED, and it exists for exactly
+// one consumer: recordUse's aggregation key. Redaction can map two different
+// argvs onto one string (two MCP servers under long versioned paths, say),
+// and keying the collapse window on the redacted form would merge unrelated
+// callers into one event stamped with the first caller's pid — misattribution
+// in the audit trail. The raw string lives only in the in-memory pendingUses
+// map key; everything recorded or displayed goes through command().
+func (c *caller) rawCommand() string {
+	if c == nil {
+		return ""
+	}
+	if cmd := c.self.Command(); cmd != "" {
+		return cmd
+	}
+	return fmt.Sprintf("pid %d", c.pid)
+}
+
 // launchedBy names the nearest ancestor that actually EXPLAINS the call. The
 // rule (skip the shells that merely relayed it) lives in internal/lineage,
 // because the mount manager asks the same question of a different process:
@@ -123,8 +140,9 @@ func (c *caller) profile() string {
 // renders the reason as one sentence inside a small modal ("jit is trying to
 // <reason>."), and Apple's own guidance is a short phrase — the raw argv of a
 // jit-launched MCP server runs past 120 characters of absolute paths and is
-// unreadable there. The full command line is still recorded for `jit agent
-// status`, which has a whole terminal to print it in.
+// unreadable there. The command line is still recorded — secrets masked, see
+// command() — for `jit agent status`, which has a whole terminal to print it
+// in.
 const maxReasonLen = 90
 
 // challengeReason is what the human actually reads on the Touch ID/passcode

--- a/internal/agent/caller.go
+++ b/internal/agent/caller.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/jitpass/jit/internal/auditlog"
 	"github.com/jitpass/jit/internal/lineage"
 )
 
@@ -58,13 +59,22 @@ func callerFromConn(conn net.Conn) *caller {
 
 // command is the caller's full invocation for a status line or a log: a wide
 // terminal can take the whole argv, and when investigating you want the
-// literal command back.
+// command back — with any secret it carried MASKED. Every By this feeds ends
+// up in the in-memory ring and the durable agent-history.jsonl, and the
+// application audit log's promise ("records that a command RAN, not the
+// secret it may have carried", internal/auditlog) has to hold for the agent's
+// half of the merged `jit audit` timeline too: a caller like
+// `jit vault set <path> <value>` or `jit run -- tool --token=…` must never
+// have its transient argv upgraded into a durable plaintext copy — the
+// shell-history exposure jit exists to eliminate. Redacting here, at the one
+// point argv becomes a By, is what keeps a future recording site from having
+// to remember to.
 func (c *caller) command() string {
 	if c == nil {
 		return ""
 	}
 	if cmd := c.self.Command(); cmd != "" {
-		return cmd
+		return auditlog.RedactCommandLine(cmd)
 	}
 	return fmt.Sprintf("pid %d", c.pid)
 }

--- a/internal/agent/caller_test.go
+++ b/internal/agent/caller_test.go
@@ -146,3 +146,74 @@ func TestChallengeReasonTruncationNeverSplitsARune(t *testing.T) {
 		t.Errorf("reason is %d runes, want <= %d", utf8.RuneCountInString(got), maxReasonLen)
 	}
 }
+
+// The session history is durable (agent-history.jsonl, rendered back by `jit
+// audit` and `jit agent history`), and By is the caller's own argv — so a
+// secret the caller carried on its command line must be masked BEFORE the
+// event exists. The application audit log promises it "records that a command
+// RAN, not the secret it may have carried" (internal/auditlog); the agent's
+// half of the merged timeline has to keep the same promise, or `jit run --
+// tool --token=…` upgrades a transient argv into a durable plaintext copy —
+// precisely the shell-history exposure jit exists to eliminate.
+func TestUnlockEventNeverRecordsACredentialFromTheCallersArgv(t *testing.T) {
+	secret := "sk_FAKEfixture_notARealKeyXYZ0123"
+	c := callerFor([]string{"jit", "run", "--profile", "deploy", "--", "curl", "-H", "Authorization=" + secret}, "claude")
+
+	e := unlockEvent(OpUnwrap, c)
+
+	if strings.Contains(e.By, secret) {
+		t.Fatalf("By = %q carries the caller's raw credential into the durable history", e.By)
+	}
+	if !strings.Contains(e.By, "jit run --profile deploy") {
+		t.Errorf("By = %q, want the non-secret part of the command kept legible", e.By)
+	}
+}
+
+// A weak value ("hunter2") is not credential-shaped, so the entropy pass alone
+// would record it — the vault-set positional mask has to catch it, the same
+// way cli/auditrecord.go masks the identical position in jit's own os.Args.
+// The PATH stays legible: it is the one part of the line an investigation
+// needs, and it is not a secret.
+func TestUnlockEventMasksAVaultSetValueTooWeakForTheEntropyTest(t *testing.T) {
+	c := callerFor([]string{"jit", "vault", "set", "stripe/live-key", "hunter2"})
+
+	e := unlockEvent(OpWrap, c)
+
+	if strings.Contains(e.By, "hunter2") {
+		t.Fatalf("By = %q records the vault-set value in the clear", e.By)
+	}
+	if !strings.Contains(e.By, "stripe/live-key") {
+		t.Errorf("By = %q, want the secret's path kept, it is not a secret", e.By)
+	}
+}
+
+// The path-only form carries no value (it came from the prompt or --stdin),
+// and masking the last positional then would redact the path itself.
+func TestUnlockEventKeepsVaultSetPathWhenValueCameFromPrompt(t *testing.T) {
+	c := callerFor([]string{"jit", "vault", "set", "stripe/live-key", "--stdin"})
+
+	e := unlockEvent(OpWrap, c)
+
+	if !strings.Contains(e.By, "stripe/live-key") {
+		t.Errorf("By = %q, want the path kept when no value was on the line", e.By)
+	}
+}
+
+// recordServeError stamps the same By provenance an unlock would, for peers
+// that were REJECTED — and a rejected peer's argv is even less trustworthy
+// than an accepted one's, so it gets the same redaction.
+func TestRecordServeErrorRedactsTheRejectedPeersArgv(t *testing.T) {
+	secret := "sk_FAKEfixture_notARealKeyXYZ0123"
+	var got SessionEvent
+	s := &Server{OnServeError: func(e SessionEvent) { got = e }}
+	c := callerFor([]string{"some-tool", "--token=" + secret})
+
+	s.recordServeError("reject", "peer uid mismatch", c)
+
+	if strings.Contains(got.By, secret) {
+		t.Fatalf("By = %q carries a rejected peer's raw credential into the history", got.By)
+	}
+	if got.ByPID != c.pid {
+		t.Errorf("ByPID = %d, want %d: redaction must not cost the provenance", got.ByPID, c.pid)
+	}
+}

--- a/internal/agent/caller_test.go
+++ b/internal/agent/caller_test.go
@@ -8,6 +8,7 @@ package agent
 import (
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/jitpass/jit/internal/lineage"
@@ -215,5 +216,34 @@ func TestRecordServeErrorRedactsTheRejectedPeersArgv(t *testing.T) {
 	}
 	if got.ByPID != c.pid {
 		t.Errorf("ByPID = %d, want %d: redaction must not cost the provenance", got.ByPID, c.pid)
+	}
+}
+
+// Redaction can map two DIFFERENT callers' argvs onto one string — here two
+// tools differing only in the token they carry. The use-aggregation key must
+// be the raw command (never recorded, in-memory only), or the second
+// caller's uses would merge into the first's aggregate and jit audit would
+// attribute them to the wrong process.
+func TestRecordUseKeepsCallersSeparateWhenRedactionCollides(t *testing.T) {
+	s := &Server{useWindow: time.Hour} // a real window, so neither aggregate expires mid-test
+	c1 := callerFor([]string{"some-tool", "--token=sk_FAKEfixtureAAAA1111BBBB2222"})
+	c2 := callerFor([]string{"some-tool", "--token=sk_FAKEfixtureCCCC3333DDDD4444"})
+	if c1.command() != c2.command() {
+		t.Fatalf("test premise broken: redacted commands differ: %q vs %q", c1.command(), c2.command())
+	}
+
+	s.recordUse(OpUnwrap, c1, "a")
+	s.recordUse(OpUnwrap, c2, "b")
+
+	s.mu.Lock()
+	flushed := s.flushUsesLocked(true, time.Now())
+	s.mu.Unlock()
+	if len(flushed) != 2 {
+		t.Fatalf("flushed %d aggregate(s), want 2: distinct callers must not merge just because their redacted argvs match (got %+v)", len(flushed), flushed)
+	}
+	for _, e := range flushed {
+		if strings.Contains(e.By, "sk_FAKEfixture") {
+			t.Errorf("flushed event By = %q still carries the raw token", e.By)
+		}
 	}
 }

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -10,6 +10,8 @@ import (
 	"net"
 	"os"
 	"time"
+
+	"github.com/jitpass/jit/internal/auditlog"
 )
 
 // ErrNotRunning marks a dial failure: nothing answered the agent socket at
@@ -451,6 +453,9 @@ func (c *Client) History() ([]SessionEvent, error) {
 	if err != nil {
 		return nil, err
 	}
+	for i := range resp.Events {
+		scrubEventBy(&resp.Events[i])
+	}
 	return resp.Events, nil
 }
 
@@ -460,6 +465,9 @@ func (c *Client) Status() (Status, error) {
 	if err != nil {
 		return Status{}, err
 	}
+	scrubEventBy(resp.LastUnlock)
+	scrubEventBy(resp.LastLock)
+	scrubEventBy(resp.PendingUnlock)
 	return Status{
 		Unlocked:       resp.Unlocked,
 		Remaining:      time.Duration(resp.ExpiresInSeconds) * time.Second,
@@ -471,4 +479,18 @@ func (c *Client) Status() (Status, error) {
 		Version:        resp.Version,
 		ExecutablePath: resp.ExecutablePath,
 	}, nil
+}
+
+// scrubEventBy masks an RPC-served event's By on the CLIENT side, mirroring
+// the legacy scrub the file readers apply. The agent now redacts By at the
+// source, but the process answering this RPC may still be a pre-fix binary
+// whose in-memory ring holds raw argv — launchd swaps it within the stale
+// binary poll, a foreground `jit agent run` never does — and an upgraded CLI
+// must not render that window's plaintext through `jit service status` or
+// `jit agent history`.
+func scrubEventBy(e *SessionEvent) {
+	if e == nil {
+		return
+	}
+	e.By = auditlog.RedactCommandLine(e.By)
 }

--- a/internal/agent/grant.go
+++ b/internal/agent/grant.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jitpass/jit/internal/auditlog"
 	"github.com/jitpass/jit/internal/lineage"
 )
 
@@ -257,11 +258,15 @@ func (s *Server) createGrant(req Request, c *caller) Response {
 		return Response{OK: false, Error: err.Error()}
 	}
 	g := &processGrant{
-		id:         id,
-		rootPID:    req.TargetPID,
-		rootStart:  rootStart,
-		name:       who,
-		command:    target.Command(),
+		id:        id,
+		rootPID:   req.TargetPID,
+		rootStart: rootStart,
+		name:      who,
+		// Masked at capture like every other argv the agent keeps: this
+		// string ships out through GrantStatus.Command into `jit grant list
+		// --json` and `jit status`, and a grant target launched as
+		// `tool --token=…` must not show its secret in every status listing.
+		command:    auditlog.RedactCommandLine(target.Command()),
 		nameFilter: req.GrantName,
 		anchorName: under,
 		profiles:   append([]string(nil), req.GrantProfiles...),

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -392,10 +392,14 @@ type SessionEvent struct {
 	// "serve_mounts" for the agent's own in-process unlock when it resolves
 	// a mount's real content. Empty on a lock event.
 	Op string `json:"op,omitempty"`
-	// By is the caller's full command line as the kernel reports it, and
-	// ByPID its pid — the literal "what asked for this", for a terminal wide
-	// enough to print it. The Touch ID prompt gets a much shorter phrasing
-	// (see challengeReason); this is the investigative version.
+	// By is the caller's full command line as the kernel reports it — with
+	// any secret the caller carried on it masked (caller.command routes argv
+	// through auditlog.RedactCommandLine before a By ever exists) — and
+	// ByPID its pid: the "what asked for this", for a terminal wide enough
+	// to print it. The Touch ID prompt gets a much shorter phrasing (see
+	// challengeReason); this is the investigative version, durable in
+	// agent-history.jsonl, which is exactly why it must never hold a
+	// plaintext secret.
 	By    string `json:"by,omitempty"`
 	ByPID int32  `json:"by_pid,omitempty"`
 	// ByLikely marks By/ByPID as an identity carried over from an earlier

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -1529,7 +1529,12 @@ const maxUseLabels = 8
 // actually reads). A crash loses at most the still-pending window —
 // bounded, and the durable file gets everything else.
 func (s *Server) recordUse(op string, c *caller, label string) {
-	s.recordAggregated(KindUse, op, c.command(), c, label)
+	// The collapse key is the RAW command line, not the redacted one the
+	// event will carry: redaction can map two different callers' argvs onto
+	// one string, and merging their aggregates would stamp the first
+	// caller's pid onto the second's uses. The raw string never leaves the
+	// in-memory pendingUses map (see caller.rawCommand).
+	s.recordAggregated(KindUse, op, c.rawCommand(), c, label)
 }
 
 // opClassMismatch is the op label for an unwrap rejected because the class the

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -320,72 +320,149 @@ func RedactText(s string) string {
 
 // RedactCommandLine masks secrets inside a whole command line recorded as ONE
 // string — the agent's SessionEvent.By, a caller's argv joined with spaces —
-// the one recorded shape neither Redact (which sees jit's own parsed args) nor
-// a plain RedactText pass fully covers. Two passes, mirroring what Redact plus
-// cli/auditrecord.go's positional mask do for jit's own os.Args: a grammar
-// pass that unconditionally masks the value positionals of a
-// `jit vault set <path> <value>` line (a weak value — "hunter2" — is not
-// credential-shaped and would survive the entropy test), then RedactText for
-// every credential-shaped token whatever the command was.
+// the one recorded shape Redact (which sees jit's own parsed args) never
+// covers. Two passes: the vault-set grammar mask (a weak value — "hunter2" —
+// is not credential-shaped and would survive every heuristic), then redactArg
+// on each field, the same KEY=VALUE-splitting, path-exempting judgement
+// Redact applies to jit's own os.Args. Fields redactArg keeps and that carry
+// no path separator get one more RedactText sweep, so a credential wrapped in
+// quotes or glued to punctuation is still found; path-bearing fields skip it
+// because the entropy test has no business inside "/opt/homebrew/Cellar/…" —
+// an investigator needs the program back, and looksSecret's prefix check has
+// already had its chance at a path that really is a credential.
+//
+// Whitespace is normalized to single spaces (the fields are re-joined). By
+// strings are argv joined with single spaces already, so nothing observable
+// changes.
 //
 // This lives here rather than beside the agent that records By or the CLI
 // that re-reads it, because both need the identical judgement and auditlog is
 // the leaf they already share for exactly this doctrine.
 func RedactCommandLine(line string) string {
 	fields := strings.Fields(line)
-	if masked, changed := maskVaultSetValues(fields); changed {
-		line = strings.Join(masked, " ")
+	if len(fields) == 0 {
+		return line
 	}
-	return RedactText(line)
+	fields, _ = MaskVaultSetValues(fields)
+	for i, f := range fields {
+		if f == RedactToken {
+			continue
+		}
+		if r := redactArg(f); r != f {
+			fields[i] = r
+			continue
+		}
+		if !strings.Contains(f, "/") {
+			fields[i] = RedactText(f)
+		}
+	}
+	return strings.Join(fields, " ")
 }
 
-// maskVaultSetValues replaces the value positionals of a `jit vault set
-// <path> <value>` field list with RedactToken. The first four positionals —
-// the program (matched on its base name, argv[0] is usually an absolute
-// path), "vault", "set", and the path — stay legible: the path is the one
-// part of the line an investigation needs, and it is not a secret. EVERY
-// positional past the path is masked, not just the last: a value argv element
-// containing spaces rejoins as several fields, and a mistyped extra argument
-// is more likely a mis-pasted secret than anything the trail should keep.
-func maskVaultSetValues(fields []string) ([]string, bool) {
-	pos := positionalIndexes(fields)
-	if len(pos) < 5 {
-		return fields, false
+// MaskVaultSetValues replaces the value positionals of a `jit vault set
+// <path> <value>` argv with RedactToken, reporting whether anything was
+// masked. The grammar's own words — the program (matched on its base name,
+// argv[0] is usually an absolute path), "vault", "set", and the path — stay
+// legible: the path is the one part of the line an investigation needs, and
+// it is not a secret. EVERY element past the path is masked, not just the
+// last: a value argv element containing spaces rejoins as several fields, a
+// mistyped extra argument is more likely a mis-pasted secret than anything
+// the trail should keep, and a dash-prefixed token past the path is masked
+// too unless it is one of the command's own boolean flags — a value that
+// happens to start with "-" must not slip through by looking like a flag.
+// After a bare "--" even a flag-spelled token is a value, exactly as cobra
+// reads it.
+//
+// Exported because the two producers of this judgement — RedactCommandLine
+// here and cli/auditrecord.go's positional mask for jit's own os.Args — must
+// share ONE grammar; they briefly held two hand-rolled copies, which
+// disagreed within the first review. It works element-wise, so both a real
+// argv slice (elements may contain spaces) and a Fields-split line get the
+// identical treatment. A slice that is not a vault-set invocation is
+// returned unchanged.
+func MaskVaultSetValues(argv []string) ([]string, bool) {
+	const (
+		wantJit = iota
+		wantVault
+		wantSet
+		wantPath
+		masking
+	)
+	stage := wantJit
+	terminated := false
+	changed := false
+	out := append([]string(nil), argv...)
+	for i, f := range argv {
+		if !terminated && f == "--" {
+			terminated = true
+			continue
+		}
+		flagLike := !terminated && strings.HasPrefix(f, "-") && f != "-"
+		switch stage {
+		case wantJit:
+			if flagLike {
+				continue
+			}
+			if filepath.Base(f) != "jit" {
+				return argv, false
+			}
+			stage = wantVault
+		case wantVault:
+			if flagLike {
+				continue
+			}
+			if f != "vault" {
+				return argv, false
+			}
+			stage = wantSet
+		case wantSet:
+			if flagLike {
+				continue
+			}
+			if f != "set" {
+				return argv, false
+			}
+			stage = wantPath
+		case wantPath:
+			if flagLike {
+				continue
+			}
+			stage = masking // f is the path; keep it
+		case masking:
+			if !terminated && isVaultSetFlag(f) {
+				continue
+			}
+			out[i] = RedactToken
+			changed = true
+		}
 	}
-	if filepath.Base(fields[pos[0]]) != "jit" || fields[pos[1]] != "vault" || fields[pos[2]] != "set" {
-		return fields, false
-	}
-	out := append([]string(nil), fields...)
-	for _, i := range pos[4:] {
-		out[i] = RedactToken
+	if !changed {
+		return argv, false
 	}
 	return out, true
 }
 
-// positionalIndexes lists the indexes of fields' non-flag tokens. Reliable
-// for the vault-set grammar specifically because every flag that command can
-// see (--stdin, --yes/-y, --force/-f, the root --quiet) is a BOOLEAN, so a
-// "-" prefix is always a whole flag and never a flag's detached value; if a
-// value-taking flag is ever added there, its value would count as positional
-// and be masked — over-masking, never a leak. A bare "--" ends flag parsing:
-// everything after it is positional whatever it looks like, exactly as cobra
-// reads it.
-func positionalIndexes(fields []string) []int {
-	var pos []int
-	flagsDone := false
-	for i, f := range fields {
-		if !flagsDone {
-			if f == "--" {
-				flagsDone = true
-				continue
-			}
-			if strings.HasPrefix(f, "-") && f != "-" {
-				continue
-			}
-		}
-		pos = append(pos, i)
+// VaultSetBooleanFlags are the flags a `jit vault set` command line can
+// legitimately carry, all boolean — which is what lets MaskVaultSetValues
+// keep them legible while masking every other token past the path. A flag
+// added to the command but not listed here is masked as if it were a value:
+// over-masking, never a leak. TestVaultSetGrammarMatchesCommand (cli) walks
+// the real cobra command and fails if this map drifts from it, or if the
+// command ever grows a non-boolean flag this grammar could not survive.
+var VaultSetBooleanFlags = map[string]bool{
+	"--stdin": true,
+	"--yes":   true, "-y": true,
+	"--force": true, "-f": true,
+	"--quiet": true,
+}
+
+// isVaultSetFlag reports whether tok spells one of vault set's own boolean
+// flags, including the "--flag=true" form.
+func isVaultSetFlag(tok string) bool {
+	if i := strings.IndexByte(tok, '='); i > 0 {
+		tok = tok[:i]
 	}
-	return pos
+	return VaultSetBooleanFlags[tok]
 }
 
 // hasMixedClasses requires both letters and digits, a lone long word

--- a/internal/auditlog/auditlog.go
+++ b/internal/auditlog/auditlog.go
@@ -318,6 +318,76 @@ func RedactText(s string) string {
 	})
 }
 
+// RedactCommandLine masks secrets inside a whole command line recorded as ONE
+// string — the agent's SessionEvent.By, a caller's argv joined with spaces —
+// the one recorded shape neither Redact (which sees jit's own parsed args) nor
+// a plain RedactText pass fully covers. Two passes, mirroring what Redact plus
+// cli/auditrecord.go's positional mask do for jit's own os.Args: a grammar
+// pass that unconditionally masks the value positionals of a
+// `jit vault set <path> <value>` line (a weak value — "hunter2" — is not
+// credential-shaped and would survive the entropy test), then RedactText for
+// every credential-shaped token whatever the command was.
+//
+// This lives here rather than beside the agent that records By or the CLI
+// that re-reads it, because both need the identical judgement and auditlog is
+// the leaf they already share for exactly this doctrine.
+func RedactCommandLine(line string) string {
+	fields := strings.Fields(line)
+	if masked, changed := maskVaultSetValues(fields); changed {
+		line = strings.Join(masked, " ")
+	}
+	return RedactText(line)
+}
+
+// maskVaultSetValues replaces the value positionals of a `jit vault set
+// <path> <value>` field list with RedactToken. The first four positionals —
+// the program (matched on its base name, argv[0] is usually an absolute
+// path), "vault", "set", and the path — stay legible: the path is the one
+// part of the line an investigation needs, and it is not a secret. EVERY
+// positional past the path is masked, not just the last: a value argv element
+// containing spaces rejoins as several fields, and a mistyped extra argument
+// is more likely a mis-pasted secret than anything the trail should keep.
+func maskVaultSetValues(fields []string) ([]string, bool) {
+	pos := positionalIndexes(fields)
+	if len(pos) < 5 {
+		return fields, false
+	}
+	if filepath.Base(fields[pos[0]]) != "jit" || fields[pos[1]] != "vault" || fields[pos[2]] != "set" {
+		return fields, false
+	}
+	out := append([]string(nil), fields...)
+	for _, i := range pos[4:] {
+		out[i] = RedactToken
+	}
+	return out, true
+}
+
+// positionalIndexes lists the indexes of fields' non-flag tokens. Reliable
+// for the vault-set grammar specifically because every flag that command can
+// see (--stdin, --yes/-y, --force/-f, the root --quiet) is a BOOLEAN, so a
+// "-" prefix is always a whole flag and never a flag's detached value; if a
+// value-taking flag is ever added there, its value would count as positional
+// and be masked — over-masking, never a leak. A bare "--" ends flag parsing:
+// everything after it is positional whatever it looks like, exactly as cobra
+// reads it.
+func positionalIndexes(fields []string) []int {
+	var pos []int
+	flagsDone := false
+	for i, f := range fields {
+		if !flagsDone {
+			if f == "--" {
+				flagsDone = true
+				continue
+			}
+			if strings.HasPrefix(f, "-") && f != "-" {
+				continue
+			}
+		}
+		pos = append(pos, i)
+	}
+	return pos
+}
+
 // hasMixedClasses requires both letters and digits, a lone long word
 // ("informationtechnology") or a lone long number (a nanosecond timestamp) is
 // not credential-shaped, so this keeps the entropy test from flagging them.

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -316,3 +316,105 @@ func TestRedactCommandLineOutsideVaultSetGrammar(t *testing.T) {
 		}
 	}
 }
+
+// A secret glued to its key with '=' is the single most common shape a
+// credential takes on a real command line (`--token=ghp_…`, `KEY=VALUE` env
+// prefixes), and the first review of this redactor found exactly that shape
+// leaking: the whole glued token starts with the key, so a prefix test on it
+// never fires, and a short vendor token is under the entropy floor. The
+// value half must be judged on its own, the same split Redact applies to
+// jit's own args.
+func TestRedactCommandLineMasksKeyValueGluedSecrets(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{
+			"jit run -- curl -H token=ghp_short1",
+			"jit run -- curl -H token=" + RedactToken,
+		},
+		{
+			"jit run -- tool --token=ghp_short1",
+			"jit run -- tool --token=" + RedactToken,
+		},
+		{
+			"some-tool --api-key=sk_FAKEfixture_notARealKeyXYZ01",
+			"some-tool --api-key=" + RedactToken,
+		},
+	}
+	for _, tc := range cases {
+		if got := RedactCommandLine(tc.in); got != tc.want {
+			t.Errorf("RedactCommandLine(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The entropy pass must never eat an ordinary path: By exists so an
+// investigator can identify the program, and a versioned install path
+// ("/opt/homebrew/Cellar/awscli/2.17.5/bin/aws") is long, digit-bearing, and
+// entirely credential-alphabet — everything the entropy test looks for. The
+// same '/'-exemption looksSecret applies to jit's own args holds here, and
+// it must also protect a long vault PATH inside a vault-set line: masking
+// the path the grammar pass deliberately kept would defeat its whole point.
+func TestRedactCommandLineKeepsOrdinaryPaths(t *testing.T) {
+	for _, in := range []string{
+		"/opt/homebrew/Cellar/awscli/2.17.5/bin/aws s3 ls",
+		"node /Users/me/.nvm/versions/node/v22.1.0/bin/mcp-server-jamf",
+	} {
+		if got := RedactCommandLine(in); got != in {
+			t.Errorf("RedactCommandLine mangled an innocent path:\n in: %q\nout: %q", in, got)
+		}
+	}
+	in := "jit vault set github/tokens/menit-bot-2026 hunter2"
+	want := "jit vault set github/tokens/menit-bot-2026 " + RedactToken
+	if got := RedactCommandLine(in); got != want {
+		t.Errorf("long vault path lost:\n in: %q\ngot: %q\nwant: %q", in, got, want)
+	}
+}
+
+// A value that happens to start with "-" must not escape the grammar mask by
+// looking like a flag — secrets pasted from base64 output realistically do.
+// Only vault set's own boolean flags stay legible; anything else past the
+// path is a value.
+func TestRedactCommandLineMasksDashPrefixedVaultSetValues(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{
+			"jit vault set stripe/live-key -hunter2",
+			"jit vault set stripe/live-key " + RedactToken,
+		},
+		{
+			"jit vault set stripe/live-key -my weak phrase",
+			"jit vault set stripe/live-key " + RedactToken + " " + RedactToken + " " + RedactToken,
+		},
+		{
+			"jit vault set stripe/live-key --stdin",
+			"jit vault set stripe/live-key --stdin",
+		},
+		{
+			"jit vault set --stdin=true stripe/live-key",
+			"jit vault set --stdin=true stripe/live-key",
+		},
+	}
+	for _, tc := range cases {
+		if got := RedactCommandLine(tc.in); got != tc.want {
+			t.Errorf("RedactCommandLine(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// MaskVaultSetValues works element-wise so a REAL argv (where a multi-word
+// value is one element) gets the identical judgement a Fields-split line
+// does — it is the one grammar both producers share.
+func TestMaskVaultSetValuesArgvElements(t *testing.T) {
+	got, changed := MaskVaultSetValues([]string{"jit", "vault", "set", "stripe/key", "my weak phrase"})
+	if !changed {
+		t.Fatal("value element not masked")
+	}
+	want := []string{"jit", "vault", "set", "stripe/key", RedactToken}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("MaskVaultSetValues = %v, want %v", got, want)
+		}
+	}
+	in := []string{"vi", "jit", "vault", "set", "notes.txt"}
+	if _, changed := MaskVaultSetValues(in); changed {
+		t.Errorf("non-jit argv %v was treated as vault set", in)
+	}
+}

--- a/internal/auditlog/auditlog_test.go
+++ b/internal/auditlog/auditlog_test.go
@@ -228,3 +228,91 @@ func TestRedactTextKeepsOrdinaryText(t *testing.T) {
 		t.Errorf("RedactText altered ordinary text:\n in: %q\nout: %q", in, got)
 	}
 }
+
+// RedactCommandLine guards the one recorded shape Redact never sees: a whole
+// command line stored as a single string — the agent's SessionEvent.By, the
+// caller's argv joined with spaces. Its grammar pass must mask the value
+// positionals of a `jit vault set <path> <value>` line unconditionally,
+// because a weak value ("hunter2") is not credential-shaped and would sail
+// through the entropy test — the exact reason cli/auditrecord.go masks the
+// same position in jit's own recorded args.
+func TestRedactCommandLineMasksVaultSetValues(t *testing.T) {
+	cases := []struct{ name, in, want string }{
+		{
+			"weak value masked, path kept",
+			"jit vault set stripe/live-key hunter2",
+			"jit vault set stripe/live-key " + RedactToken,
+		},
+		{
+			"absolute jit path and boolean flags",
+			"/opt/homebrew/bin/jit vault set -y stripe/live-key hunter2",
+			"/opt/homebrew/bin/jit vault set -y stripe/live-key " + RedactToken,
+		},
+		{
+			"multi-word value masked whole: one argv element rejoins as several fields",
+			"jit vault set stripe/live-key my weak phrase",
+			"jit vault set stripe/live-key " + RedactToken + " " + RedactToken + " " + RedactToken,
+		},
+		{
+			"value after the -- terminator is still the value",
+			"jit vault set stripe/live-key -- -hunter2",
+			"jit vault set stripe/live-key -- " + RedactToken,
+		},
+	}
+	for _, tc := range cases {
+		if got := RedactCommandLine(tc.in); got != tc.want {
+			t.Errorf("%s:\n in: %q\ngot: %q\nwant: %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}
+
+// The path-only form (value from the prompt or --stdin) has NO value on the
+// line, and masking then would redact the secret's PATH — a non-secret the
+// trail should keep. Same rule cli/auditrecord.go applies via cobra's
+// positional count; here the count comes from the line itself.
+func TestRedactCommandLineKeepsVaultSetPathWhenNoValuePresent(t *testing.T) {
+	for _, in := range []string{
+		"jit vault set stripe/live-key",
+		"jit vault set --stdin stripe/live-key",
+		"jit vault set stripe/live-key --stdin",
+	} {
+		if got := RedactCommandLine(in); got != in {
+			t.Errorf("RedactCommandLine(%q) = %q, want unchanged: the only positional is the path", in, got)
+		}
+	}
+}
+
+// Everything that is not the vault-set grammar still gets the credential-
+// shaped pass and nothing more: ordinary lines survive verbatim, shaped
+// tokens are masked wherever they sit.
+func TestRedactCommandLineOutsideVaultSetGrammar(t *testing.T) {
+	secret := "sk_FAKEfixture_notARealKeyXYZ0123"
+	cases := []struct{ name, in, want string }{
+		{
+			"ordinary command untouched",
+			"jit run --profile deploy -- terraform plan",
+			"jit run --profile deploy -- terraform plan",
+		},
+		{
+			"vault get keeps its path",
+			"jit vault get stripe/live-key",
+			"jit vault get stripe/live-key",
+		},
+		{
+			"a non-jit program is not vault-set even with the words",
+			"vi jit vault set notes.txt",
+			"vi jit vault set notes.txt",
+		},
+		{
+			"shaped token masked in any command",
+			"jit run -- curl -H " + secret,
+			"jit run -- curl -H " + RedactToken,
+		},
+		{"empty line", "", ""},
+	}
+	for _, tc := range cases {
+		if got := RedactCommandLine(tc.in); got != tc.want {
+			t.Errorf("%s:\n in: %q\ngot: %q\nwant: %q", tc.name, tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -204,6 +204,11 @@ var agentRunCmd = &cobra.Command{
 		// and followed.
 		hist := newHistoryLog(root, stderr)
 		hist.trim()
+		// One-time rewrite masking any By a pre-fix agent recorded raw —
+		// this is what removes a legacy line's plaintext from DISK; the
+		// readers' scrub only keeps it off the screen. Same single-writer
+		// startup window as trim, so it can't race an append.
+		hist.scrubLegacy()
 		hist.append(agent.SessionEvent{
 			UnixTime: time.Now().Unix(),
 			Kind:     agent.KindStart,

--- a/internal/cli/agenthistory.go
+++ b/internal/cli/agenthistory.go
@@ -118,18 +118,81 @@ func (h *historyLog) load(max int) []agent.SessionEvent {
 		if err := json.Unmarshal(line, &e); err != nil || e.Kind == "" {
 			continue
 		}
-		// Lines written before the agent masked By at the source can hold a
-		// caller's raw secret, and this file keeps ~10k events — scrub them
-		// with the same judgement the agent now applies on record, so a
-		// poisoned legacy line stops leaking the moment it is read rather
-		// than the year it rotates out.
-		e.By = auditlog.RedactCommandLine(e.By)
 		out = append(out, e)
 	}
 	if len(out) > max {
 		out = out[len(out)-max:]
 	}
+	// Lines written before the agent masked By at the source can hold a
+	// caller's raw secret — scrub the ones being returned with the same
+	// judgement the agent now applies on record, so a poisoned legacy line
+	// never renders. After the cap, not inside the decode loop: seeding the
+	// ring reads a ~10k-line file to keep 200, and redacting the other 98%
+	// first was pure waste. scrubLegacy is what actually removes the
+	// plaintext from disk; this keeps a file it hasn't rewritten yet (an
+	// upgraded CLI reading before the upgraded service ran) from leaking on
+	// display in the meantime.
+	for i := range out {
+		out[i].By = auditlog.RedactCommandLine(out[i].By)
+	}
 	return out
+}
+
+// scrubLegacy rewrites the history file ONCE with every By masked, so lines
+// written before the agent redacted By at the source stop existing in
+// plaintext on disk — not merely on display. Without this the raw secret
+// would sit in the 0600 file (and in every backup of it) until ~2MB of newer
+// events pushed it out, which on a quiet machine is years. Called at service
+// startup next to trim, the same single-writer window, so it never races an
+// append.
+//
+// Lines whose By is already clean are kept byte-for-byte (no re-marshal), so
+// fields written by a newer binary than this one survive. Undecodable lines
+// are dropped: every reader skips them anyway, and a torn legacy line is the
+// one shape that could hold a partial secret this scrub cannot judge.
+func (h *historyLog) scrubLegacy() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	data, err := os.ReadFile(h.path) // #nosec G304 -- jit's own bookkeeping file under its config root
+	if err != nil {
+		return
+	}
+	var buf bytes.Buffer
+	changed := false
+	for _, line := range bytes.Split(data, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var e agent.SessionEvent
+		if err := json.Unmarshal(line, &e); err != nil || e.Kind == "" {
+			changed = true
+			continue
+		}
+		if red := auditlog.RedactCommandLine(e.By); red != e.By {
+			e.By = red
+			changed = true
+			nl, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			buf.Write(nl)
+			buf.WriteByte('\n')
+			continue
+		}
+		buf.Write(line)
+		buf.WriteByte('\n')
+	}
+	if !changed {
+		return
+	}
+	tmp := h.path + ".tmp"
+	if err := os.WriteFile(tmp, buf.Bytes(), 0o600); err != nil { // #nosec G703 -- jit's own bookkeeping path under its config root, not external input
+		fmt.Fprintf(h.stderr, "jit service: scrubbing session history: %v\n", err)
+		return
+	}
+	if err := os.Rename(tmp, h.path); err != nil {
+		fmt.Fprintf(h.stderr, "jit service: scrubbing session history: %v\n", err)
+	}
 }
 
 // trim rewrites the file down to its newest half once it exceeds

--- a/internal/cli/agenthistory.go
+++ b/internal/cli/agenthistory.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 
 	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/auditlog"
 )
 
 // historyLog is the durable half of the agent's session history: one JSON
@@ -117,6 +118,12 @@ func (h *historyLog) load(max int) []agent.SessionEvent {
 		if err := json.Unmarshal(line, &e); err != nil || e.Kind == "" {
 			continue
 		}
+		// Lines written before the agent masked By at the source can hold a
+		// caller's raw secret, and this file keeps ~10k events — scrub them
+		// with the same judgement the agent now applies on record, so a
+		// poisoned legacy line stops leaking the moment it is read rather
+		// than the year it rotates out.
+		e.By = auditlog.RedactCommandLine(e.By)
 		out = append(out, e)
 	}
 	if len(out) > max {

--- a/internal/cli/agenthistory_test.go
+++ b/internal/cli/agenthistory_test.go
@@ -192,3 +192,45 @@ func TestHistoryLogLoadScrubsLegacyPlaintextBy(t *testing.T) {
 		t.Errorf("By = %q, want the path kept while scrubbing the value", got[1].By)
 	}
 }
+
+// scrubLegacy is the half of the legacy story load's display scrub cannot
+// deliver: the plaintext must leave the DISK, not just the screen — the file
+// is readable by any same-user process and lands in every backup. After the
+// rewrite the secret bytes are gone, the events still parse, and a line that
+// was already clean survives byte-for-byte (so fields written by a newer
+// binary than this one are not lost to a re-marshal).
+func TestHistoryLogScrubLegacyRemovesPlaintextFromDisk(t *testing.T) {
+	secret := "sk_FAKEfixture_notARealKeyXYZ0123"
+	dir := t.TempDir()
+	h := newHistoryLog(dir, nil)
+	cleanLine := `{"unix_time":50,"kind":"start","cause":"build test","future_field":"kept"}`
+	legacy := cleanLine + "\n" + fmt.Sprintf(
+		`{"unix_time":100,"kind":"unlock","op":"unwrap","by":"jit run -- curl -H token=%s","by_pid":42}
+{"unix_time":200,"kind":"unlock","op":"wrap","by":"jit vault set stripe/live-key hunter2","by_pid":43}
+`, secret)
+	if err := os.WriteFile(filepath.Join(dir, historyFileName), []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	h.scrubLegacy()
+
+	raw, err := os.ReadFile(filepath.Join(dir, historyFileName))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), secret) {
+		t.Fatalf("secret still on disk after scrubLegacy:\n%s", raw)
+	}
+	if strings.Contains(string(raw), "hunter2") {
+		t.Fatalf("weak vault-set value still on disk after scrubLegacy:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), "stripe/live-key") {
+		t.Errorf("scrubLegacy lost the vault path:\n%s", raw)
+	}
+	if !strings.Contains(string(raw), cleanLine) {
+		t.Errorf("already-clean line was rewritten (unknown fields would be lost):\n%s", raw)
+	}
+	if got := h.load(agent.MaxSessionEvents); len(got) != 3 {
+		t.Errorf("load returned %d events after scrub, want 3", len(got))
+	}
+}

--- a/internal/cli/agenthistory_test.go
+++ b/internal/cli/agenthistory_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/jitpass/jit/internal/agent"
@@ -157,5 +158,37 @@ func TestHistoryLogLoadMissingFile(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(filepath.Dir(h.path))); err != nil {
 		t.Fatalf("temp dir: %v", err)
+	}
+}
+
+// Lines written before the agent redacted By at the source (the pre-fix
+// format) can hold a caller's raw secret for years — the file keeps ~10k
+// events. Loading must scrub them with the same masking the agent now applies
+// on record, so a poisoned legacy line stops leaking through `jit agent
+// history`, the seeded ring, and `jit audit` alike.
+func TestHistoryLogLoadScrubsLegacyPlaintextBy(t *testing.T) {
+	secret := "sk_FAKEfixture_notARealKeyXYZ0123"
+	dir := t.TempDir()
+	h := newHistoryLog(dir, nil)
+	legacy := fmt.Sprintf(
+		`{"unix_time":100,"kind":"unlock","op":"unwrap","by":"jit run -- curl -H %s","by_pid":42}
+{"unix_time":200,"kind":"unlock","op":"wrap","by":"jit vault set stripe/live-key hunter2","by_pid":43}
+`, secret)
+	if err := os.WriteFile(filepath.Join(dir, historyFileName), []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := h.load(agent.MaxSessionEvents)
+	if len(got) != 2 {
+		t.Fatalf("load returned %d events, want 2", len(got))
+	}
+	if strings.Contains(got[0].By, secret) {
+		t.Errorf("By = %q still carries a legacy line's raw credential", got[0].By)
+	}
+	if strings.Contains(got[1].By, "hunter2") {
+		t.Errorf("By = %q still carries a legacy vault-set value", got[1].By)
+	}
+	if !strings.Contains(got[1].By, "stripe/live-key") {
+		t.Errorf("By = %q, want the path kept while scrubbing the value", got[1].By)
 	}
 }

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -677,6 +677,10 @@ func readNewEvents(path string, off int64) (int64, []agent.SessionEvent) {
 		if err := json.Unmarshal(line, &e); err != nil || e.Kind == "" {
 			continue
 		}
+		// Same legacy scrub historyLog.load applies: a line written before the
+		// agent masked By at the source can hold a caller's raw secret, and
+		// this reader feeds `jit audit` (text and JSON alike).
+		e.By = auditlog.RedactCommandLine(e.By)
 		out = append(out, e)
 	}
 	return newOff, out

--- a/internal/cli/auditrecord.go
+++ b/internal/cli/auditrecord.go
@@ -201,8 +201,19 @@ func sanitizeInvocationArgs(cmdPath string, rawArgs, positionals []string, parse
 	if parsedOK && len(positionals) == 1 {
 		return args
 	}
-	// Mask the last non-flag token: where a value is present it is the value,
-	// the only thing it can be, and Redact may have left a weak one alone.
+	// The SAME grammar the agent's By redaction applies (one implementation,
+	// auditlog.MaskVaultSetValues, so the two halves of the merged `jit
+	// audit` timeline can never disagree): every element past the path is
+	// masked, including a value that starts with "-" or a mis-pasted extra
+	// argument. The grammar wants argv[0]; os.Args[1:] lacks it, so lend it
+	// one.
+	if masked, changed := auditlog.MaskVaultSetValues(append([]string{"jit"}, args...)); changed {
+		return masked[1:]
+	}
+	// The grammar saw nothing past the path, but on a failed parse the one
+	// positional present may itself be a mistyped value sitting in the path
+	// slot — keep the old conservative fallback and mask the last non-flag
+	// token rather than trust it.
 	for i := len(args) - 1; i >= 0; i-- {
 		if strings.HasPrefix(args[i], "-") {
 			continue

--- a/internal/cli/auditrecord_test.go
+++ b/internal/cli/auditrecord_test.go
@@ -8,6 +8,10 @@ package cli
 import (
 	"strings"
 	"testing"
+
+	"github.com/spf13/pflag"
+
+	"github.com/jitpass/jit/internal/auditlog"
 )
 
 // TestSanitizeInvocationArgsVaultSet checks that `jit vault set` masks the
@@ -88,5 +92,62 @@ func TestSanitizeInvocationArgsVaultSet(t *testing.T) {
 				t.Errorf("the secret path was lost from the record: %v", got)
 			}
 		})
+	}
+}
+
+// auditlog.MaskVaultSetValues is the ONE vault-set grammar both producers
+// share — sanitizeInvocationArgs for jit's own os.Args, RedactCommandLine
+// for a recorded By. Its flag knowledge (VaultSetBooleanFlags) is what lets
+// it keep real flags legible while masking a dash-prefixed value, so it must
+// track the real command: every flag vault set defines (its own and the
+// root's persistent ones) must be listed, boolean, and nothing extra may be
+// listed. A non-boolean flag added to vault set would break the grammar's
+// core assumption — fail loudly here, not silently over-mask in the log.
+func TestVaultSetGrammarMatchesCommand(t *testing.T) {
+	seen := map[string]bool{}
+	collect := func(fs *pflag.FlagSet) {
+		fs.VisitAll(func(f *pflag.Flag) {
+			if f.Name == "help" {
+				return
+			}
+			if f.Value.Type() != "bool" {
+				t.Errorf("vault set flag --%s is %s, not bool: MaskVaultSetValues assumes every flag is boolean (a flag's detached value would be masked as a secret) — rethink the grammar before adding it", f.Name, f.Value.Type())
+			}
+			seen["--"+f.Name] = true
+			if f.Shorthand != "" {
+				seen["-"+f.Shorthand] = true
+			}
+		})
+	}
+	collect(vaultSetCmd.Flags())
+	collect(vaultSetCmd.Root().PersistentFlags())
+	for tok := range seen {
+		if !auditlog.VaultSetBooleanFlags[tok] {
+			t.Errorf("vault set defines %s but auditlog.VaultSetBooleanFlags does not list it — the grammar would mask it as a value (over-masking, but fix the list)", tok)
+		}
+	}
+	for tok := range auditlog.VaultSetBooleanFlags {
+		if !seen[tok] {
+			t.Errorf("auditlog.VaultSetBooleanFlags lists %s but vault set defines no such flag — a value spelled like it would be kept in the clear", tok)
+		}
+	}
+}
+
+// The parse-error fallback and the shared grammar must agree that EVERY
+// token past the path is masked — the first review caught them disagreeing
+// on `hunter2 extra`, where only the last token was masked and the actual
+// mis-pasted value survived into the durable log.
+func TestSanitizeInvocationArgsMasksEveryValuePastThePath(t *testing.T) {
+	got := sanitizeInvocationArgs("jit vault set",
+		[]string{"vault", "set", "stripe/key", "hunter2", "extra"},
+		nil, false)
+	want := []string{"vault", "set", "stripe/key", "<redacted>", "<redacted>"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v — a mis-pasted value must not outlive the mask", got, want)
+		}
 	}
 }

--- a/internal/cli/mountruns.go
+++ b/internal/cli/mountruns.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/auditlog"
 	"github.com/jitpass/jit/internal/lineage"
 )
 
@@ -187,7 +188,13 @@ func (m *mountManager) newRunAttachment(pid int32) (*runAttachment, bool) {
 	}
 	command := ""
 	if p, ok := lineage.Describe(pid); ok {
-		command = p.Command()
+		// Masked at capture, same doctrine as SessionEvent.By: this string
+		// is Fprintf'd into the durable service log ("serving real content
+		// to pid N's process tree (…)") and shipped out via
+		// MountGrantStatus.Command, and a run target launched as
+		// `tool --token=…` must not have its argv upgraded into a durable
+		// plaintext copy there either.
+		command = auditlog.RedactCommandLine(p.Command())
 	}
 	now := time.Now()
 	return &runAttachment{pid: pid, startMicro: startMicro, command: command, since: now, hardCap: now.Add(runHardCap)}, true


### PR DESCRIPTION
## Summary

Fixes the HIGH finding of **GHSA-5f6j-w3xx-jx8g**: the agent session history recorded the caller's full argv unredacted, so a secret carried on a command line (`jit vault set <path> <value>`, or a token in a `jit run -- tool --token=…` tail) was persisted in plaintext to `agent-history.jsonl` and rendered back by `jit audit` / `jit agent history` — while the application audit log promises it "records that a command RAN, not the secret it may have carried" and `cli/auditrecord.go` already masks these exact positions in jit's own `os.Args`.

Three layers, one shared judgement:

- **`auditlog.RedactCommandLine`** (new): the credential-shaped `RedactText` pass plus an unconditional mask of a `jit vault set` line's value positionals — the entropy test alone would let a weak value ("hunter2") through, the same reason `sanitizeInvocationArgs` masks that position for jit's own args. Positional counting is reliable here because every flag that command can see is a boolean; a future value-taking flag would over-mask, never leak. Placed in `auditlog` because both producers need the identical judgement and it is the leaf they already share (the same reasoning `RedactToken`'s export comment records).
- **`caller.command()`** routes argv through it, so every `By` — unlock, use aggregate, serve-error, grant end — is masked at the single point it is minted, and no future recording site can forget to.
- **`historyLog.load` / `readNewEvents`** scrub `By` on read, so a legacy line written before this fix stops leaking the moment it is displayed (seeded ring, `jit agent history`, `jit audit` text + JSON) rather than the year it rotates out of the 2MB file.

The path of a `jit vault set` stays legible (it is the one part an investigation needs and is not a secret), including the value-from-prompt/`--stdin` form where masking the last positional would have redacted the path itself.

## Test plan

- [x] New tests: `TestRedactCommandLine*` (auditlog — grammar, flags, `--` terminator, multi-word values, path-only forms, non-jit lines), `TestUnlockEventNeverRecordsACredentialFromTheCallersArgv`, `TestUnlockEventMasksAVaultSetValueTooWeakForTheEntropyTest`, `TestUnlockEventKeepsVaultSetPathWhenValueCameFromPrompt`, `TestRecordServeErrorRedactsTheRejectedPeersArgv` (agent), `TestHistoryLogLoadScrubsLegacyPlaintextBy` (cli)
- [x] `go build ./...` && `go test -race -timeout 2m ./...` — full suite green
- [x] `gofmt -l ./cmd ./internal` (clean), `go vet ./...`, `go mod verify && go mod tidy` (no drift)
- [x] `staticcheck ./...` @v0.7.0, `govulncheck ./...` @v1.6.0, `gosec -exclude-generated ./...` @v2.28.0 — all clean
- [ ] Maintainer: consider a one-shot trim/rewrite of existing `agent-history.jsonl` files if you want poisoned legacy lines gone from disk (this PR scrubs them on every read, but the bytes remain in the file until rotation)

Reported privately first per SECURITY.md; the advisory (GHSA-5f6j-w3xx-jx8g) has the full analysis, including two smaller findings this PR deliberately does not touch.
