### PR TITLE
ci: accept any GitHub noreply address in the authorship guard

### DIFF
--- a/.github/workflows/authorship-guard.yml
+++ b/.github/workflows/authorship-guard.yml
@@ -39,9 +39,14 @@ jobs:
           set -euo pipefail
           ZERO=0000000000000000000000000000000000000000
 
-          # Approved author/committer emails for this project. Keep in sync with
-          # the repository ruleset that enforces the same identity server-side.
-          allow='^menitasa@users\.noreply\.github\.com$'
+          # Approved author/committer emails: any GitHub noreply address. The
+          # incident this guard exists for was a REAL email reaching main; a
+          # noreply address leaks nothing, and the maintainer's own hazard
+          # identities (gmail, work domains, *.shared hostnames) all fail this
+          # pattern, so the original protection is intact while outside
+          # contributors keep their attribution. Keep in sync with the
+          # repository ruleset that enforces the same pattern server-side.
+          allow='^[A-Za-z0-9._+-]+@users\.noreply\.github\.com$'
 
           if [ -n "${PR_HEAD:-}" ]; then
             base="$PR_BASE"; head="$PR_HEAD"


### PR DESCRIPTION
## Summary

Widens the Authorship Guard's allowlist from the single maintainer email to any `*@users.noreply.github.com` address, matching the ruleset change already applied server-side. The guard was built to keep real emails out of main after the address-leak incident; a GitHub noreply address leaks nothing, and every identity the guard was built to reject still fails the pattern. Unblocks PR #61, the repo's first outside contribution.

## Test plan

- [x] Pattern verified against the approved identity (passes), the outside contributor's noreply address (passes), and gmail/work-domain/*.shared shapes (all fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YsDoTdd24LnbBtHwkvwrB