### PR TITLE
ci: pin the exact goreleaser version, not the v2 range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,18 +152,22 @@ jobs:
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          # Pin the goreleaser MAJOR, not "latest", so CI's config check and
-          # snapshot build track the same v2 the release job uses.
-          version: "~> v2"
+          # Pin the EXACT goreleaser, not a range: this job and the release
+          # job must agree, and "~> v2" let whatever v2.x existed at run
+          # time decide whether a release built. Must stay >= v2.13, which
+          # is where the cask's `binaries:` field landed. Bump on purpose.
+          version: "2.17.1"
           args: check
 
       - name: Snapshot build (no publish, no signing)
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          # Pin the goreleaser MAJOR, not "latest", so CI's config check and
-          # snapshot build track the same v2 the release job uses.
-          version: "~> v2"
+          # Pin the EXACT goreleaser, not a range: this job and the release
+          # job must agree, and "~> v2" let whatever v2.x existed at run
+          # time decide whether a release built. Must stay >= v2.13, which
+          # is where the cask's `binaries:` field landed. Bump on purpose.
+          version: "2.17.1"
           # notarize and homebrew are skipped explicitly, not just left to
           # their `enabled`/`skip_upload` env gates: CI must never post a
           # snapshot to Apple's notary service or to the tap, even if the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,12 @@ jobs:
       - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
-          # Pin the goreleaser MAJOR, not "latest": a future v3 with breaking
-          # changes must not silently break a release we didn't touch.
-          version: "~> v2"
+          # Pin the EXACT goreleaser. Every action here is SHA-pinned
+          # because a tag is mutable; this job holds MACOS_SIGN_P12 and the
+          # notary key, so the one remaining floating executable it fetched
+          # deserved the same treatment. Must stay >= v2.13 (the cask's
+          # `binaries:` field). Bump on purpose, never incidentally.
+          version: "2.17.1"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Item 1 of #59. Every action in these workflows is SHA-pinned on the reasoning that a tag is mutable, but goreleaser itself was fetched as `version: "~> v2"` — so whatever v2.x happened to exist at run time decided whether a release built, in the job that holds `MACOS_SIGN_P12` and the notary key.

Pinned to **2.17.1** in all three places (both `ci.yml` uses and `release.yml`). That is the version the v0.95.0 release actually built with, so this is behaviorally a no-op today and purely removes the drift window. The comments now record the constraint that matters on a bump: it must stay **>= v2.13**, where the cask's `binaries:` field landed.

Worth being precise about the limit: this buys **immutability, not verification**. `goreleaser-action` accepts a version string and no checksum, so an exact pin is as far as that mechanism goes; closing the rest would mean fetching and verifying the binary by hand.

## Test plan

- [x] Both workflow files parse as valid YAML
- [x] Verified 2.17.1 is what the v0.95.0 release run downloaded (from the v2.17.1 tag), so CI and release stay on the version already proven against this config
- [ ] CI on this PR exercises `goreleaser check` and the snapshot build against the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YsDoTdd24LnbBtHwkvwrB