### PR TITLE
harden: 0600 scan reports, xucred version gate, malformed-MEK diagnosis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Caller identity — peercred, then pid command line and parent chain — **expla
 
 **Dependency minimalism is a threat-model consistency check, not taste.** jit exists partly to mitigate malicious dependency lifecycle scripts, so a bloated supply chain undermines the product. Prefer stdlib; `golang.org/x/*` is the default extension point; every crypto or OS-security-boundary dependency gets named and justified in `TECH_STACK.md` §2. Two credential-helper JSON shapes are hand-rolled (`k8scred.go`, `awscred.go`) specifically to avoid pulling `client-go`'s tree for a five-field struct. Adding a dependency means updating `TECH_STACK.md`.
 
-**Every `.go` file carries the SPDX header** (364/364 currently):
+**Every `.go` file carries the SPDX header** (390/390 currently):
 
 ```go
 // Copyright 2026 Meni Tasa

--- a/internal/agent/peercred.go
+++ b/internal/agent/peercred.go
@@ -22,6 +22,15 @@ import (
 // this agent's socket at all, regardless of file permissions on the
 // socket path (which are also restricted, but this is defense in depth,
 // not the only check).
+// xucredVersion is XUCRED_VERSION from <sys/ucred.h>, the layout version the
+// kernel stamps into every xucred it fills (cru2x sets it unconditionally).
+// Written out here because golang.org/x/sys/unix defines the STRUCT but
+// exports no constant for its version, and TestVerifyPeerUIDAcceptsARealPeer
+// proves the value against a live socket rather than trusting this comment —
+// a wrong constant here would fail every connection closed, which is the one
+// failure mode worse than the check being absent.
+const xucredVersion = 0
+
 func verifyPeerUID(conn net.Conn) error {
 	unixConn, ok := conn.(*net.UnixConn)
 	if !ok {
@@ -44,6 +53,17 @@ func verifyPeerUID(conn net.Conn) error {
 		return fmt.Errorf("LOCAL_PEERCRED failed: %w", xucredErr)
 	}
 
+	// Check the struct version BEFORE trusting any field in it. The kernel
+	// fills Xucred per its own layout, and this code reads Uid at whatever
+	// offset the Go definition puts it; a future layout the runtime does not
+	// match would have us comparing some other word against our uid and
+	// possibly liking the answer. The uid gate is the one thing standing
+	// between another user's process and this agent's unlocked session, so
+	// it fails closed on a struct it does not recognize rather than
+	// interpreting bytes whose meaning it cannot vouch for.
+	if xucred.Version != xucredVersion {
+		return fmt.Errorf("peer credentials have version %d, want %d", xucred.Version, xucredVersion)
+	}
 	if int(xucred.Uid) != os.Getuid() {
 		return fmt.Errorf("peer uid %d does not match this agent's uid %d", xucred.Uid, os.Getuid())
 	}

--- a/internal/agent/peercred_test.go
+++ b/internal/agent/peercred_test.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package agent
+
+import (
+	"net"
+	"path/filepath"
+	"testing"
+)
+
+// verifyPeerUID is the gate between another user's process and this agent's
+// unlocked session, and it now refuses any xucred whose layout version it
+// does not recognize. That check is only safe if the version the kernel
+// actually stamps matches the constant — a mismatch would fail EVERY
+// connection closed, wedging the agent completely, which is worse than the
+// check not existing. So this drives a real unix socket rather than asserting
+// the constant against itself: it would have caught the value being wrong,
+// and it will catch a future x/sys struct layout that shifts the field.
+func TestVerifyPeerUIDAcceptsARealPeer(t *testing.T) {
+	sock := filepath.Join(t.TempDir(), "s.sock")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+
+	errc := make(chan error, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			errc <- err
+			return
+		}
+		defer conn.Close()
+		errc <- verifyPeerUID(conn)
+	}()
+
+	client, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	if err := <-errc; err != nil {
+		t.Fatalf("verifyPeerUID rejected this process's own connection: %v", err)
+	}
+}

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -246,7 +246,15 @@ var scanCmd = &cobra.Command{
 			// scanOutput is a path the user typed themselves via --output —
 			// this is the intended use of the flag (like `curl -o` or `gcc
 			// -o`), not attacker-controlled input.
