### PR TITLE
docs: give jit grant its own section, and route to it

### DIFF
--- a/docs/getting-started/delivering-secrets.md
+++ b/docs/getting-started/delivering-secrets.md
@@ -1,6 +1,6 @@
 ---
 title: Which command delivers a secret
-description: When to use jit wrap, jit run, jit run --profile, jit run --with, and how a migrated .env stays compatible with your scripts.
+description: When to use jit wrap, jit run, jit run --profile, jit run --with, jit grant, and how a migrated .env stays compatible with your scripts.
 ---
 
 # Which command delivers a secret
@@ -18,6 +18,7 @@ are not alternatives to each other so much as answers to different questions.
 | A one-off command that needs a specific profile | **`jit run --profile <name>`** | No setup; name the profile for this run only |
 | A machine-wide credential *file* a tool reads (gcloud ADC, SOPS age key, global `~/.npmrc`, `~/.pypirc`) | **run it** and approve the prompt, or **`jit run --with <name>`** | Consent prompts on first read (default); `--with` is the explicit, hard-gated grant, never authorized by a repo |
 | Secrets in your current interactive shell | **`jit export`** | Prints `export` lines to `eval` |
+| Any of the above, but running while you are *away from the keyboard* (an overnight agent, a long build, a scheduled job) | **`jit grant`** first, then the command as usual | One disclosed Touch ID now covers a bounded window, so no prompt waits for a person who is not there |
 
 ## `jit wrap`: a tool that carries its own token
 
@@ -115,6 +116,46 @@ guarantee that a project can never even prompt for the credential (or,
 grant-wrapped, every time you type the tool). See [jit run](../run/index.md) and
 the per-credential pages for
 [gcp](../migrate/gcp.md), [sops](../migrate/sops.md), and [npm](../migrate/npm.md).
+
+## `jit grant`: the same delivery, while you are away
+
+`jit grant` is not a sixth way to deliver a secret. It is an answer to a
+different question: *who approves the delivery when you are not at the
+keyboard?*
+
+Everything above rides a session you opened with Touch ID, and that session
+ends when you walk away: idle timeout, screen lock, sleep. For work that runs
+while you are there, that is exactly right. For an AI agent working overnight,
+a long build, or a scheduled job, it means the next credential read stops on a
+prompt nobody will answer.
+
+A process grant moves your decision earlier instead of removing it. While you
+are still at the keyboard, one disclosed Touch ID approves that a program, and
+everything it launches, may use the secrets of named profiles until a deadline
+you set:
+
+```
+jit grant --process claude --profile jamf --for 8h
+claude                      # reads succeed with no prompt, until the grant expires
+```
+
+The command you actually run does not change. Wrap shims, credential hooks and
+`jit run` all keep working exactly as described above; the grant only decides
+whether their reads prompt. It is scoped to the terminal you type it in,
+verified through kernel process ancestry, so a same-named process elsewhere on
+the machine inherits nothing. It ends at its deadline, when its terminal quits,
+or the moment you run `jit grant revoke <id>`, and every stage lands in
+`jit audit`.
+
+**Use `jit grant` when:** the work is unattended and a Touch ID prompt would
+simply hang. Do not reach for it to skip prompts you *are* present for. See
+[Process grants](../service/grants.md) for what it anchors to, what ends it,
+and its limits (it does not cover live file mounts, which keep their own
+[consent gating](../service/consent.md)).
+
+Note the word "grant" does double duty in jit: `jit run --with` above creates a
+grant scoped to a single run that ends when that run exits, while `jit grant`
+creates a standing one, scoped to a process tree and a deadline.
 
 ## How a migrated `.env` stays compatible with your scripts
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,7 @@ then **[Install](./getting-started/install.md)** →
 - [Quickstart](./getting-started/quickstart.md) - scan → vault → migrate → status, start to finish
 - [How it works](./getting-started/how-it-works.md) - the vault, the service, mounts, shims, and provenance
 - [How it all fits together](./getting-started/how-it-fits.md) - the three delivery models, and how integrating (migrate/wrap) and running (native hook, shim, or `jit run`) connect
-- [Delivering a secret to a program](./getting-started/delivering-secrets.md) - when to use `jit wrap`, `jit run`, `jit run --profile`, and `read_as_file`
+- [Delivering a secret to a program](./getting-started/delivering-secrets.md) - when to use `jit wrap`, `jit run`, `jit run --profile`, `jit run --with`, `jit grant`, and `read_as_file`
 - [Troubleshooting](./getting-started/troubleshooting.md) - placeholder values, hangs, surprise Touch ID prompts
 - [FAQ for developers and security](./faq.md) - blunt answers on how it works, what it protects, and what it deliberately does not
 
@@ -83,11 +83,19 @@ then **[Install](./getting-started/install.md)** →
 
 ## Use secrets - `jit run` & profiles
 
-- [Which command delivers a secret](./getting-started/delivering-secrets.md) - when to use `jit wrap`, `jit run`, `jit run --profile`, and `read_as_file`
+- [Which command delivers a secret](./getting-started/delivering-secrets.md) - when to use `jit wrap`, `jit run`, `jit run --profile`, `jit run --with`, `jit grant`, and `read_as_file`
 - [Run a command with secrets](./run/index.md) - layer merging, modes, `--profile`, the compatibility swap and `--live`
 - [Profiles](./run/profiles.md) - the manifest mapping variables to vault paths
 - [Shell exports](./run/export.md) - `eval "$(jit export)"`
 - [Live-mounted files](./run/mounts.md) - decoys, grants, the compatibility swap, and reading values safely
+
+## Run unattended - `jit grant`
+
+- [Process grants](./service/grants.md) - one disclosed Touch ID now lets a
+  program and everything it launches use profiles for a bounded time, instead of
+  a prompt nobody is there to answer; revocable, expiring, fully audited
+- [`list`, `revoke`, `extend`](./reference/commands/jit_grant.md) - what is open
+  right now, the kill switch that needs no authentication, and buying more time
 
 ## The vault
 


### PR DESCRIPTION
Placement fix for `jit grant`, which was documented but unfindable.

`docs/service/grants.md` covers the feature in full and the generated reference pages exist, but the docs index listed it as one bullet under **The background service** - the only user-facing verb without its own heading, sitting next to unlock and provenance as if it were daemon plumbing rather than a command you type.

**What changed**

- `docs/index.md` gains a top-level `## Run unattended - jit grant` section after the `jit run` section, since "use secrets" then "use them while away" is the reading order.
- `docs/getting-started/delivering-secrets.md` is the "which command do I use" router and did not mention grant at all, so someone with the unattended-agent problem got routed to `wrap` or `run` and never learned it existed. It gains a table row and a section.
- Both index summaries of that router page were completed while there; they listed four of its topics and had already been missing `--with` before this.

**What deliberately did not change**

The page does not move. Grants live in the service's memory and die with a service restart, so the service grouping is right on the merits, and the existing bullet there stays. No `docs/grant/` directory either: `jit run` earned four pages because it has four separate topics, while grant has one story already told at the same depth as `run/index.md`.

The new section leads with the point that grant is not a sixth delivery mechanism but an answer to a different question (who approves when you are not at the keyboard), and disambiguates the overloaded word, since that page already used "grant" four times for `jit run --with`.

No CLI code touched, so the generated reference pages are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)