### PR TITLE
doctor: report secrets still stored in the pre-AAD format

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -628,6 +628,12 @@ func findingLabel(f checkFinding) string {
 		return "[vault key]"
 	case kindRekey:
 		return "[rekey]"
+	case kindLegacyEnvelope:
+		// "storage format", not "envelope": the envelope is jit's own word
+		// for the on-disk shape and means nothing to the person reading a
+		// health report. Nothing here is damaged, so the header names what
+		// the line is ABOUT and leaves the verdict to the glyph.
+		return "[storage format]"
 	case kindAudit:
 		return "[audit]"
 	case kindMCP:
@@ -658,7 +664,7 @@ func findingLabel(f checkFinding) string {
 // that identifies the file off the first line (rule 6).
 func formatFinding(f checkFinding) string {
 	switch f.Kind {
-	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindMountStale, kindDuplicates, kindOriginGone, kindVaultKey, kindRekey, kindAudit, kindMCP, kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion:
+	case kindParse, kindNotFound, kindService, kindBackup, kindWrap, kindWrapEnv, kindMount, kindMountStale, kindDuplicates, kindOriginGone, kindVaultKey, kindRekey, kindLegacyEnvelope, kindAudit, kindMCP, kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion:
 		return shortHome(f.Detail)
 	case kindMissing:
 		return fmt.Sprintf("%s: %s "+glyphAction+" %s, not in the vault", profileRef(f), f.Variable, f.Path)

--- a/internal/cli/doctorsections.go
+++ b/internal/cli/doctorsections.go
@@ -469,13 +469,40 @@ func gatherVaultIntegrityFindings(root string, v *vault.Vault) []checkFinding {
 	// exists to catch; MEKIndeterminate (a keychain error, or a query that
 	// would have required interaction) is reported as neither present nor gone,
 	// so doctor stays silent rather than raise a false alarm.
-	if vaultMasterKeyPresence() == keychainwrap.MEKAbsent {
+	keyGone := vaultMasterKeyPresence() == keychainwrap.MEKAbsent
+	if keyGone {
 		out = append(out, checkFinding{
 			Kind: kindVaultKey,
 			Detail: fmt.Sprintf(
 				"the vault holds %s but this Mac's master key is missing from the keychain, so none of them can be decrypted. Every envelope is structurally intact; only the key is gone.",
 				countWord(len(paths), "secret", "secrets")),
 			Action: "`jit vault import <file>` from a `jit vault export` backup",
+		})
+	}
+
+	// Auth-free like everything else here: UnboundPaths reads envelope
+	// metadata only. Reported LAST because it is the least urgent thing this
+	// section can say — nothing is broken, and a v1 file decrypts today
+	// exactly as it always has. It earns a line because no other command
+	// reports it and it never fixes itself: rekey rewraps the DEK and leaves
+	// the envelope alone, so a secret written before v0.57.0 stays v1 until
+	// it is written again.
+	//
+	// Silent when the master key is gone. The remediation is an export,
+	// which has to DECRYPT every secret, so with no key it is not advice —
+	// it is a second line telling a user whose vault just became unreadable
+	// to go run something that cannot work. The vault-key finding above is
+	// the only actionable thing in that state.
+	if keyGone {
+		return out
+	}
+	if unbound, err := v.UnboundPaths(); err == nil && len(unbound) > 0 {
+		out = append(out, checkFinding{
+			Kind: kindLegacyEnvelope,
+			Detail: fmt.Sprintf(
+				"%s an old format that cannot tell if a value was swapped on disk.",
+				countWord(len(unbound), "secret uses", "secrets use")),
+			Action: "`jit vault export <file>` then `jit vault import <file>` to update them",
 		})
 	}
 	return out

--- a/internal/cli/doctorsections_test.go
+++ b/internal/cli/doctorsections_test.go
@@ -350,3 +350,70 @@ func TestMCPFindingsIgnoresUnwrappedServers(t *testing.T) {
 		t.Errorf("findings = %+v, want none: nothing here is jit's", findings)
 	}
 }
+
+// plantLegacySecret writes a pre-AAD (v1) envelope, the shape every jit
+// before v0.57.0 wrote. Structurally fine and readable forever — what makes
+// it worth a doctor line is that its payload is bound to nothing.
+func plantLegacySecret(t *testing.T, home, path string) {
+	t.Helper()
+	writeVaultEnc(t, home, path, `{"version":1,"recipients":{"test":"00"},"payload":"00"}`)
+}
+
+// A vault still holding pre-v0.57.0 envelopes gets one advisory line. It has
+// to be advisory: nothing is broken, the secrets read exactly as they always
+// have, and exploiting the unbound payload takes write access to the vault
+// directory — an attacker who could read those files anyway. It has to be
+// SAID because no other command reports it and it never heals on its own.
+func TestLegacyEnvelopesAreReportedAsAdvisory(t *testing.T) {
+	home := withFixtureHome(t)
+	plantLegacySecret(t, home, "legacy/old-key")
+	plantVaultSecret(t, home, "modern/current")
+	stubKeychain(t, keychainwrap.MEKPresent)
+
+	findings := gatherVaultIntegrityFindings(fixtureRoot(home), fixtureVault(home))
+	if len(findings) != 1 || findings[0].Kind != kindLegacyEnvelope {
+		t.Fatalf("expected one legacy_envelope finding, got %+v", findings)
+	}
+	if !findings[0].Kind.warning() {
+		t.Error("a legacy envelope must be advisory: nothing is broken and the secret still reads")
+	}
+	if !strings.Contains(findings[0].Detail, "1 secret uses") {
+		t.Errorf("expected the finding to count what is affected, got: %s", findings[0].Detail)
+	}
+	// The action has to name a remediation that actually works. Re-writing
+	// the secret is the only thing that upgrades an envelope, and
+	// export/import is how a whole vault does it at once — a rekey would
+	// leave every one of these exactly as it found them.
+	if !strings.Contains(findings[0].Action, "export") || !strings.Contains(findings[0].Action, "import") {
+		t.Errorf("action must point at the round-trip that rewrites envelopes, got: %s", findings[0].Action)
+	}
+}
+
+// A vault written by a current jit must stay silent, or every user carries a
+// permanent doctor line urging an export/import round-trip that would
+// rewrite every secret they own for nothing.
+func TestCurrentEnvelopesAreSilent(t *testing.T) {
+	home := withFixtureHome(t)
+	plantVaultSecret(t, home, "modern/current")
+	plantOriginSecret(t, home, "modern/other", "~/code/app/.env")
+	stubKeychain(t, keychainwrap.MEKPresent)
+
+	if findings := gatherVaultIntegrityFindings(fixtureRoot(home), fixtureVault(home)); len(findings) != 0 {
+		t.Errorf("a current vault must be silent about envelope formats, got %+v", findings)
+	}
+}
+
+// With the master key gone, the legacy-envelope line must not appear. Its
+// remediation is an export, which decrypts every secret — unrunnable without
+// the key. Printing it beside the vault-key finding would tell a user whose
+// vault just became unreadable to go do something that cannot work.
+func TestLegacyEnvelopesStaySilentWhenTheMasterKeyIsGone(t *testing.T) {
+	home := withFixtureHome(t)
+	plantLegacySecret(t, home, "legacy/old-key")
+	stubKeychain(t, keychainwrap.MEKAbsent)
+
+	findings := gatherVaultIntegrityFindings(fixtureRoot(home), fixtureVault(home))
+	if len(findings) != 1 || findings[0].Kind != kindVaultKey {
+		t.Fatalf("expected only the vault_key finding, got %+v", findings)
+	}
+}

--- a/internal/cli/profilecheck.go
+++ b/internal/cli/profilecheck.go
@@ -125,6 +125,17 @@ const (
 	// errRekeyInProgress), so a doctor that reported a clean bill of health
 	// left the user to discover the state from the next command that failed.
 	kindRekey checkKind = "rekey"
+	// kindLegacyEnvelope: secrets are still stored in the pre-AAD envelope
+	// (v1), whose payload is sealed with no additional authenticated data
+	// and so is bound to nothing — two v1 payloads can be exchanged and both
+	// still decrypt, the swap envelopeAAD exists to refuse. Advisory: it
+	// takes write access to the vault directory to exploit, which on macOS
+	// means an attacker who can read those files anyway, and nothing is
+	// broken today. It is here because nothing else reports it and it does
+	// not heal on its own — a rekey rewraps the DEK and leaves the envelope
+	// alone, so a secret stored before v0.57.0 and never re-set is still v1
+	// years later, with no way for its owner to find out.
+	kindLegacyEnvelope checkKind = "legacy_envelope"
 	// kindAudit: the audit trail has stopped recording. Advisory — no secret
 	// is at risk and no command is blocked — but for a tool whose job is
 	// custody of secrets, losing the record of what touched them silently is
@@ -199,7 +210,8 @@ var allCheckKinds = []checkKind{
 	kindParse, kindNotFound, kindMissing, kindCorrupt, kindVaultError,
 	kindBadPath, kindOrphan, kindDuplicates, kindOriginGone, kindShadowed,
 	kindService, kindBackup, kindWrap, kindWrapEnv, kindMount,
-	kindMountStale, kindVaultKey, kindRekey, kindAudit, kindMCP,
+	kindMountStale, kindVaultKey, kindRekey, kindLegacyEnvelope,
+	kindAudit, kindMCP,
 	kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion,
 }
 
@@ -216,7 +228,7 @@ var allCheckKinds = []checkKind{
 // one process and must never fail a CI run.
 func (k checkKind) warning() bool {
 	switch k {
-	case kindOrphan, kindDuplicates, kindOriginGone, kindShadowed, kindService, kindBackup, kindMount, kindMountStale, kindWrapEnv, kindAudit, kindInstall, kindJitPathUpgrade, kindCompletion:
+	case kindOrphan, kindDuplicates, kindOriginGone, kindShadowed, kindService, kindBackup, kindMount, kindMountStale, kindWrapEnv, kindAudit, kindInstall, kindJitPathUpgrade, kindCompletion, kindLegacyEnvelope:
 		return true
 	default:
 		return false

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -534,3 +534,45 @@ func syncDir(dir string) {
 		_ = d.Close()
 	}
 }
+
+// UnboundPaths lists the secrets whose envelope predates AAD binding —
+// v1 files, the only schema that sealed its payload with no additional
+// authenticated data. Sorted, so a report reads the same twice.
+//
+// Why this is worth naming at all: a v1 payload opens under aad = nil
+// forever, so nothing ties it to the secret it belongs to. Two v1 files can
+// have their payloads exchanged and both still decrypt, which is exactly
+// what envelopeAAD was introduced to prevent (see its comment). v2 and v3
+// bind the path, so the same swap fails the auth tag.
+//
+// It is not self-healing. RewrapAll rewraps the DEK and leaves the envelope
+// untouched, so even a full master-key rotation never upgrades a v1 file;
+// only writing the secret again does, which is what `jit vault export`
+// followed by `jit vault import` accomplishes for a whole vault at once.
+// AAD binding shipped in v0.57.0, so any secret stored before it and not
+// re-set since is still v1 — a real population, and one no command
+// currently reports.
+//
+// Auth-free by construction: it reads envelope metadata through the same
+// path Info does, never touching the KeyWrapper, so it can never prompt and
+// is safe for jit doctor to run unattended. An unreadable envelope is
+// skipped rather than reported — Verify owns corruption, and one bad file
+// should not cost the count of the rest.
+func (v *Vault) UnboundPaths() ([]string, error) {
+	paths, err := v.List()
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, p := range paths {
+		info, err := v.Info(p)
+		if err != nil {
+			continue
+		}
+		if info.Version == envelopeVersionAADLess {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -745,3 +745,82 @@ func TestWrappedDEKReadsWithoutDecrypting(t *testing.T) {
 		t.Errorf("WrappedDEK on missing secret = %v, want ErrNotFound", err)
 	}
 }
+
+// UnboundPaths is how a user finds out they are carrying pre-v0.57.0
+// envelopes at all: nothing else reports it, and it never heals on its own
+// (RewrapAll rewraps the DEK and leaves the envelope alone). It must name
+// exactly the v1 files — a v3 secret listed here would send someone through
+// a full export/import round-trip for nothing.
+func TestUnboundPathsNamesOnlyPreAADEnvelopes(t *testing.T) {
+	v := newTestVault(t)
+	writeV1Envelope(t, v, "legacy/old-key", []byte("pre-v2 value"))
+	writeV1Envelope(t, v, "legacy/another", []byte("also old"))
+	if err := v.Set("modern/current", []byte("today")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := v.UnboundPaths()
+	if err != nil {
+		t.Fatalf("UnboundPaths: %v", err)
+	}
+	want := []string{"legacy/another", "legacy/old-key"} // sorted, so a report reads the same twice
+	if len(got) != len(want) {
+		t.Fatalf("UnboundPaths = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("UnboundPaths = %v, want %v", got, want)
+		}
+	}
+}
+
+// A vault written entirely by a current jit must report nothing at all —
+// otherwise doctor grows a line every user sees forever, recommending an
+// export/import round-trip that would rewrite every secret they own for no
+// reason.
+func TestUnboundPathsSilentOnACurrentVault(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.Set("modern/one", []byte("a")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	if err := v.Set("modern/two", []byte("b")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := v.UnboundPaths()
+	if err != nil {
+		t.Fatalf("UnboundPaths: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("UnboundPaths = %v on an all-v3 vault, want none", got)
+	}
+}
+
+// The whole point of re-sealing: writing the secret again is what upgrades
+// it, and it is the ONLY thing that does. This pins the remediation the
+// doctor finding recommends (export/import writes through Set), so a change
+// that broke the upgrade would fail here rather than leave users following
+// advice that no longer works.
+func TestSettingAV1SecretAgainUpgradesItsEnvelope(t *testing.T) {
+	v := newTestVault(t)
+	writeV1Envelope(t, v, "legacy/old-key", []byte("pre-v2 value"))
+
+	if err := v.Set("legacy/old-key", []byte("rewritten")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := v.UnboundPaths()
+	if err != nil {
+		t.Fatalf("UnboundPaths: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("UnboundPaths = %v after rewriting, want none: Set must seal at the current version", got)
+	}
+	info, err := v.Info("legacy/old-key")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Version != envelopeVersion {
+		t.Errorf("Version = %d after rewrite, want %d", info.Version, envelopeVersion)
+	}
+}


### PR DESCRIPTION
## Summary

Item 2 of #59, the one item on that list with real substance.

Envelope **v1** sealed its payload with no additional authenticated data, so nothing ties a stored value to the secret it belongs to. Two v1 payloads can be exchanged on disk and both still decrypt, which is exactly the swap `envelopeAAD` was introduced to refuse. v2 and v3 bind the path, so the same swap fails the auth tag.

The part that makes it worth a line: **it never heals on its own.** `RewrapAll` rewraps the DEK and leaves the envelope untouched, so even a full master-key rotation leaves a v1 file exactly as it found it. Only writing the secret again upgrades it. AAD binding shipped in **v0.57.0** and everything before it wrote v1, so a secret stored earlier and not re-set since is still v1 today, and no command reports it.

**Severity, honestly:** advisory, not a hard problem. Exploiting it needs write access to the vault directory, which on macOS means an attacker who can generally read those files anyway, and `GAPS.md` already concedes that someone with code execution as the user reaches the unlocked agent regardless. This closes the gap between "the format makes the swap impossible" and "the swap merely has not happened."

**Why detection rather than a migration.** The affected population may be small or empty: this machine's vault is 116 secrets, all v3. An opportunistic re-seal on `Get` would be complexity bought for nobody, plus a read path that suddenly writes. If real vaults turn out to hold v1 files, the migration becomes a separate change with this finding to justify it.

Two design points worth calling out:

- `vault.UnboundPaths` is **auth-free by construction**, reading envelope metadata through the same path `Info` uses, so doctor keeps its promise never to prompt.
- The finding is **silent when the master key is absent**. Its remediation has to decrypt, so with no key it would be a second line telling a user whose vault just became unreadable to go run something that cannot work.

## Output

```
[storage format]
  ○ 2 secrets use an old format that cannot tell if a value was swapped on disk.
  → jit vault export <file> then jit vault import <file> to update them
```

Previewed at 80, 60 and 50 columns before implementing, per the house rule.

## Test plan

- [x] `TestUnboundPathsNamesOnlyPreAADEnvelopes` — names the v1 files and not the v3 one
- [x] `TestUnboundPathsSilentOnACurrentVault` — an all-v3 vault reports nothing, so nobody carries a permanent nag
- [x] `TestSettingAV1SecretAgainUpgradesItsEnvelope` — pins the remediation: `Set` seals at the current version, which is what export/import relies on
- [x] `TestLegacyEnvelopesAreReportedAsAdvisory` — advisory, counts what is affected, and the action names a round-trip that actually works
- [x] `TestLegacyEnvelopesStaySilentWhenTheMasterKeyIsGone`
- [x] `TestCurrentEnvelopesAreSilent`
- [x] `go build ./...` && `go test -race -timeout 2m ./...` — full suite green
- [x] `gofmt -l ./cmd ./internal` (clean), `go vet ./...`, `go mod verify && go mod tidy` (no drift)
- [x] `staticcheck ./...`, `gosec -exclude-generated ./...` — clean
- [x] Verified `Export` walks the same `List()` as `UnboundPaths`, so everything counted is something the round-trip rewrites and the finding will clear rather than nag forever
- [x] Verified `SetWithMeta` preserves class/group/origin on rewrite, so the remediation costs no provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YsDoTdd24LnbBtHwkvwrB