### PR TITLE
docs: state the mkfifo mechanism, and close the grant and AI-wrap gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,41 @@ the time.
 
  
 
+**What it does not do:** it does not make an already-compromised account safe,
+and it does not protect a secret once it is in the memory of the process that
+asked for it. The boundaries are stated on one page, up front:
+**[the deliberate limits](./docs/security/brief.md#deliberate-limits-stated-plainly)**.
+
+## How it works, mechanically
+
+No kernel extension, no filesystem driver, no FUSE. Three mechanisms, picked
+by what the tool can do:
+
+1. **Environment variables into one process, then `execve`.** jit's own image
+   is replaced by your command, so the value lives in that one process and jit
+   is gone from memory.
+2. **The tool's native credential protocol**, where one exists: AWS
+   `credential_process`, docker and git credential helpers, kubectl exec
+   plugins, Terraform's credentials helper. The tool asks, jit answers, no
+   file involved.
+3. **A named-pipe mount**, for tools that can only read a file.
+
+That third one is the one people ask about. The "file" is a POSIX FIFO made
+with `mkfifo(2)` at mode `0600`. When a program calls `open(".env")`, the
+kernel blocks that open until a writer connects. The background service is the
+writer: it opens the path `O_WRONLY`, which releases the reader, writes the
+decrypted bytes from memory straight into the kernel pipe buffer, closes, then
+loops back to `open(2)` for the next reader. Nothing touches the disk, and
+what gets written is decided per read: decoy values for an ambient reader,
+real values only for a process inside a run you authorized.
+
+One caveat worth stating plainly, since it is the obvious follow-up question:
+**caller identity explains and audits, it never decides.** Process names are
+forgeable and a fast-closing FIFO reader can evade identification entirely.
+The human answering the prompt is the gate; the process name only tells you
+what to answer. Full detail in
+**[how it works](./docs/getting-started/how-it-works.md)** and
+**[live mounts](./docs/run/mounts.md)**.
 
 ## Install
 
@@ -37,14 +72,34 @@ the time.
 brew install jitpass/tap/jitpass
 ```
 
-Or without Homebrew:
+That is the recommended route, and for a security tool the reason matters.
+Releases are signed with an Apple Developer ID and notarized by Apple.
+Homebrew quarantines what it downloads, so Gatekeeper checks the binary
+against its notarization ticket before it is ever allowed to run. To verify
+that yourself rather than take our word for it, run `jit doctor`: its `jit`
+line reports `signed CZC6BH93GJ`, the same check `jit upgrade` runs before it
+will install anything.
+
+<details>
+<summary>Without Homebrew (the weaker path, and why)</summary>
 
 ```sh
 curl -sL https://dl.jitpass.com/jitpass/jit/releases/latest/download/jitpass_darwin_arm64.tar.gz | tar -xz jit
+shasum -a 256 jit   # compare against checksums.txt on the release page
+codesign -dv --verify --verbose=2 ./jit   # expect: Developer ID, TeamIdentifier=CZC6BH93GJ
 sudo mv jit /usr/local/bin/
 ```
 
-Apple Silicon only — on an Intel Mac, build from source with
+This is here for people without Homebrew, and it is genuinely the weaker
+path: `curl` sets no quarantine bit, so Gatekeeper never consults the
+notarization ticket, and the same is true of `go install`. The binary is
+still signed and still notarized, so the two lines above let you check both
+before you run it, but you have to actually run them. If you have Homebrew,
+use Homebrew.
+
+</details>
+
+Apple Silicon only. On an Intel Mac, build from source with
 `go install github.com/jitpass/jit/cmd/jit@latest`.
 
 Pick one route. If you installed from the tarball before and are switching to
@@ -52,15 +107,7 @@ Homebrew, remove the old copy after the `brew install` (`sudo rm
 /usr/local/bin/jit`); otherwise two jits sit on PATH upgrading separately, and
 `jit doctor` will flag it.
 
-Releases are signed with a Developer ID and notarized by Apple, so both paths
-run without a Gatekeeper prompt: Homebrew quarantines its downloads and
-Gatekeeper clears them against the notarization ticket, while `curl` (and `go
-install`) set no quarantine flag at all. To check what you got rather than
-take our word for it, run `jit doctor` — its `jit` line reports
-`signed CZC6BH93GJ`, using the same check `jit upgrade` runs before it will
-install anything.
-
-**Upgrading:** `brew upgrade jitpass`, or `jit upgrade` — a verified
+**Upgrading:** `brew upgrade jitpass`, or `jit upgrade`: a verified
 self-update (Developer-ID signature and checksum both checked before the
 swap, restarts the service). Either way your vault is untouched.
 
@@ -210,7 +257,7 @@ Kicking off something that needs several credentials at once? `jit run --trust
 -- terraform apply` approves that whole run's tools in one gesture. Full details:
 [per-process consent](./docs/service/consent.md).
 
-## Leaving the keyboard? Approve the work before you go
+## Leaving the keyboard? `jit grant`
 
 Both gates assume a human is there to answer. An AI agent working overnight, a
 long build, a scheduled job: the screen locks, the session drops, and the run
@@ -237,6 +284,40 @@ one exact process instead, gone when it exits? `--pid`. Every serve lands in
 the audit trail as its own event, so the morning after you can read exactly
 what your agent touched while you slept. Full details:
 [process grants](./docs/service/grants.md).
+
+## AI agents and MCP servers
+
+The agent in your editor runs as you, with your permissions, and reads files
+for you all day. That is the whole point of it, and it is also why a plaintext
+`.env` in your repo is now a very different risk than it was two years ago.
+jit treats agents as first-class, on four fronts:
+
+```sh
+jit migrate ~/.claude.json           # MCP server configs: keys move to the vault,
+                                     # each server now launches through `jit run`
+jit wrap claude                      # the AI CLIs themselves: claude, codex, gemini,
+                                     # cursor-agent, copilot, cline, opencode, kiro-cli
+jit grant --process claude --profile myapp --for 8h
+                                     # let it work overnight without a prompt nobody answers
+jit audit --parent claude            # read back exactly what it touched while you slept
+```
+
+- **The prompt names the agent.** With per-process consent on (the default),
+  the first time a tool reaches for a real credential you get a Touch ID that
+  says which program is asking. That is what the two screenshots at the top of
+  this page show: the same secret requested by VS Code and by `claude`, each
+  named. An agent quietly reading `~/.aws/credentials` is a prompt, not a
+  silent success.
+- **MCP servers launch through `jit run`.** A migrated MCP config holds vault
+  paths, not keys, so the config file itself is safe to have on disk and safe
+  to hand to the agent that reads it.
+- **A decoy is what an unauthorized read gets.** An agent that greps your repo
+  for `.env` and reads it cold gets placeholder values, and the read is logged.
+- **`jit audit --parent claude`** shows every secret an agent used, every
+  prompt it triggered, and every one you declined.
+
+More in [MCP / AI tools](./docs/migrate/mcp.md) and
+[per-process consent](./docs/service/consent.md).
 
 ## The audit trail: what happened, and who did it
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,13 +20,19 @@ collects the threat-model answers on one page.
 - [Does it work inside scripts, Makefiles, and git hooks?](#does-it-work-inside-scripts-makefiles-and-git-hooks)
 - [Does it work in CI?](#does-it-work-in-ci)
 - [What if a tool breaks after I migrate?](#what-if-a-tool-breaks-after-i-migrate)
+- [Why not just use age, SOPS, dotenvx, 1Password, or systemd-creds?](#why-not-just-use-age-sops-dotenvx-1password-or-systemd-creds)
 - [Which platforms does it run on?](#which-platforms-does-it-run-on)
+- [What license is it under, and is it free?](#what-license-is-it-under-and-is-it-free)
 - [What happens if the service is locked or not running?](#what-happens-if-the-service-is-locked-or-not-running)
 - [Can my team share a vault?](#can-my-team-share-a-vault)
 
 **Security**
 
 - [What is the threat model in one line?](#what-is-the-threat-model-in-one-line)
+- [If something is running code as me, haven't I already lost?](#if-something-is-running-code-as-me-havent-i-already-lost)
+- [I have FileVault. Isn't my disk already encrypted?](#i-have-filevault-isnt-my-disk-already-encrypted)
+- [How can I trust your crypto implementation?](#how-can-i-trust-your-crypto-implementation)
+- [What about the secret once it is in memory?](#what-about-the-secret-once-it-is-in-memory)
 - [How are secrets encrypted at rest?](#how-are-secrets-encrypted-at-rest)
 - [Where does the master key live, and is it hardware-bound?](#where-does-the-master-key-live-and-is-it-hardware-bound)
 - [Can an attacker who already runs code as me read my secrets?](#so-can-an-attacker-who-already-runs-code-as-me-read-my-secrets)
@@ -34,8 +40,9 @@ collects the threat-model answers on one page.
 - [Can a malicious repo I clone steal my cloud credentials?](#can-a-malicious-repo-i-clone-steal-my-cloud-credentials)
 - [The mounts identify the reading process, isn't that spoofable?](#the-mounts-identify-the-reading-process-isnt-that-spoofable)
 - [Does jit phone home or sync anywhere?](#does-jit-phone-home-or-sync-anywhere)
-- [Is `jit scan` safe to run on a sensitive machine?](#is-jit-audit-safe-to-run-on-a-sensitive-machine)
+- [Is `jit scan` safe to run on a sensitive machine?](#is-jit-scan-safe-to-run-on-a-sensitive-machine)
 - [What about secrets already committed to git?](#what-about-secrets-already-committed-to-git)
+- [What about credentials sitting in my shell history?](#what-about-credentials-sitting-in-my-shell-history)
 - [Once a secret reaches a process, what stops it leaking it?](#once-a-secret-reaches-a-process-what-stops-that-process-from-leaking-it)
 - [How is it distributed and signed?](#how-is-it-distributed-and-signed)
 - [Where can I report a security issue?](#where-can-i-report-a-security-issue)
@@ -101,10 +108,57 @@ handles the common cases automatically, and `--live` (or `read_as_file: true`)
 covers the rest. Failures are loud and self-explaining, not silent
 placeholder errors.
 
+### Why not just use age, SOPS, dotenvx, 1Password, or systemd-creds?
+
+Use them. Most of them are good, and several solve a problem jit does not.
+The honest comparison is about which problem you are solving:
+
+- **`age` / SOPS / dotenvx** encrypt a file *you decided to encrypt*, and you
+  decrypt it when you need it (`eval $(age -d -i secrets.env.age)`). Fewer
+  moving parts than jit, and the trusted-tool argument is real. Two
+  differences: they do not tell you about the plaintext already sitting in
+  `~/.aws/credentials`, `~/.docker/config.json`, and a `.env` you forgot about
+  three projects ago, and once you decrypt into your environment or a file,
+  every process running as you can read it for as long as it is there. jit's
+  bet is on the secrets you did not remember to protect.
+- **1Password (and its CLI / Environments)** is a better home for a secret
+  than jit and the right way for a *team* to share one. Its model is to keep
+  the secret in the vendor cloud and have you rewrite files to reference it
+  (`op://…`). jit works the other way around: it stays local, finds the
+  plaintext already on your disk, and rewrites the files for you through each
+  tool's native credential mechanism. Sensible setup: 1Password for shared
+  team secrets, jit underneath for the copies that land on your machine. More
+  detail in [Why jit](./why-jit.md#if-you-already-use-1password-or-another-password-manager).
+- **`systemd-creds`** does the equivalent job on Linux, TPM-backed, and if you
+  are on Linux you should use it. It is not available on macOS, which is the
+  platform jit targets.
+- **Credential-proxying tools** (fnox, nono, and similar) sit in front of a
+  provider and hand out short-lived credentials. That is a strong model and a
+  different one: it changes where credentials come from, while jit's starting
+  assumption is the plaintext already on the disk of a machine you did not set
+  up from scratch. They are not mutually exclusive.
+
+The thing jit does that none of the above do is `jit scan`: tell you what is
+exposed on this machine right now, read-only, before you have committed to any
+of it.
+
 ### Which platforms does it run on?
 
-macOS only, currently, because the local-auth and Keychain integration is
-macOS-native. There is no Linux or Windows build.
+macOS only today (Apple Silicon), because the Touch ID and Keychain
+integration is macOS-native. There is no Linux or Windows build yet. The
+platform-specific code is deliberately confined to a small number of packages
+rather than spread through the tree, so a port is a bounded piece of work
+rather than a rewrite, but it is not done and there is no date. More platforms
+are [on the roadmap](./why-jit.md#on-the-roadmap). On Linux today,
+`systemd-creds` covers part of the same ground.
+
+### What license is it under, and is it free?
+
+[PolyForm Perimeter 1.0.0](./about/license.md). Source-available, not OSI
+open source: you can read it, build it, fork it, and run it free of charge for
+personal use and for internal use at your company, with no seat count and no
+subscription. What the license forbids is repackaging it into a competing
+product. It never converts to another license.
 
 ### What happens if the service is locked or not running?
 
@@ -128,6 +182,65 @@ Every deliberate limit is documented in the
 [security architecture](./security/architecture.md) and re-stated in each
 published [self-review](./security/self-reviews/index.md).
 
+### If something is running code as me, haven't I already lost?
+
+Not entirely, and the "already lost" framing proves too much: by that logic
+per-app permissions on phones, short-lived cloud credentials, and not running
+as root would all be theatre. They aren't, because they raise cost and cut
+blast radius.
+
+Be concrete about what is actually attacking developers. It is overwhelmingly
+not a targeted operator with a debugger attached to your processes. It is an
+automated infostealer, usually arriving through a dependency's install script
+or a compromised package, that globs for `.env`, `~/.aws/credentials`,
+`.npmrc`, and kubeconfig, reads whatever it finds, and posts it. That entire
+class fails against a decoy, because the file it reads returns fake values and
+the read itself is recorded.
+
+What jit does not do is stop a determined attacker who already has local
+execution and is willing to spend time. Nothing at this layer does. jit is one
+layer, it says so, and it is not a reason to skip the others (containers, VMs,
+short-lived credentials, least privilege).
+
+### I have FileVault. Isn't my disk already encrypted?
+
+FileVault protects a machine that is powered off or stolen. It is decrypted
+and mounted the entire time you are logged in and working, which is precisely
+when every process running as your user can read every plaintext credential on
+it. The AI agent in your editor does not need to defeat FileVault to `cat`
+your `.env`.
+
+They solve different problems and compose fine. Keep FileVault on.
+
+### How can I trust your crypto implementation?
+
+By not having to trust much of it. The primitives are Go's standard library:
+AES-256-GCM via `crypto/aes` and `crypto/cipher`, with `crypto/rand` for keys
+and nonces. The single third-party primitive is Argon2id from
+`golang.org/x/crypto`, used only to derive a key from a passphrase for
+[encrypted exports](./vault/backup-restore.md), because a passphrase needs a
+memory-hard KDF and the standard library has none. Nothing is hand-rolled.
+
+What is jit-specific is the composition: envelope encryption, plus binding
+each ciphertext to the secret's vault path and metadata as AEAD additional
+data so a swapped or renamed file fails to decrypt rather than quietly
+resolving as the wrong secret. That is the part to read critically, and it is
+under 90 lines in `internal/vault/crypto.go`. The non-pure-Go surface is four
+small packages, named in the [security brief](./security/brief.md) so you can
+start there instead of hunting for them.
+
+### What about the secret once it is in memory?
+
+That is out of scope, deliberately. Once a value reaches the address space of
+the process that asked for it, jit has no further control: there is no attempt
+to lock its pages, defeat a debugger, or hide it from another process running
+as you. jit's own handling is bounded (the master key is page-locked and wiped
+on lock, and `jit run` `execve`s so jit's image is gone), but the tool you
+handed the credential to is on its own.
+
+If in-memory extraction is in your threat model, you want VM-level or
+container isolation, which is a different and complementary control.
+
 ### How are secrets encrypted at rest?
 
 Envelope encryption: each secret is its own authenticated-encrypted file with
@@ -143,7 +256,7 @@ ID or device-passcode challenge. Be precise about the guarantee: today that is
 an **application-level** local-auth gate (LocalAuthentication), not a
 hardware-enforced Keychain ACL or a Secure Enclave binding. A real OS-enforced
 ACL needs an entitlement macOS only grants through a provisioning profile,
-and a provisioning profile can only be embedded in an `.app` bundle — never a
+and a provisioning profile can only be embedded in an `.app` bundle, never a
 bare CLI binary like jit (releases are Developer-ID signed, and that alone
 doesn't unlock it; see `spike/secure-enclave/FINDINGS.md`). So the honest
 statement is "OS local-authentication-bound," not "cryptographically enforced

--- a/docs/getting-started/how-it-works.md
+++ b/docs/getting-started/how-it-works.md
@@ -40,6 +40,34 @@ myapp/STRIPE_API_KEY`). `jit migrate` and `jit wrap` create them;
 contains a secret value, only names and paths - which is exactly why it's
 safe to commit. More in **[Profiles](../run/profiles.md)**.
 
+## How a secret actually reaches a program
+
+No kernel extension, no filesystem driver, no FUSE. Three mechanisms, picked
+by what the tool is able to do:
+
+1. **Environment injection, then `execve`.** `jit run` puts the values in the
+   environment and replaces its own process image with your command. jit is
+   gone from memory the instant your command starts, and the value exists
+   only in that one process.
+2. **The tool's own credential protocol**, where one exists: AWS
+   `credential_process`, docker and git credential helpers, kubectl exec
+   plugins, Terraform's credentials helper. The tool asks on stdout/stdin and
+   jit answers. No file is involved at any point.
+3. **A named-pipe mount**, for tools that only know how to read a file.
+
+The third one is the one people ask about, so here it is concretely. The
+"file" is a POSIX FIFO created with `mkfifo(2)` at mode `0600`. When a program
+calls `open(".env")`, the kernel **blocks that open** until a writer connects.
+The background service is the writer: it opens the same path `O_WRONLY`, which
+releases the reader, writes the decrypted bytes from memory straight into the
+kernel pipe buffer, closes, and loops back to `open(2)` to wait for the next
+reader. Nothing is written to disk in that sequence.
+
+What gets written is decided per read, in the service: decoy values for an
+ambient reader (a `cat`, a backup, a stray `npm install`), real values only
+for a process inside an authorized run's tree. Details, including what a FIFO
+cannot do that a regular file can, in **[Live-mounted files](../run/mounts.md)**.
+
 ## How each secret keeps working
 
 Each credential flows back to its consumer through that tool's own native

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -30,9 +30,9 @@ After setup, daily life with jit is mostly nothing: your app starts normally,
 
 ## 1. See what's exposed: `jit scan`
 
-Start here. `audit` is strictly read-only under every flag: it never touches,
-encrypts, or rewrites anything, and never prints a real secret value in full,
-only a masked preview.
+Start here. `jit scan` is strictly read-only under every flag: it never
+touches, encrypts, or rewrites anything, and never prints a real secret value
+in full, only a masked preview.
 
 ```
 $ jit scan
@@ -132,14 +132,14 @@ Touch ID; both are safe to run as often as you like.
 ## 5. Run your project: `jit run`
 
 After migration a `.env` serves **decoy** values to anything that reads it
-cold — a `cat`, a backup, or a bare `npm run dev`. Real values reach a tool
+cold: a `cat`, a backup, or a bare `npm run dev`. Real values reach a tool
 **only** when you launch it through `jit run`:
 
 ```
 $ jit run -- npm run dev      # injects your .env secrets into the process
 ```
 
-There are four modes, split across two independent switches — `--live` for
+There are four modes, split across two independent switches. `--live` is for
 **this project's** files, `--with` for a **machine-global** credential:
 
 ```
@@ -152,6 +152,30 @@ $ jit run --live --with gcp -- <cmd>     # needs both at once
 Not sure whether you need `--live`? Just run the default first; if the tool
 acts like its config is empty, re-run with `--live`. Full guide, including a
 decision table, in **[Run a command with secrets](../run/index.md)**.
+
+## 6. Work that runs while you're away: `jit grant`
+
+The session above ends when you do: idle timeout, screen lock, sleep. That is
+the right default until something has to keep running without you - an agent
+working overnight, a long build, a scheduled job. Those stop at a prompt
+nobody is there to answer.
+
+`jit grant` moves the decision earlier instead of removing it. One Touch ID,
+now, approves a named program to use specific profiles until a deadline you
+set:
+
+```sh
+$ jit grant --process claude --profile jamf --for 8h
+```
+
+The prompt names exactly what you're signing ("let claude under iTerm2 use
+2 secrets (jamf) unattended for 8h"), and the grant is scoped to the terminal
+you typed it in, including sessions you start later inside that window.
+Everything else keeps prompting as usual. `jit grant list` shows what's open,
+`jit grant revoke` ends one early, and every grant and every use of it lands
+in `jit audit`.
+
+More in **[Process grants](../service/grants.md)**.
 
 ## Optional: wrap your CLI tools
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -67,7 +67,10 @@ then **[Install](./getting-started/install.md)** →
   [hf](./wrap/hf.md) · [supabase](./wrap/supabase.md) ·
   [wrangler](./wrap/wrangler.md) · [openai](./wrap/openai.md) ·
   [claude](./wrap/claude-code.md) · [gemini](./wrap/gemini.md) ·
-  [codex](./wrap/codex.md) · [sentry-cli](./wrap/sentry-cli.md) ·
+  [codex](./wrap/codex.md) · [cursor-agent](./wrap/cursor-agent.md) ·
+  [copilot](./wrap/copilot.md) · [cline](./wrap/cline.md) ·
+  [opencode](./wrap/opencode.md) · [kiro-cli](./wrap/kiro-cli.md) ·
+  [sentry-cli](./wrap/sentry-cli.md) ·
   [snyk](./wrap/snyk.md) · [circleci](./wrap/circleci.md) ·
   [vault](./wrap/vault.md) · [pulumi](./wrap/pulumi.md) ·
   [descope](./wrap/descope.md) · [okta-cli-client](./wrap/okta-cli-client.md) ·

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -22,7 +22,7 @@ their token in the variable the tool documents, for example:
 The **[wrap catalog](../wrap/index.md#shim-based-plugins)** lists every wrapped
 tool and its injected variable - it tracks the code, so it's always current.
 (`aws`, `terraform`, `docker`, and `git` don't inject variables - they use
-[native credential hooks](../wrap/index.md#native-hook-plugins-no-shim--stronger).)
+[native credential hooks](../wrap/index.md#native-hook-plugins-no-shim---stronger).)
 
 An injected variable exists only inside that one process, for its
 lifetime - it is never exported to your shell or written anywhere.

--- a/docs/run/index.md
+++ b/docs/run/index.md
@@ -131,6 +131,26 @@ just clearer.) Whatever the mode, real values flow **only** to the process
 tree of the `jit run` you launch — never on an unlock, a `cd`, or a bare
 command with no `jit run` in front of it.
 
+## Runs that outlive your presence
+
+Everything above assumes you are at the keyboard: a read that needs approval
+gets it, because you are there. A run that continues after you leave hits the
+opposite case, since the session ends on idle timeout, screen lock, and sleep,
+and the next credential read stops on a prompt nobody will answer.
+
+`jit grant` decides that in advance instead of removing the decision. One
+Touch ID, while you are there, approves a named program to use specific
+profiles until a deadline:
+
+```
+$ jit grant --process claude --profile jamf --for 8h
+```
+
+The grant is scoped to the terminal you typed it in, covers sessions started
+later inside that window, and is listed by `jit grant list`, ended early by
+`jit grant revoke`, and recorded in `jit audit` both when it is created and on
+every use. See **[Process grants](../service/grants.md)**.
+
 ## Where else `jit run` shows up
 
 Migrated [MCP configs](../migrate/mcp.md) launch their servers through

--- a/docs/run/mounts.md
+++ b/docs/run/mounts.md
@@ -14,6 +14,34 @@ a `cat` never makes a mount serve real values. A file that served real
 secrets to whatever opened it would defeat the point of moving them off
 disk.
 
+## The mechanism, exactly
+
+No kernel extension, no filesystem driver, no FUSE, nothing privileged. The
+mount is a plain POSIX FIFO created with `mkfifo(2)` at mode `0600`, and the
+delivery is the kernel's own blocking-open semantics:
+
+1. jit replaces the file with a FIFO (`unix.Mkfifo(path, 0600)`).
+2. A reader calls `open(".env")`. On a FIFO opened for reading, that call
+   **blocks in the kernel** until a writer connects. Your tool is now parked
+   in `open(2)`, having read nothing.
+3. The [service](../service/index.md) is that writer. It opens the same path
+   `O_WRONLY`, which unblocks the reader, decrypts in memory, writes those
+   bytes straight into the kernel pipe buffer, and closes.
+4. It then loops immediately back to `open(2)` and blocks again, waiting for
+   the next reader. That re-open loop is what makes the pipe survive being
+   read more than once, which is the part a naive FIFO gets wrong.
+
+The decision of *what* to write happens in step 3, in the service, per read:
+decoy bytes for an ambient reader, real bytes only for a process sitting in
+an authorized run's tree. Nothing is written to disk at any point in this
+sequence, so there is no window in which the plaintext exists as a file, and
+no file to recover afterwards. The FIFO has no contents of its own: `cat`ing
+it when the service is stopped simply blocks, and when the service is locked
+it yields decoys.
+
+The re-open behavior was proven out before it was built on, in
+`spike/named-pipe/FINDINGS.md`.
+
 ## Real values flow only through `jit run`
 
 - `jit run <command>` makes this run's mounted files compatible with the

--- a/docs/security/architecture.md
+++ b/docs/security/architecture.md
@@ -44,8 +44,8 @@ Secrets materialize at the moment of use and nowhere else:
   file) or, with `--live`, kept as a pipe that serves real values only to
   that run's own process tree. Neither writes a secret to disk, and both
   end the instant the command exits.
-- A tool that *mints* credentials rather than carrying one — an SSO CLI like
-  [clisso](../wrap/clisso.md) — is intercepted at the mint: its shim runs it
+- A tool that *mints* credentials rather than carrying one (an SSO CLI like
+  [clisso](../wrap/clisso.md)) is intercepted at the mint: its shim runs it
   with the tool's own machine-readable output mode, captures the credentials
   from that output, and stores them in the vault instead of letting the tool
   write them to a plaintext file. The capture happens in the user's terminal,
@@ -150,8 +150,8 @@ dialog *per request* while saying yes cost one dialog *once*, so anything
 asking in a loop could simply outlast you. Consent prompts now back off per
 request after a refusal (about two seconds, then eight, then thirty), and the
 prompt says how many times that caller has already been refused. Nothing is
-locked out, the next genuine attempt still asks, and a *fresh* `jit unlock` —
-one that actually challenges you — clears the pause outright, while an unlock
+locked out, the next genuine attempt still asks, and a *fresh* `jit unlock`,
+one that actually challenges you, clears the pause outright, while an unlock
 against an already-open session prompts nobody and so clears nothing. A caller
 also cannot conjure a prompt out of
 nothing: the credential class it names is verified against the ciphertext it

--- a/docs/security/brief.md
+++ b/docs/security/brief.md
@@ -24,6 +24,37 @@ jit narrows *where* and *when* a secret exists in plaintext, down to the
 moment a tool uses it. It does **not** make an already-compromised user
 account safe.
 
+## What you have to trust, and how to check it
+
+Reviewing this does not require taking anything on faith, so here is where to
+point a reviewer:
+
+- **No custom cryptography.** The primitives are Go's standard library:
+  AES-256-GCM (`crypto/aes` + `crypto/cipher`) for both the per-secret data
+  keys and the master key wrap, and `crypto/rand` for all key and nonce
+  generation. The one exception is deliberate and narrow: a
+  passphrase-encrypted [export](../vault/backup-restore.md) derives its key
+  with Argon2id from `golang.org/x/crypto`, because a passphrase needs a
+  memory-hard KDF and the standard library has none. There are no hand-rolled
+  primitives and no novel constructions. What is jit-specific is the
+  *composition*: envelope encryption, and binding each ciphertext to the
+  secret's vault path and metadata as AEAD additional data so a swapped or
+  renamed file fails to decrypt instead of resolving as the wrong secret.
+  That composition is the part worth reading critically, and it is under 90
+  lines in `internal/vault/crypto.go`.
+- **The non-pure-Go surface is four small packages**, and they are named so a
+  reviewer can start there rather than hunting: `internal/keychainwrap`
+  (Keychain and the Touch ID challenge), `internal/lineage` (libproc, audit
+  logging only, never a gate), `internal/pasteboard`, and
+  `internal/screenlock`. Everything else is portable Go.
+- **The design notes are in the tree.** Each `internal/` package has a
+  `doc.go` stating what it does and what it deliberately does not, and the
+  hard problems (the named-pipe re-open loop, peer credentials, the Secure
+  Enclave entitlement wall) carry their evidence in `spike/*/FINDINGS.md`.
+- **Every published [self-review](./self-reviews/index.md)** carries an explicit
+  "known, accepted limitations" list as of that review, rather than a summary
+  that only reports what passed.
+
 ## Architecture at a glance
 
 - **At rest.** Envelope encryption: each secret is its own AEAD-encrypted file
@@ -69,7 +100,7 @@ session, not the scope. A cloned repo's config, or a script that slips a
   application-level LocalAuthentication challenge, not an OS-enforced Keychain
   ACL or a Secure Enclave binding, because a real ACL needs a
   provisioning-profile-authorized entitlement that macOS will only honor
-  inside an `.app` bundle — a bare CLI binary has nowhere to carry it, signed
+  inside an `.app` bundle, and a bare CLI binary has nowhere to carry it, signed
   or not (see `spike/secure-enclave/FINDINGS.md`). A determined attacker with
   local code execution could read the plain Keychain item directly while the
   vault is locked, and could ask the service while it is unlocked. This is the
@@ -77,6 +108,20 @@ session, not the scope. A cloned repo's config, or a script that slips a
 - **A process you give a secret to can do anything with it.** Delivery is the
   end of jit's control; that is why the decision point is the caller-naming
   prompt, before delivery.
+- **Memory is not protected, and jit does not claim to protect it.** Once a
+  value is in the address space of the process that asked for it, jit is out
+  of the loop. There is no attempt to lock pages, defeat a debugger, or hide
+  from a process running as you with the patience to attach to another one.
+  The threat this is built against is the infostealer that globs for `.env`
+  and `~/.aws/credentials`, reads them, and exfiltrates, which is the common
+  case and the automatable one. If your adversary is instead a targeted
+  attacker with local code execution and time, you want VM-level isolation,
+  not this.
+- **Full-disk encryption solves a different problem.** FileVault protects a
+  powered-off or stolen machine. It does nothing once you are logged in and
+  the volume is mounted, which is exactly when every process running as you
+  can read every plaintext credential on it. The two are complementary; keep
+  FileVault on.
 - **Credentials a tool mints for itself are not jit's.** After the AWS CLI uses
   a migrated key to assume a role it caches the resulting STS session in
   plaintext under `~/.aws/cli/cache`, and `aws sso login` writes tokens to
@@ -104,12 +149,20 @@ session, not the scope. A cloned repo's config, or a script that slips a
 
 - Source is public on GitHub under the **PolyForm Perimeter License 1.0.0**
   (source-available, not open source); it can be built from source with Go.
-- Release builds are **Developer-ID signed** (`Meni Tasa, CZC6BH93GJ`); the
-  `curl` install is quarantine-free, so Gatekeeper clears it without a prompt.
-  Dev builds from source are ad-hoc signed, so a dev build's first run shows a
-  one-time Keychain permission prompt.
-- No network calls, no telemetry, no auto-update. The vault leaves the machine
-  only through an explicit passphrase-encrypted export the user runs.
+- Release builds are **Developer-ID signed and notarized by Apple**
+  (`Meni Tasa, CZC6BH93GJ`). Homebrew quarantines its download, so Gatekeeper
+  verifies it against the notarization ticket before first run; a `curl`
+  install sets no quarantine bit, so that check never happens and the tarball
+  is the weaker path. `jit doctor` reports the Team ID it verified. Dev builds
+  from source are ad-hoc signed, so a dev build's first run shows a one-time
+  Keychain permission prompt.
+- **No telemetry and no background network activity.** jit makes exactly one
+  kind of outbound request, and only when you type it: `jit upgrade` fetches
+  the release archive and `checksums.txt`, verifies both the Developer-ID
+  signature and the checksum, and refuses to install if either fails (there is
+  no override flag). Nothing auto-updates, nothing phones home, and no secret,
+  path, or scan result is ever transmitted. The vault leaves the machine only
+  through a passphrase-encrypted export you run yourself.
 
 ## Verifying and reporting
 

--- a/docs/security/self-reviews/2026-07.md
+++ b/docs/security/self-reviews/2026-07.md
@@ -69,7 +69,7 @@ This is the part every user should read. jit's protection depends entirely on
   OS-enforced and biometric-gated. It's built but not yet wired up. (*Correction,
   2026-07-30:* this originally said it was "blocked on an Apple Developer ID
   signing identity." The spike that followed showed the identity is necessary but
-  not sufficient — SE persistence needs a provisioning-profile entitlement that
+  not sufficient: SE persistence needs a provisioning-profile entitlement that
   only an `.app` bundle can carry, so the real dependency is shipping the agent
   as a bundled daemon; see `spike/secure-enclave/FINDINGS.md`.)
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -18,6 +18,7 @@ short prefix. Here's what to type for your tool, and why.
 | `docker compose`, `podman`, tools that read the `.env` file itself | **`jit run --live -- <cmd>`** | jit serves the real file to that run (auto-picked for these). |
 | `gcp`, `sops`, `npm`, `netrc`, `pypi` | **run it** and approve the prompt, or **`jit run --with <name> -- <cmd>`** | A machine-global credential file: consent prompts on first read, or `--with` grants it explicitly. |
 | A specific named set of secrets (an MCP server, a one-off) | **`jit run --profile <name> -- <cmd>`** | Loads that profile instead of the ambient project `.env`. |
+| An agent or job that must keep working while you're away | **`jit grant --process <name> --profile <p> --for <d>`** once | One Touch ID now approves that program's reads until the deadline, so nothing stops on a prompt nobody is there to answer. [Process grants](./service/grants.md) |
 
 ## Just run them (nothing to type)
 
@@ -50,9 +51,13 @@ moves it to the vault once; after that you keep typing the command by name and
 the token is injected per call.
 
 `gh`, `glab`, `stripe`, `ngrok`, `doctl`, `hcloud`, `flyctl`, `vercel`,
-`railway`, `databricks`, `hf`, `supabase`, `wrangler`, `openai`, `claude`,
-`gemini`, `codex`, `sentry-cli`, `snyk`, `circleci`, `vault`, `pulumi`,
-`descope`, `okta-cli-client`, `snow`, `jira`.
+`railway`, `databricks`, `hf`, `supabase`, `wrangler`, `sentry-cli`, `snyk`,
+`circleci`, `vault`, `pulumi`, `descope`, `okta-cli-client`, `snow`, `jira`.
+
+The AI coding CLIs are wrappable too, and worth doing precisely because they
+run as you and read your files: `claude`, `codex`, `gemini`, `cursor-agent`,
+`copilot`, `cline`, `opencode`, `kiro-cli`, and `openai`. Their own API keys
+stop living in a config file on disk and get injected per invocation.
 
 One tool works the other way around: `clisso` doesn't carry a token, it
 *mints* AWS credentials at every SSO login. `jit wrap clisso` captures

--- a/docs/vault/index.md
+++ b/docs/vault/index.md
@@ -27,10 +27,15 @@ version timestamps, never a value.
 
 `jit vault set myapp/NEW_KEY` prompts for a value and stores it (add `-f`
 to overwrite an existing path, `--stdin` to pipe the value in);
-`jit vault rm <path>` deletes one secret (it confirms first). If a profile
-or a live mount still points at that path, `rm` names it before the
-confirmation: deleting only the secret leaves the mount serving a file
-nothing can fill, so for a migrated file the right cleanup is
+`jit vault rm <path>...` deletes secrets (it confirms first). Several paths
+delete under a **single** Touch ID gesture, so cleaning up a decommissioned
+project is one approval rather than one per secret, and a bare group name (the
+part before the slash in `jit vault list`) removes the whole group, with the
+expansion announced and every path listed before you confirm. A missing path
+is reported without stopping the rest. If a profile or a live mount still
+points at a path, `rm` names it before the confirmation: deleting only the
+secret leaves the mount serving a file nothing can fill, so for a migrated file
+the right cleanup is
 [`jit migrate remove <file>`](../migrate/undo-and-remove.md), which takes
 the file, its profile and its secrets down together.
 `jit vault get <path>` decrypts and prints one (`--copy` sends it to the

--- a/docs/vault/maintenance.md
+++ b/docs/vault/maintenance.md
@@ -8,6 +8,15 @@ description: Prune stale file backups, empty the vault, or destroy it entirely.
 These commands run in increasing order of severity. The destructive ones
 confirm first (`-y` skips the prompt) and require a fresh Touch ID/passcode.
 
+**You do not have to remember to run these.** `jit doctor` sweeps for the
+same hygiene problems and reports what it finds as advisory warnings, naming
+the command that fixes each one: unreferenced secrets (a count, or each one
+with `--orphans`) and groups whose key names appear more than once. Doctor is
+the router and stays cheap and auth-free, so its duplicate check is
+name-level only; `jit vault duplicates` is what actually compares the values.
+Advisory warnings do not fail `jit doctor` unless you pass `--strict`, which
+is there for a pipeline that wants them to gate.
+
 ## `jit vault rekey` - rotate the master key
 
 Generates a new master encryption key, re-wraps every stored secret's key
@@ -140,6 +149,15 @@ once the profile that named a secret is gone. By default it only lists them;
 registered mount. A secret used only by another project you are not in and
 have not mounted would look orphaned here, so check each secret's origin
 before pruning, or delete just one with `jit vault rm <path>`.
+
+### Stale mount registrations
+
+Deleting a project directory without running `jit unmount` first leaves a
+registered mount whose profile no longer exists. `jit vault orphans` reports
+those separately as **stale mount registrations**, and `--prune` clears them
+along with the orphaned secrets. That is a registry edit only: no secret value
+is read or touched. Before this was handled, a deleted project could leave the
+sweep unable to complete at all.
 
 ## `jit vault clean` - delete every secret
 


### PR DESCRIPTION
Docs-only. Two drivers: a staleness audit against the shipped CLI, and the questions the HN thread kept asking that the docs did not answer.

## The mechanism people could not find

Readers asked how a file read reaches the vault and could not find it: the docs said "local encrypted store" in many places and never named the mechanism. README, `how-it-works.md` and `run/mounts.md` now state it plainly, a POSIX FIFO at mode 0600, `open(2)` blocking until the service connects `O_WRONLY`, bytes moving from memory into the kernel pipe buffer, and the re-open loop that lets it be read more than once. No kernel extension, no filesystem driver. Checked against `internal/mount` before writing.

## Coverage gaps

- `jit grant` shipped in v0.80.0-era and reached none of the onboarding pages. It lived only in `service/grants.md`, the README and the generated reference, so a reader walking quickstart to run to tools never met it. Now a quickstart step, a run-guide section and a tools row.
- The five AI wrappers from v0.84.0 (`cursor-agent`, `copilot`, `cline`, `opencode`, `kiro-cli`) had their own pages but appeared in neither tool list.
- PR #57's stale mount registrations and group-aware `vault rm`, and PR #58's doctor hygiene routing, reached the generated reference but no prose page.

## Corrections found by checking claims

- `security/brief.md` claimed "no network calls, no auto-update", untrue since `jit upgrade` landed. It now describes the one outbound request and what it verifies before installing.
- Quickstart still called `scan` "audit", stale since the rename.
- A broken anchor in `environment-variables.md` (two hyphens, needs three).

## Install ordering

The tarball sat beside brew as an equal alternative with the signing rationale ten lines below, which read as recommending the weaker path. The caveat now sits with the command, and the tarball carries its own `shasum` and `codesign` verification lines.

## New answers

Full-disk encryption solving a different problem, memory being explicitly out of scope, what the crypto actually is (stdlib AES-256-GCM, with Argon2id from `x/crypto` for export passphrases only), and an honest comparison against age, SOPS, dotenvx, 1Password and systemd-creds.

## Verification

- Generated command reference regenerated: no drift
- All relative links and heading anchors across README and `docs/` resolve
- `go build ./...` clean, no code touched

## Not included

The em dash in `jit scan` output (`internal/audit/triage.go`) breaks the voice guide's hard rule, but changing it is a terminal-output change and wants a preview script first. Prose em dashes on the entry and security pages are fixed here; sample output blocks keep theirs because they accurately reproduce what the CLI prints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HU9CJPZU9B5JydjLqr4js4