### PR TITLE
vault export: warn on a passphrase too short to protect the file

### DIFF
--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -1594,6 +1594,10 @@ var vaultExportCmd = &cobra.Command{
 			return fmt.Errorf("jit vault export: %w", err)
 		}
 		defer wipeBytes(passphrase)
+		// Said HERE, before the Touch ID prompt and before a byte is
+		// written, so Ctrl-C still costs nothing. After the file exists it
+		// would be a scolding rather than a warning.
+		warnWeakExportPassphrase(cmd, passphrase)
 
 		// Fresh challenge on purpose, even mid-session — see
 		// openVaultFreshAuth: one command that decrypts EVERY secret into
@@ -1693,6 +1697,37 @@ var vaultImportCmd = &cobra.Command{
 		fmt.Fprintf(cmd.OutOrStdout(), "Restored %s from %s.\n", countWord(n, "secret", "secrets"), srcPath)
 		return nil
 	},
+}
+
+// weakExportPassphraseLen is where the export passphrase stops being the
+// only real protection this file has and starts being a formality. Length is
+// a crude proxy for strength, deliberately: the alternative is shipping a
+// wordlist to grade what someone typed, and a check that guesses at quality
+// would refuse real passphrases while waving through "Password1234". Twelve
+// is low enough that a considered passphrase never trips it.
+const weakExportPassphraseLen = 12
+
+// warnWeakExportPassphrase says one line when the passphrase protecting a
+// full-vault export is short. It never refuses, never re-prompts, and never
+// fails the command.
+//
+// A warning rather than a floor because the shapes it would break are
+// legitimate: `--stdin` exports pipe a passphrase in from a password
+// manager's CLI, and a minimum length turns a working backup script into a
+// broken one at the worst possible moment. It is worth saying at all because
+// this file is the one place jit's secrets leave their device binding: the
+// vault itself is useless without this Mac's keychain, while the export is
+// restorable anywhere by anyone who has it and the passphrase. Argon2id at
+// 64 MiB is a strong KDF and still cannot save a one-character secret.
+//
+// Written to stderr so a scripted `--stdin` export still surfaces it without
+// polluting anything a caller might be capturing on stdout.
+func warnWeakExportPassphrase(cmd *cobra.Command, passphrase []byte) {
+	if len(passphrase) >= weakExportPassphraseLen {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "  %s Short passphrase (%s). It is all that protects this file.\n",
+		cWarn.Sprint(glyphWarn), countWord(len(passphrase), "character", "characters"))
 }
 
 // readPassphrase reads a passphrase for jit vault export/import — hidden

--- a/internal/cli/vault_test.go
+++ b/internal/cli/vault_test.go
@@ -1430,3 +1430,52 @@ func TestPromptEllipsis(t *testing.T) {
 		t.Errorf("promptEllipsis = %q, want the head and tail kept", got)
 	}
 }
+
+// The export is the one file where jit's secrets leave their device binding:
+// the vault is useless without this Mac's keychain, while the export opens
+// anywhere for anyone holding it and the passphrase. So a short passphrase
+// gets one line — and only a line. It must never refuse or re-prompt: an
+// enforced minimum would break `--stdin` exports piping a passphrase in from
+// a password manager, turning a working backup script into a broken one.
+func TestWarnWeakExportPassphrase(t *testing.T) {
+	cases := []struct {
+		name       string
+		passphrase string
+		wantWarn   bool
+		wantText   string
+	}{
+		{"one character", "x", true, "1 character"},
+		{"short", "hunter2", true, "7 characters"},
+		{"just under the line", "elevenchars", true, "11 characters"},
+		{"at the line", "twelvechars!", false, ""},
+		{"a real passphrase", "correct horse battery staple", false, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			var stderr bytes.Buffer
+			cmd.SetErr(&stderr)
+
+			warnWeakExportPassphrase(cmd, []byte(tc.passphrase))
+
+			got := stderr.String()
+			if !tc.wantWarn {
+				if got != "" {
+					t.Fatalf("warned on a passphrase that is long enough: %q", got)
+				}
+				return
+			}
+			if got == "" {
+				t.Fatal("no warning for a short passphrase on a full-vault export")
+			}
+			if !strings.Contains(got, tc.wantText) {
+				t.Errorf("warning = %q, want it to name the length %q", got, tc.wantText)
+			}
+			// The passphrase itself must never be echoed back — it was typed
+			// hidden, and a terminal it appears in is one it can be read from.
+			if strings.Contains(got, tc.passphrase) {
+				t.Errorf("warning echoed the passphrase itself: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Item 4 of #59, the last of the six. `jit vault export` accepted any non-empty passphrase, including a single character, on the one file that holds every secret in the vault.

That file is different from everything else jit stores: the vault is device-bound and useless without this Mac's keychain, while an export deliberately breaks that binding so it can be restored anywhere. The passphrase is therefore the only thing protecting it. Argon2id at 64 MiB/t=3 is a strong KDF and still cannot save a one-character secret.

Three decisions worth stating:

- **A warning, never a floor.** An enforced minimum would break shapes that are legitimate today: `--stdin` exports pipe a passphrase in from a password manager's CLI, and a length rule turns a working backup script into a broken one at the worst possible moment.
- **It fires before any work starts** — before the Touch ID prompt, before a byte is written — so Ctrl-C still costs nothing. Printed after the file exists, it would be a scolding rather than a warning. It goes to stderr so a scripted export still surfaces it without polluting captured stdout.
- **Twelve characters, by length alone.** Length is a crude proxy for strength deliberately: grading quality properly means shipping a wordlist, and a guess at it would refuse real passphrases while waving through `Password1234`.

## Output

```
Enter a passphrase to encrypt this export: 
Confirm passphrase: 
  ○ Short passphrase (7 characters). It is all that protects this file.
🔐 Waiting for Touch ID...
Exported 34 secrets to backup.jitx.
```

Previewed at 80, 60 and 50 columns before implementing, per the house rule.

## Test plan

- [x] `TestWarnWeakExportPassphrase` — 1, 7 and 11 characters warn and name the length; 12 and a real passphrase stay silent; the passphrase itself is never echoed back (it was typed hidden, and a terminal it appears in is one it can be read from)
- [x] `go build ./...` && `go test -race -timeout 2m ./...` — full suite green
- [x] `gofmt -l ./cmd ./internal` (clean), `go vet ./...`
- [x] `staticcheck ./...`, `gosec -exclude-generated ./...` — clean

Closes the last open item of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YsDoTdd24LnbBtHwkvwrB