-			outFile, err = os.Create(scanOutput) // #nosec G304 -- user-specified output destination, the flag's entire purpose
+			//
+			// 0600, not os.Create's 0666-minus-umask: the report holds only
+			// masked previews (first 4 characters), key names and paths, but
+			// an inventory of exactly where this machine keeps its
+			// credentials is worth reading on its own, and every other file
+			// jit writes is owner-only. A report the user then chooses to
+			// share is a chmod away; one written world-readable by default
+			// cannot be un-read.
+			outFile, err = os.OpenFile(scanOutput, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600) // #nosec G304 -- user-specified output destination, the flag's entire purpose
 			if err != nil {
 				return fmt.Errorf("jit scan: %w", err)
 			}

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -193,6 +193,18 @@ func TestScanCommandOutputToFile(t *testing.T) {
 	if strings.Contains(string(contents), "sk_test_fixture_value") {
 		t.Fatal("report file must never contain the raw secret value")
 	}
+
+	// A saved report is an inventory of where this machine keeps its
+	// credentials, so it gets the owner-only posture every other file jit
+	// writes has — os.Create's 0666-minus-umask would leave it readable by
+	// anyone with an account here.
+	fi, err := os.Stat(reportPath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if perm := fi.Mode().Perm(); perm != 0o600 {
+		t.Errorf("report file mode = %#o, want 0600", perm)
+	}
 }
 
 func TestScanCommandRejectsUnknownFormat(t *testing.T) {

--- a/internal/keychainwrap/keychainwrap.go
+++ b/internal/keychainwrap/keychainwrap.go
@@ -230,6 +230,18 @@ func (w *Wrapper) fetchMEK(reason string) ([]byte, error) {
 		// in freed C heap memory.
 		wipe(unsafe.Slice((*byte)(unsafe.Pointer(keyPtr)), int(keyLen)))
 		C.free(unsafe.Pointer(keyPtr))
+		// Check the length HERE, where "the keychain item is not a
+		// master key" can still be said plainly. A truncated or
+		// foreign item (a hand-edited Keychain Access entry, a
+		// half-written migration) otherwise travels on and surfaces
+		// from aes.NewCipher as "invalid key size", several layers
+		// below the fact that explains it — and a user who has just
+		// been asked for Touch ID reads any error about their vault
+		// as "my secrets are gone".
+		if len(mek) != mekSize {
+			wipe(mek)
+			return nil, fmt.Errorf("master key item in keychain %q is malformed: got %d bytes, want %d", w.service, len(mek), mekSize)
+		}
 		w.mek = mek
 		// Best-effort: keep the cached MEK's page out of swap for this
 		// Wrapper's lifetime (same defense-in-depth internal/agent applies

--- a/internal/keychainwrap/keychainwrap_test.go
+++ b/internal/keychainwrap/keychainwrap_test.go
@@ -8,6 +8,7 @@ package keychainwrap
 import (
 	"bytes"
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -371,5 +372,32 @@ func TestRequireUserPresenceFailedChallenge(t *testing.T) {
 	}
 	if err := w.RequireUserPresence("test"); err == nil {
 		t.Fatal("RequireUserPresence succeeded despite a failed challenge")
+	}
+}
+
+// A keychain item that is not a 32-byte key must be rejected AT THE FETCH,
+// where "the master key item is malformed" can still be stated plainly. Left
+// to travel on, a short item surfaces from aes.NewCipher as "invalid key
+// size" several layers below the fact that explains it — and a user who has
+// just approved a Touch ID prompt reads any error about their vault as "my
+// secrets are gone". Reachable in practice through a half-written migration
+// or a hand-edited Keychain Access entry.
+func TestFetchMEKRejectsAMalformedKeychainItem(t *testing.T) {
+	w := testWrapper(noChallenge)
+	cleanupTestMEK(t, w)
+
+	if err := w.setMEK(make([]byte, 16)); err != nil { // AES-128 length, not this vault's AES-256
+		t.Fatalf("setMEK: %v", err)
+	}
+
+	_, err := w.fetchMEK("test")
+	if err == nil {
+		t.Fatal("fetchMEK accepted a 16-byte master key item; a wrong-length item must never reach the cipher")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Errorf("error = %q, want it to name the item as malformed rather than surfacing a cipher-level message", err)
+	}
+	if w.mek != nil {
+		t.Error("a rejected item must not be cached on the Wrapper")
 	}
 }


### PR DESCRIPTION
## Summary

The first batch from the independent security review (#59): the three items that are genuinely small, additive, and carry no behavior change for anyone. None is an exploitable path.

- **`jit scan --output` writes 0600** (`internal/cli/scan.go`). It used `os.Create`, so 0666-minus-umask. The report holds masked previews only, but it is an inventory of where this machine keeps its credentials, and every other file jit writes is owner-only.
- **`verifyPeerUID` checks the xucred layout version before trusting `Uid`** (`internal/agent/peercred.go`). This is the gate between another user's process and an unlocked session, so it now fails closed on a struct it does not recognize. `x/sys/unix` exports no constant for `XUCRED_VERSION`, so the value is written out with its provenance and **proved against a live unix socket** by the accompanying test rather than asserted against itself: a wrong constant would fail every connection closed, which is worse than no check.
- **`fetchMEK` validates the MEK length** (`internal/keychainwrap/keychainwrap.go`). A truncated or foreign keychain item previously surfaced from `aes.NewCipher` as "invalid key size", several layers below the fact that explains it, to a user who has just answered a Touch ID prompt.
- Corrects `CLAUDE.md`'s SPDX count (said 364/364, actual 390/390).

Items 1, 2 and 4 of #59 are deliberately **not** here: the goreleaser pin is CI-only and belongs on its own, the v1 envelope re-seal needs a design decision (opportunistic re-seal on `Get` vs a doctor nudge) rather than a quick patch, and the export-passphrase warning is user-facing output that wants a rendered preview first.

## Test plan

- [x] New tests: `TestVerifyPeerUIDAcceptsARealPeer` (drives a real unix socket end to end), `TestFetchMEKRejectsAMalformedKeychainItem` (stores a 16-byte item in the TEST-ONLY keychain service and asserts the fetch names it malformed and caches nothing), plus a 0600 mode assertion in `TestScanCommandOutputToFile`
- [x] `go build ./...` && `go test -race -timeout 2m ./...` — full suite green
- [x] `gofmt -l ./cmd ./internal` (clean), `go vet ./...`, `go mod verify && go mod tidy` (no drift)
- [x] `staticcheck ./...`, `gosec -exclude-generated ./...` — clean
- [x] Verified empirically that the kernel stamps `Version=0` for `LOCAL_PEERCRED`, matching `XUCRED_VERSION` in `<sys/ucred.h>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YsDoTdd24LnbBtHwkvwrB