### PR TITLE
1Password adapter: linked secrets resolved through op (issue #60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,11 @@ The full catalog, grouped by exactly what to type for each tool, is
 removed. Anything not listed can still be wrapped with
 [`jit wrap add`](./docs/wrap/custom-tools.md).
 
+Already keep your secrets in 1Password? [`jit vault
+link`](./docs/vault/1password.md) stores the `op://` reference instead of a
+copy: 1Password stays the system of record, and jit delivers the value
+just-in-time through every mechanism above.
+
 ## Can I undo it? Always.
 
 `jit` never destroys a credential. Migrate **moves** the value into the vault and

--- a/README.md
+++ b/README.md
@@ -358,10 +358,12 @@ The full catalog, grouped by exactly what to type for each tool, is
 removed. Anything not listed can still be wrapped with
 [`jit wrap add`](./docs/wrap/custom-tools.md).
 
-Already keep your secrets in 1Password? [`jit vault
-link`](./docs/vault/1password.md) stores the `op://` reference instead of a
-copy: 1Password stays the system of record, and jit delivers the value
-just-in-time through every mechanism above.
+Already keep your secrets in 1Password? With its CLI installed,
+[`jit migrate` links instead of copying](./docs/vault/1password.md): a
+value that already lives in 1Password is vaulted as its `op://` reference,
+so 1Password stays the system of record and jit delivers the value
+just-in-time through every mechanism above (`jit vault link` does the same
+for one secret by hand).
 
 ## Can I undo it? Always.
 

--- a/TECH_STACK.md
+++ b/TECH_STACK.md
@@ -126,6 +126,12 @@ This is the one layer of the stack that is unavoidably macOS-only and unavoidabl
 | `net/http` (stdlib) | Base client for Datadog/Splunk/Slack/Teams webhook delivery. |
 | `github.com/hashicorp/go-retryablehttp` | Backoff/retry wrapper so a transient network blip doesn't silently drop a high-severity event (failed auth, blocked lineage, tripped velocity limit, canary use), these are exactly the events where "we tried once and gave up" is the wrong failure mode. |
 
+### 2.13 1Password reference resolution (design/1password-adapter.md)
+
+| Package | Role |
+|---|---|
+| No SDK for 1Password | `github.com/1password/onepassword-sdk-go` exists and was NOT adopted: it authenticates via service-account token (a credential jit would then have to store, recursively) and adds a supply-chain edge to the exact class of secret this feature handles. `internal/onepassword` instead execs the user's own `op` CLI (`op read -n`), pure Go, zero new modules -- and refuses to exec an `op` that fails Developer ID signature verification against AgileBits' pinned Team ID (same codesign requirement shape as `jit upgrade`'s own check). The desktop app's biometric authorization gates release from 1Password; jit's consent gates delivery. |
+
 ---
 
 ## 3. Architecture Note: Two Curves, Two Purposes

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -442,6 +442,39 @@ commands kept prompting per their own policy. Still untested: the
 background service's op session behavior (no linked secret has been
 mounted yet), and 1Password-app-locked failure at refresh time.
 
+### Dogfood, phase 2 build (2026-08-17, live account, dev VM)
+
+The dedupe ran end to end against the real account (174 items) with a
+throwaway 1Password item: a matching value linked ID-form, a verbatim
+op:// value linked as itself, a plain value copied — the mutation-log
+block named all of it. Rotating the item in 1Password flowed through
+with no re-link. Edge cases held live: duplicate values both linked to
+the same field, an under-8-byte value ("admin") stayed a copy even
+with a real concealed "admin" field present, `--no-1password` stored a
+literal and silenced the plan line, `--dry-run` never contacted op,
+decoy mounts served placeholder values for linked paths with no op
+call, undo restored the original bytes, and a PATH-planted fake op was
+rejected by the signature gate with the amber fail-open note while the
+run completed on copies.
+
+Two live findings worth keeping. First, the rename split is real and
+correct: after renaming the item, the ID-form (matched) link kept
+resolving while the verbatim name-form link failed loud with op's own
+item-not-found error — exactly the fragility the user's `op run` file
+already had, preserved rather than silently rewritten. Upgrading
+verbatim name-form refs to ID form via the index is a possible future
+nicety, but it means storing something the user didn't write. Second,
+`op signout` is NOT a way to observe the fail-open path on a machine
+with the desktop-app integration: the next op invocation transparently
+re-signs in through the app, so the enumeration succeeds. The genuine
+failure modes remain app-locked and CLI-not-integrated.
+
+The previously untested service-side path is now half-covered: the
+background service refreshed and served decoy mounts for linked
+secrets without an op session (decoys are name-derived). Real-value
+mount delivery of a linked secret through a grant is still the open
+verification, along with app-locked failure at refresh.
+
 `jit audit` captures the whole story with no new code: every link and
 get is a command record with caller attribution, failed resolves keep
 op's full error text, and a `jit run` against a linked profile shows

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -379,6 +379,20 @@ commands kept prompting per their own policy. Still untested: the
 background service's op session behavior (no linked secret has been
 mounted yet), and 1Password-app-locked failure at refresh time.
 
+`jit audit` captures the whole story with no new code: every link and
+get is a command record with caller attribution, failed resolves keep
+op's full error text, and a `jit run` against a linked profile shows
+the unlock event with the secret's path beneath it. Two notes. The
+audit log necessarily contains reference URIs — they appear in the
+command line the user typed and in op's error text; that is command
+recording working as designed, and the log is local, but it is why
+ErrRefUnresolvable still keeps the URI out of arbitrary error
+surfaces. And a SUCCESSFUL resolve is not marked as
+"via 1Password" — the command record is identical to a literal get,
+with the class/storage fields in `vault get --format json` as the
+tell. An explicit resolve audit kind is a phase 2 candidate, not a
+gap in the trail's honesty.
+
 ## Dependencies and testing
 
 Zero new Go modules: the integration is an exec boundary, consistent

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -358,6 +358,27 @@ Each gets a one-clause error plus the one command to type:
 - Any daemonized 1Password sync; manual re-runs of the bulk/migrate
   flows are the refresh.
 
+## Dogfood findings (2026-08-17, live account, phase 1 build)
+
+Exercised end to end against a real signed-in 1Password desktop app:
+link (name form and ID form), get, get --format json, rotation in
+1Password reflected with no re-link, byte-exact resolution of a value
+containing quotes, backticks, `$VAR`, double spaces, and emoji
+(delta vs `op read -n` was exactly vault get's display newline; the
+JSON channel matches op byte for byte), `jit run` env injection,
+literal-set-over-link clearing storage while keeping birth class,
+history archiving the reference and restore turning the path back
+into a link, dead links failing with op's own item-not-found error,
+and malformed references failing before any prompt.
+
+Two UX facts confirmed: the first use costs exactly the predicted
+double prompt (jit Touch ID, then 1Password's "Allow iTerm2 to get
+CLI access" dialog naming the process and account), and every op call
+after that rode the 1Password session silently while jit's fresh-auth
+commands kept prompting per their own policy. Still untested: the
+background service's op session behavior (no linked secret has been
+mounted yet), and 1Password-app-locked failure at refresh time.
+
 ## Dependencies and testing
 
 Zero new Go modules: the integration is an exec boundary, consistent

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -260,21 +260,73 @@ Rules, all fail-safe:
 - `--prefix <p>` namespaces everything under `p/` for users whose
   1Password vault names collide with existing jit paths.
 
-### Migrate dedupe: link instead of copy
+### Migrate dedupe: link instead of copy (phase 2, plan verified against the code 2026-08-17)
 
-The sharper flow. When `jit scan` has found a plaintext secret and
-the user runs `jit migrate --link-1password <path>`, migrate bulk-
-fetches concealed field values once, and any found secret whose
-value **exactly matches** a 1Password field is vaulted as a
-reference to that field instead of as a literal copy — the file is
-neutralized identically either way, and no second copy of the value
-is ever created. Matching compares the value the migrator parsed
-(after its own unquoting) against the field bytes, byte-exact, no
-trimming or normalization: a near-miss silently linking the wrong
-credential is far worse than a miss that falls back to a local copy. No match falls back to today's behavior, a local
-literal. A value matching several 1Password fields links to the
-first, and says so in the plan (same value, same secret; the choice
-is cosmetic).
+The sharper flow, and the one that ships first. When the 1Password
+CLI is installed, every `jit migrate` run dedupes against 1Password
+by default: any secret it is about to vault whose value byte-exactly
+matches a concealed 1Password field is stored as a reference to that
+field instead of as a literal copy. The file is neutralized
+identically either way, and no second copy of the value is created.
+Opt-OUT (`--no-1password`), not opt-in: the user already opted in by
+installing `op` and signing in, and a flag nobody discovers is a
+feature nobody has. No `op` on PATH means the whole path is inert.
+
+Matching compares the value the migrator parsed (after its own
+unquoting) against the field bytes, byte-exact, no trimming or
+normalization: a near-miss silently linking the wrong credential is
+far worse than a miss that falls back to a local copy. Values
+shorter than 8 bytes never match (a `PASSWORD=admin` line must not
+link to whichever item also says "admin"). A value matching several
+fields links to the first under a deterministic order (vault id,
+item id, field id) — same value, same secret; the choice is
+cosmetic. No match falls back to today's behavior, a local literal.
+
+A migrated value that already IS a reference (`FOO=op://…` in a
+`.env` kept for `op run`) links verbatim. Verified against the code:
+today migrate would vault the literal `op://` string and `jit run`
+would deliver it unresolved, breaking the workflow being migrated —
+the dedupe hook turns that file into linked entries that keep
+resolving. `jit scan` already treats `op://` values as non-secrets
+(verified live), so scan and migrate agree.
+
+**Where each piece lives**, verified against the real seams:
+
+- **The intercept is a vault hook, not 23 edited call sites.**
+  `vault.Vault` grows `LinkOnSet func(path string, value []byte,
+  meta Meta) (ref string, ok bool)` beside `OnSet`, consulted by
+  `SetWithMeta` (never by `SetReference`, never for
+  `IsBackupPath` paths — whole-file backups are jit's copies, not
+  credentials). Returning a ref stores a reference envelope with the
+  MIGRATOR'S meta: class stays `dotenv`/`aws`/…, `storage` alone
+  marks linkedness, exactly the provenance model above. All 23
+  `SetWithMeta` call sites across 19 Apply paths stay untouched,
+  the same reasoning that put `OnSet` on the vault.
+- **`OnSet` still fires with the ORIGINAL plaintext on a linked
+  write** — the agent-cache sweep hunts copies of the real value,
+  which was on disk regardless of where the vault now points. A
+  reference envelope write never reports the `op://` string to
+  `OnSet`; a reference is not a credential the sweep should hunt.
+- **The match list prints in the mutation log, not the plan.** The
+  plan renders BEFORE `openVault()` by explicit design (declining
+  must never cost a Touch ID prompt), and the same holds for
+  1Password's authorization dialog, so the plan cannot contact `op`.
+  The plan (and `--dry-run`, same rendering path, parity preserved)
+  carries one announcement line when `op` is on PATH; the bulk fetch
+  runs after [y/N] and Touch ID, behind a stderr cue in `jit vault
+  link`'s wording, and the per-secret `path → reference` rows print
+  as a `[1Password]` block in the mutation log.
+- **Fail open, say so.** A signed-out CLI, a locked app, a timeout,
+  or unparseable output degrades to literal copies with one amber
+  note naming op's first error line. Migrate must never break
+  because 1Password is broken.
+- **The index holds hashes, not values**: SHA-256 of each concealed
+  field → its reference, built from one
+  `op item list --format json | op item get - --format json`
+  enumeration (one authorization, values in memory only, raw JSON
+  wiped after parsing). Stored references are built in ID form from
+  the item JSON's own vault/item/field ids; the mutation log
+  displays the name form, which is what the user recognizes.
 
 This closes the loop the issue is really about: a 1Password user's
 `.env` is usually a hand-made plaintext cache of things 1Password
@@ -284,7 +336,18 @@ written to.
 
 What "automatic" does NOT mean: no daemon watches 1Password for new
 items, and nothing links without the plan/confirm step. Re-running
-`--from-op` or `--link-1password` is the refresh.
+migrate or `--from-op` is the refresh.
+
+### Scan nudge (with the dedupe, scoped down)
+
+Scan stays promptless and read-only, so it can never value-match
+against 1Password; that nudge lives in migrate alone. What scan CAN
+say textually: when a reported `.env` file also carries `op://`
+reference values, the file's entry notes how many, and that migrate
+keeps them linked. No new finding type, no schema change — a
+rendering-only note on findings that already exist, `EndLine`'s
+precedent. A file that is ALL references produces no findings and
+stays unreported: nothing is exposed, and scan does not advertise.
 
 ## Interaction with the agent, grants, and mounts
 

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -1,0 +1,374 @@
+# 1Password adapter: reference secrets resolved through `op`
+
+**Status: draft — issue #60 (maelp): "Could there be an adapter for
+1Password storage, possibly through `op` cli?"**
+
+A 1Password user's secrets already have a home: synced, shared with a
+team, rotated in the 1Password app. Today jit asks that user to copy
+values into its own vault, which creates a second source of truth that
+starts drifting the moment a teammate rotates a key. The adapter removes
+the copy: a vault entry may hold a **reference** to a 1Password item
+instead of a literal value, and jit resolves it at delivery time by
+running `op read`. 1Password stays the system of record; jit stays the
+just-in-time delivery and policy layer — the parts 1Password does not
+have: decoy FIFO mounts, per-process consent, process-tree grants,
+native credential-helper protocols, scan/migrate, one audit surface.
+
+That framing decides the scope: **read-only, value-level**. jit never
+writes to 1Password, and there is no "storage backend" abstraction —
+a reference is just a different kind of payload inside the existing
+envelope, resolved at the one place every consumer already funnels
+through (`Vault.Get`). Every injection tier inherits 1Password support
+at once, with no per-tier work.
+
+## What `op` gives us (verified against the CLI docs, 2026-08)
+
+- **Secret references**: `op://<vault>/<item>[/<section>]/<field>`,
+  1Password's own URI scheme, copyable from the desktop app and stable
+  across value rotation. Query parameters cover OTPs
+  (`?attribute=otp`) and SSH key formats (`?ssh-format=openssh`).
+- **`op read -n <ref>`** prints the exact field bytes to stdout; `-n`
+  suppresses the trailing newline op otherwise appends, which matters
+  for byte-exact injection.
+- **Desktop-app integration**: `op` authenticates through the
+  1Password app (Touch ID / Apple Watch / device password) over XPC
+  with mutual code-signature verification, and logs CLI activity in
+  the app. Authorization is per account, per **terminal session**
+  (the macOS session credential is the tty plus its start time): a
+  10-minute inactivity expiry that refreshes on each use, a 12-hour
+  hard cap, and **every authorization is revoked when the app
+  locks**. The prompt names the account and the process being
+  authorized. An encrypted in-memory cache daemon (default on for
+  UNIX) cuts API calls between commands. `OP_BIOMETRIC_UNLOCK_ENABLED`
+  and `OP_ACCOUNT` tune it from the environment; account selection
+  precedence is `--account`, then `OP_ACCOUNT`, then the most recent
+  `op signin`.
+- **Enumeration hands us everything**: `op item get --format json`
+  returns each field with its concealed value AND a ready-made
+  `reference` key (name form); vault, item, and field ids sit in the
+  same output, so ID-form references are assembled from one pass.
+- **Service accounts** exist for headless use (vault-scoped token in
+  `OP_SERVICE_ACCOUNT_TOKEN`). Deliberately out of scope for v1: the
+  token is itself a credential jit would then need to store, and the
+  attended desktop-app path is the one the issue is about.
+
+Note the overlap: `op run` / `op inject` / shell plugins already do
+Tier-1-style env injection. The adapter's value is everything op
+cannot do, listed above — which is also why resolution belongs at the
+vault layer and not as a wrapper around `op run`.
+
+## The shape: a reference is an encrypted payload, not a new store
+
+A linked secret is a normal envelope whose decrypted payload is the
+`op://` URI, plus an authoritative marker saying "resolve me, don't
+serve me". Two properties fall out, both deliberate:
+
+- **The reference is encrypted and consent-gated like any secret.**
+  An `op://` URI names your 1Password vault, item, and field — your
+  credential map. More importantly, gating its DEK unwrap is what
+  keeps jit's per-process consent, class-AAD policy, and process
+  grants meaningful for linked secrets: the agent's decision point is
+  unchanged, it just guards a pointer instead of the bytes.
+- **The marker is AAD-bound, never sniffed.** Dispatching on "payload
+  happens to start with `op://`" would silently morph a literal value
+  into a network fetch. Instead the envelope grows an explicit field,
+  bound into the AAD so it cannot be flipped on disk: marking a
+  literal secret as a reference (or the reverse) fails decryption.
+
+### Envelope v4
+
+```
+Storage string `json:"storage,omitempty"`   // "" = literal value
+                                            // "op-ref" = payload is an op:// URI
+```
+
+- `envelopeVersion` bumps to 4. v4's AAD string appends `storage`
+  after `origin`; Get reconstructs per stored version exactly as the
+  v2/v3 branch does today. v1–v3 files stay readable forever,
+  unchanged.
+- Rekey (`rewrapFile`) already round-trips the whole envelope struct
+  and never re-seals the payload, so `storage` survives a rekey by
+  construction — but a rekey-a-reference test pins that, since a
+  dropped field here would silently turn a pointer into garbage.
+- Set keeps writing what it writes; only `jit vault link` (below)
+  writes `storage: "op-ref"`. Rotation semantics for a reference are
+  "the reference changed", which is re-linking, not a value rotation —
+  1Password owns value rotation, and jit's per-path history archives
+  old references, not old values. Stated plainly in the docs: history,
+  `jit vault get` of an archived version, and export all operate on
+  the reference for linked secrets.
+- Provenance: a manual or bulk link stamps
+  `Meta{Class: ClassOnePassword, Origin: ""}`. A new
+  `ClassOnePassword = "1password"` is honest birth provenance ("born
+  as a link"), flows through the class-AAD consent gate like every
+  other class, and gives list/audit/status a display hook. A secret
+  that `jit migrate` links (below) keeps its migrator's class
+  (dotenv, mcp, …) — it was born in that file; `storage: "op-ref"`
+  alone says how it is fulfilled. This is exactly why reference-ness
+  is its own field and not a class. Origin stays empty for links made
+  from nothing: Origin is plaintext on disk and the URI must not leak
+  there — the encrypted payload is its only home.
+
+## The resolver seam (mirrors KeyWrapper)
+
+`internal/vault` gets no opinion about 1Password, exactly as it has no
+opinion about keychains:
+
+```go
+// RefResolver resolves a reference-kind payload to the secret bytes it
+// names. Schemes are dispatched by the resolver, not the vault.
+type RefResolver interface {
+    ResolveRef(ref string) ([]byte, error)
+}
+```
+
+- `Vault` gains an optional `RefResolver` field. `Get`, after opening
+  a `storage: "op-ref"` payload, calls it and returns the resolved
+  bytes; every caller keeps calling `Get` and cannot tell the
+  difference. A nil resolver returns a typed error
+  (`ErrRefUnresolvable`) naming the reference kind, so surfaces that
+  must never block on a GUI prompt can opt out by construction.
+- The shipped implementation lives in a new **`internal/onepassword`**
+  package (pure Go, no CGo, no new module dependency): it accepts only
+  the `op://` scheme, rejects anything else, and execs the `op`
+  binary. Scheme dispatch keys the door for a future second backend
+  without building the abstraction now. op's query parameters pass
+  through, and because resolution happens at every Get, a
+  `?attribute=otp` reference yields a *current* TOTP each time — a
+  feature, worth one line in the docs.
+- Cost, stated up front: one `op read` is one process exec, roughly
+  100–300ms, with no extra prompt inside an op session. A profile
+  with a dozen linked secrets pays that a dozen times per resolve.
+  v1 accepts it; if it hurts in practice, the follow-up is a batch
+  method on the resolver (one `op inject` template resolving every
+  reference in a single exec) driven from profile resolution — noted
+  below, not built now.
+- Wiring is centralized where vault construction already is:
+  `openVault` / `openVaultFreshAuth` in `internal/cli`, and the
+  service's vault construction in `agent.go`. `openVaultReadOnly`
+  stays resolver-free (it never Gets).
+
+### Executing `op` safely
+
+- **Find**: `exec.LookPath("op")`, resolved once per process.
+- **Verify before exec**: the resolved binary must carry a valid
+  Developer ID signature from 1Password's (AgileBits') Apple Team ID,
+  checked with the same technique `verifyStagedSignature` uses in
+  `upgrade.go` (requirement string with the Developer ID marker OIDs
+  and a pinned team ID, confirmed against the real binary during
+  implementation). Fail closed, no override flag. The threat is a
+  PATH-planted fake `op`: it never receives a secret, but it learns
+  which references exist and can answer with attacker-chosen values;
+  for a security tool the check is cheap and on-brand. `jit doctor`
+  reports the state without prompting. op's own documented accepted
+  risks (root, or an app with macOS accessibility permissions, can
+  bypass its authorization while the app is unlocked) are the same
+  same-user local-attacker bound `internal/keychainwrap`'s doc
+  already states for jit itself — the adapter aligns two matching
+  threat models rather than weakening either.
+- **Invoke**: `op read -n <ref>`, no shell. The caller's environment
+  passes through (op needs `HOME`, its config, `OP_ACCOUNT`,
+  `OP_BIOMETRIC_UNLOCK_ENABLED`); jit sets nothing op-specific itself.
+  stdout is the value, byte-exact. A nonzero exit surfaces op's stderr
+  wrapped with a jit-side hint (see failure modes).
+- **Waiting**: a read may block on the 1Password unlock dialog. Use
+  the same generous timeout class as the Touch ID wait, with a plain
+  progress line ("waiting for 1Password…") — the `🔐` glyph stays
+  reserved for the Touch ID wait per the output contract. First use
+  in a fresh session can cost two prompts back to back (jit's Touch
+  ID, then 1Password's); both sides session-cache, so steady state is
+  zero or one. Dogfood this before shipping — it is the UX risk.
+- **Multi-account**: the URI does not name an account. v1 defers to
+  op's own selection (`OP_ACCOUNT`, app-integration chooser) and
+  records this as an open question rather than inventing per-link
+  account storage speculatively.
+
+## Command surface
+
+```
+jit vault link <vault-path> <op://vault/item/field>
+```
+
+The only new verb. It validates the URI shape, resolves it once
+through the real resolver (proving op is installed, signed, signed in,
+and the item exists — and costing the one prompt the user expects at
+setup time), then writes the v4 reference envelope with
+`ClassOnePassword`. `--no-verify` skips the trial resolve for offline
+setup. Re-linking an existing path follows the overwrite-confirmation
+convention (`-y`/`--yes`).
+
+Existing commands change display only:
+
+- `jit vault get` resolves and prints the value (that is the point);
+  `--format json` adds the reference URI alongside the usual
+  provenance. `jit vault list -l` and `jit status` tag linked entries
+  with the plain-text class name, no new glyphs.
+- `jit vault link --verify [path...]` re-resolves references on
+  demand. `jit doctor` stays prompt-free: it checks the op binary's
+  presence and signature and counts linked entries, but never
+  resolves (doctor's auth-free guarantee holds).
+- `jit vault export` exports the **reference**, never the resolved
+  value: export is a vault backup, not a 1Password exfiltration. The
+  export doc says so explicitly. A pleasant side effect: an exported
+  reference imported on a second Mac resolves there as soon as op is
+  signed in — linked secrets are the first vault entries that move
+  between machines without moving any secret bytes.
+
+## Automatic linking
+
+Typing one `jit vault link` per field does not scale past a handful
+of secrets, and it is not where the adapter earns its keep. Two
+automatic flows, both built on the same enumeration primitive:
+`op item list --format json | op item get - --format json` returns
+every item's fields in one authenticated invocation, filterable to
+`type=concealed` — one 1Password prompt per run, values held in
+memory only, nothing written anywhere.
+
+References produced by either flow are stored in **ID form**
+(`op://<vault-id>/<item-id>/<field-id>`), not name form: 1Password
+item and vault IDs survive renames, and a rename must not silently
+break every link. The syntax docs support this explicitly — any
+reference segment may be an ID, and segments whose names fall
+outside the reference charset (alphanumeric, `-`, `_`, `.`, space)
+MUST be — so ID form also sidesteps every quoting and encoding
+question a title like `Stripe (prod)` would raise. The friendly name
+lives where it already does, in the jit vault path.
+
+### Bulk link: `jit vault link --from-op [--op-vault <name>]`
+
+Enumerate the chosen 1Password vault (secret-bearing categories:
+API Credential, Login, Password), take each concealed field, and
+propose a jit path per field: `<item-title>/<field-label>`,
+normalized to the vault path charset, single-field items collapsing
+to `<item-title>`. Secure Notes are excluded in v1: a note's body is
+`notesPlain`, not a concealed field, so admitting the category would
+either link nothing or link prose; PEM-keys-in-notes is a real
+pattern and an open question, not a v1 accident. Every run mints one
+`GroupID` per 1Password vault (the vault is the source), so "these
+40 came from the dev vault" survives any later renames, exactly as
+migrate groups do. Then the house pattern: plan → [y/N] → write.
+Rules, all fail-safe:
+
+- An entry already linked to the same reference is "up to date" and
+  skipped — re-running `--from-op` IS the sync, and it is idempotent.
+- An existing entry with different content (a literal secret, or a
+  link elsewhere) is reported and left alone; `--yes` does not
+  override this one, a name collision with a real secret is a
+  decision, not a confirmation.
+- Title/label collisions after normalization are reported and
+  skipped, with the `jit vault link` one-liner to resolve by hand.
+- `--prefix <p>` namespaces everything under `p/` for users whose
+  1Password vault names collide with existing jit paths.
+
+### Migrate dedupe: link instead of copy
+
+The sharper flow. When `jit scan` has found a plaintext secret and
+the user runs `jit migrate --link-1password <path>`, migrate bulk-
+fetches concealed field values once, and any found secret whose
+value **exactly matches** a 1Password field is vaulted as a
+reference to that field instead of as a literal copy — the file is
+neutralized identically either way, and no second copy of the value
+is ever created. Matching compares the value the migrator parsed
+(after its own unquoting) against the field bytes, byte-exact, no
+trimming or normalization: a near-miss silently linking the wrong
+credential is far worse than a miss that falls back to a local copy. No match falls back to today's behavior, a local
+literal. A value matching several 1Password fields links to the
+first, and says so in the plan (same value, same secret; the choice
+is cosmetic).
+
+This closes the loop the issue is really about: a 1Password user's
+`.env` is usually a hand-made plaintext cache of things 1Password
+already holds. Scan finds it, migrate replaces it with pointers, and
+the drift-prone copy is gone from disk without 1Password ever being
+written to.
+
+What "automatic" does NOT mean: no daemon watches 1Password for new
+items, and nothing links without the plan/confirm step. Re-running
+`--from-op` or `--link-1password` is the refresh.
+
+## Interaction with the agent, grants, and mounts
+
+Nothing about the decision points moves:
+
+- **Consent / class AAD**: unchanged — the gate fires at DEK unwrap
+  of the reference envelope, binding whatever class the envelope
+  carries (`1password` for born-as-link entries, the migrator's
+  class for migrate-linked ones), identically in both wrappers.
+- **Process grants**: grant creation pre-unwraps wrapped DEKs exactly
+  as today; what the serve path then decrypts is the reference, and
+  resolution runs wherever `Get` runs.
+- **Decoys need no resolution, verified**: mount decoy content is
+  built from the profile's variable NAMES alone — `DecoyValues` never
+  reads a value, by documented design (`mountmanager.go`). So an
+  unauthorized reader `cat`-ing a mount can never trigger an `op`
+  exec, and linked secrets change nothing on the decoy path.
+- **Mounts already have the right shape**: the service resolves real
+  content EAGERLY at unlock/refresh (`resolveReal` → `setRealIfGen`)
+  and serves granted reads from memory, invalidating on session lock.
+  For linked secrets that means the `op` calls fire at the unlock
+  moment — right after the user's Touch ID, when they are provably
+  present — not at read time. The residual caveat is narrow: a
+  refresh landing while 1Password is locked (or its exec failing)
+  must bound its wait, keep the mount on decoys, record the failure
+  via the existing `lastResolveErr` / serve-audit path, and retry at
+  the next unlock — fail closed, never a hung FIFO reader.
+- **The service has no tty, and op's session model is tty-keyed.**
+  op's authorization is scoped to a terminal session (tty + start
+  time on macOS). jit's CLI-side resolves inherit the user's own
+  terminal session, so an already-authorized terminal pays no extra
+  prompt. The launchd service is different: its op invocations get no
+  terminal session to ride, so each unlock-time refresh may need its
+  own biometric authorization, with the prompt naming the jit service
+  as the asking process — honest disclosure, but it must be verified
+  on a real Mac before the mount path ships, and it is the strongest
+  argument for the batch-resolution follow-up (one authorization per
+  refresh, not one per secret). One genuine symmetry helps: 1Password
+  revokes all CLI authorization when the app locks, the same moment
+  jit's own screen-lock trigger drops its session — the two tools
+  fail closed together.
+
+## Failure modes
+
+Each gets a one-clause error plus the one command to type:
+
+- op not installed → `brew install 1password-cli` (or the app's CLI
+  toggle).
+- op present but unsigned/wrong team → refuse to exec, name the path.
+- Not signed in / app integration off → surface op's stderr, hint
+  `op signin` and the app's Developer settings toggle.
+- Item or field deleted in 1Password → op's error names the missing
+  piece; `jit vault link --verify` finds these in bulk.
+- Reference entry opened by a jit built before v4 → the existing
+  "newer than this jit understands, upgrade jit" path already covers
+  it, unchanged.
+
+## Out of scope for v1 (recorded, not forgotten)
+
+- Writing to 1Password (`jit migrate --to-1password`, push-on-set).
+- Service-account / headless resolution.
+- Batch resolution (one `op inject` exec for a whole profile) — only
+  if per-reference exec latency proves annoying in practice.
+- Secure Note linking (PEM keys stored in note bodies).
+- Per-link account pinning for multi-account users.
+- Other backends (the scheme-dispatched resolver leaves the door
+  open; nothing else is built).
+- `jit scan` awareness of `op://` references already sitting in
+  config files (cheap to detect, natural nudge toward
+  `--link-1password`; a later increment).
+- Any daemonized 1Password sync; manual re-runs of the bulk/migrate
+  flows are the refresh.
+
+## Dependencies and testing
+
+Zero new Go modules: the integration is an exec boundary, consistent
+with the supply-chain stance, and gets a TECH_STACK.md §2 entry naming
+`op` as a trusted-and-verified external binary.
+
+Tests: envelope v4 round-trip, AAD tamper cases, and
+rekey-carries-storage in `internal/vault`; `internal/onepassword` driven against a fake `op`
+script on PATH (exit codes, stderr, newline handling, scheme
+rejection, plus canned `item list`/`item get` JSON exercising the
+bulk-link and migrate-dedupe plans, including collision and
+already-linked cases); signature verification against the real binary exercised
+in the attended QA pass on a real Mac, alongside a live end-to-end
+`link → run → mount` dogfood.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -127,7 +127,10 @@ The honest comparison is about which problem you are solving:
   (`op://…`). jit works the other way around: it stays local, finds the
   plaintext already on your disk, and rewrites the files for you through each
   tool's native credential mechanism. Sensible setup: 1Password for shared
-  team secrets, jit underneath for the copies that land on your machine. More
+  team secrets, jit underneath for the copies that land on your machine. The
+  two also compose: `jit vault link` stores the `op://` reference so the
+  value stays in 1Password and jit delivers it just-in-time, see
+  [Use secrets that live in 1Password](./vault/1password.md). More
   detail in [Why jit](./why-jit.md#if-you-already-use-1password-or-another-password-manager).
 - **`systemd-creds`** does the equivalent job on Linux, TPM-backed, and if you
   are on Linux you should use it. It is not available on macOS, which is the

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -128,8 +128,10 @@ The honest comparison is about which problem you are solving:
   plaintext already on your disk, and rewrites the files for you through each
   tool's native credential mechanism. Sensible setup: 1Password for shared
   team secrets, jit underneath for the copies that land on your machine. The
-  two also compose: `jit vault link` stores the `op://` reference so the
-  value stays in 1Password and jit delivers it just-in-time, see
+  two also compose, automatically: with the 1Password CLI installed,
+  `jit migrate` stores a value that already lives in 1Password as its
+  `op://` reference rather than a copy, and `jit vault link` does the same
+  for one secret by hand, see
   [Use secrets that live in 1Password](./vault/1password.md). More
   detail in [Why jit](./why-jit.md#if-you-already-use-1password-or-another-password-manager).
 - **`systemd-creds`** does the equivalent job on Linux, TPM-backed, and if you

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,8 +93,20 @@ then **[Install](./getting-started/install.md)** →
 
 - [Store, read, and delete secrets](./vault/index.md) - `set`/`get`/`list`/`rm`, rotating a key, undoing a rotation with `history`/`restore`
 - [Back up and restore](./vault/backup-restore.md) - passphrase-encrypted export/import
-- [Use secrets that live in 1Password](./vault/1password.md) - `vault link` stores an `op://` reference; the value stays in 1Password
 - [Maintenance](./vault/maintenance.md) - `rekey`, `duplicates`, `prune`, `orphans`, `clean`, `delete`
+
+## Adapters - secrets that live somewhere else
+
+When a secret's real home is another manager, jit stores a reference
+instead of a copy and resolves it at the moment of use - the other tool
+stays the system of record, jit stays the layer that decides which process
+receives the value, serves decoys to everything else, and writes the audit
+trail.
+
+- [1Password](./vault/1password.md) - `jit migrate` automatically links
+  values that already live in 1Password (an `op://` reference, never a
+  copy); `vault link` links one by hand; `doctor --1password` checks every
+  link still resolves
 
 ## The background service
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ then **[Install](./getting-started/install.md)** →
 
 - [Store, read, and delete secrets](./vault/index.md) - `set`/`get`/`list`/`rm`, rotating a key, undoing a rotation with `history`/`restore`
 - [Back up and restore](./vault/backup-restore.md) - passphrase-encrypted export/import
+- [Use secrets that live in 1Password](./vault/1password.md) - `vault link` stores an `op://` reference; the value stays in 1Password
 - [Maintenance](./vault/maintenance.md) - `rekey`, `duplicates`, `prune`, `orphans`, `clean`, `delete`
 
 ## The background service

--- a/docs/migrate/index.md
+++ b/docs/migrate/index.md
@@ -109,6 +109,12 @@ them would mean one `rm` later breaking every tool that shares it.
 [`jit vault duplicates`](../vault/maintenance.md#jit-vault-duplicates---find-groups-that-hold-the-same-secrets)
 compares the values and says which copies, if any, are safe to retire.
 
+If the [1Password CLI](../vault/1password.md) is installed and signed
+in, migrate also checks each value against your 1Password (once per
+run, after you confirm): a value already stored there is vaulted as an
+`op://` reference instead of a copy, so rotating it in 1Password is the
+only rotation you do. `--no-1password` stores plain copies instead.
+
 ## What each category turns into
 
 Limit a run to specific categories with `--only`

--- a/docs/reference/commands/jit_doctor.md
+++ b/docs/reference/commands/jit_doctor.md
@@ -41,6 +41,13 @@ complaint that is only true of the shell you happen to be in — a CI job
 that doesn't put the shim dir on PATH is not a broken machine. --strict
 makes those count too.
 
+When vault secrets are linked to 1Password, doctor also checks (prompt-free)
+that the op CLI is installed and signature-verified. --1password goes
+further and test-resolves every link, so a reference broken by a deleted or
+renamed item surfaces here instead of at the moment a tool needed it; that
+sweep costs a Touch ID and 1Password may show its own prompt, which is why
+it never runs by default.
+
 Exit 2 is the FINDINGS code, matching `jit scan --fail-on`; exit 1 means
 doctor itself couldn't run (a bad flag, an unreadable vault root), which a
 pipeline needs to tell apart from a machine that is genuinely broken.
@@ -69,6 +76,7 @@ jit doctor [flags]
 ### Options
 
 ```
+      --1password              also test-resolve every 1Password-linked secret (Touch ID, and 1Password may prompt); a dead link becomes a finding
       --format string          output format: "text" (default) or "json" (default "text")
       --orphans                list each unreferenced vault secret; without it the count alone is reported
       --profile string         check only this profile, and skip the service/backup/wrap health sections

--- a/docs/reference/commands/jit_migrate.md
+++ b/docs/reference/commands/jit_migrate.md
@@ -45,6 +45,12 @@ plan and asks for confirmation before touching anything, and every modified
 file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`
 restores a migrated file from that backup.
 
+With the 1Password CLI installed and signed in, a value that already lives
+in 1Password is vaulted as an op:// reference instead of a copy (one
+authenticated check per run, after you confirm), and a value that already IS
+an op:// reference stays one; rotate in 1Password and jit follows.
+--no-1password stores plain copies instead.
+
 ```
 jit migrate <file-or-dir>... [flags]
 ```
@@ -66,6 +72,7 @@ jit migrate <file-or-dir>... [flags]
 ```
       --dry-run        preview the plan without changing anything
       --mount          for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content
+      --no-1password   store plain copies even when a value already lives in 1Password (default: matching values are vaulted as op:// references)
       --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/docs/reference/commands/jit_migrate_path.md
+++ b/docs/reference/commands/jit_migrate_path.md
@@ -13,7 +13,8 @@ jit migrate path <file-or-dir>... [flags]
 ### Options
 
 ```
-      --mount   for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content
+      --mount          for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content
+      --no-1password   store plain copies even when a value already lives in 1Password (default: matching values are vaulted as op:// references)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/commands/jit_vault.md
+++ b/docs/reference/commands/jit_vault.md
@@ -36,6 +36,7 @@ jit vault
 * [jit vault history](jit_vault_history.md)	 - List a secret's archived previous versions
 * [jit vault import](jit_vault_import.md)	 - Restore secrets from a jit vault export file
 * [jit vault init](jit_vault_init.md)	 - Set up the local vault (generates the master encryption key)
+* [jit vault link](jit_vault_link.md)	 - Store a 1Password reference instead of a value
 * [jit vault list](jit_vault_list.md)	 - List stored secret paths (names only, never values)
 * [jit vault orphans](jit_vault_orphans.md)	 - List (and with --prune delete) secrets no profile references
 * [jit vault prune](jit_vault_prune.md)	 - Delete stale encrypted file backups, keeping each file's newest

--- a/docs/reference/commands/jit_vault_link.md
+++ b/docs/reference/commands/jit_vault_link.md
@@ -1,0 +1,55 @@
+## jit vault link
+
+Store a 1Password reference instead of a value
+
+### Synopsis
+
+Links <path> to a secret that stays in 1Password: the vault stores the
+op:// reference (encrypted, like any secret), and every use (jit run,
+credential helpers, mounts) resolves it through the 1Password CLI at
+that moment. Rotate and share the value in 1Password; jit never keeps
+a copy that can drift.
+
+Copy the reference from the 1Password app (field menu > Copy Secret
+Reference). Item and vault IDs also work in place of names and survive
+renames.
+
+The link is test-resolved through `op` first, so a typo or a signed-out
+CLI fails here, not at first use; --no-verify skips that (offline setup).
+Requires the 1Password CLI (`brew install 1password-cli`) with the
+desktop app integration on.
+
+Requires a fresh Touch ID/passcode on every run, never the cached service
+session, same as `jit vault set`.
+
+Overwriting an existing secret asks first; -y/--yes skips that question,
+as it does on every other jit command.
+
+```
+jit vault link <path> <op://vault/item/field> [flags]
+```
+
+### Examples
+
+```
+  jit vault link stripe/live "op://Private/Stripe/credential"
+  jit vault link deploy/token "op://dev/GitHub/credentials/token" --no-verify
+```
+
+### Options
+
+```
+      --no-verify op   skip the trial resolve through op (offline setup)
+  -y, --yes            overwrite an existing secret without confirmation
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit vault](jit_vault.md)	 - Manage the local encrypted secret vault
+

--- a/docs/reference/commands/jit_vault_link.md
+++ b/docs/reference/commands/jit_vault_link.md
@@ -19,6 +19,11 @@ CLI fails here, not at first use; --no-verify skips that (offline setup).
 Requires the 1Password CLI (`brew install 1password-cli`) with the
 desktop app integration on.
 
+First use in a terminal session may show two prompts: jit's Touch ID
+and 1Password's own authorization dialog. Each gates a different thing
+(jit: this process gets the secret; 1Password: this terminal may use
+its CLI) and both remember, so later uses are quiet.
+
 Requires a fresh Touch ID/passcode on every run, never the cached service
 session, same as `jit vault set`.
 

--- a/docs/vault/1password.md
+++ b/docs/vault/1password.md
@@ -1,0 +1,90 @@
+# Use secrets that live in 1Password
+
+`jit vault link` stores a 1Password secret reference instead of a value.
+The secret itself never leaves 1Password: the vault holds the `op://`
+reference (encrypted, like any secret), and every delivery surface
+(`jit run`, credential helpers, mounts, `jit export`) resolves it through
+the 1Password CLI at the moment of use.
+
+Use this when 1Password is already your system of record. You keep
+rotating and sharing the value there; jit stays the layer that decides
+which process receives it, serves decoys to everything else, and writes
+the audit trail. A copy that could drift is never created.
+
+## Requirements
+
+- The 1Password desktop app, signed in.
+- The 1Password CLI: `brew install 1password-cli`.
+- The app integration: in 1Password, Settings > Developer >
+  **Integrate with 1Password CLI** (turn on Touch ID in the app's
+  Security settings if you want fingerprint unlock).
+
+jit is never given an account credential, token, or config. It talks to
+the `op` binary you installed, and refuses to run one that does not carry
+1Password's own Developer ID code signature.
+
+## Link a secret
+
+Copy the reference in the 1Password app: open the item, click the field's
+menu, **Copy Secret Reference**. Then:
+
+```sh
+jit vault link stripe/live "op://Private/Stripe/credential"
+```
+
+jit test-resolves the reference first, so a typo, a signed-out CLI, or a
+deleted item fails here rather than at first use (`--no-verify` skips the
+test for offline setup). Then it stores the reference under a fresh
+Touch ID.
+
+First use in a terminal session can show two prompts, and they are
+different decisions: jit's Touch ID approves *this process getting the
+secret*; 1Password's dialog approves *this terminal using its CLI*. Both
+remember, so later uses are quiet.
+
+Item and vault IDs work in place of names (`op item get <item> --format
+json` shows them) and survive renames in 1Password; names are easier to
+read. Query parameters pass through, so a reference like
+`"op://vault/item/one-time password?attribute=otp"` yields a fresh
+one-time code on every resolve.
+
+## Use it
+
+The linked path works everywhere a vault path works. In a profile:
+
+```yaml
+# .jit/profiles/deploy.yaml
+STRIPE_KEY: stripe/live
+```
+
+```sh
+jit run --profile deploy -- ./deploy.sh
+```
+
+`jit vault get stripe/live` prints the resolved value;
+`--format json` adds the reference it resolved through. `jit vault list
+-l` shows linked entries under the `1password` class.
+
+## Rotation, backup, removal
+
+- **Rotate in 1Password.** The next resolve returns the new value; there
+  is nothing to re-link.
+- **`jit vault export` backs up the reference, never the value**: an
+  export is a vault backup, not a 1Password read. Imported on another
+  Mac, the link resolves there as soon as `op` is signed in.
+- **`jit vault rm`** removes the link like any secret. The 1Password item
+  is untouched; jit never writes to 1Password.
+
+## When it fails
+
+Failures are loud and local: a deleted item, a signed-out CLI, or a
+locked 1Password fails the resolve with op's own error in front of you
+and in `jit audit`. Nothing falls back to a cached value, because there
+is no cached value.
+
+## Limits
+
+Linking is per-secret and manual today. jit never writes to 1Password,
+and the background service resolves at unlock/refresh time, so linked
+secrets in mounts want you present (the same moments Touch ID already
+wants you).

--- a/docs/vault/1password.md
+++ b/docs/vault/1password.md
@@ -23,7 +23,21 @@ jit is never given an account credential, token, or config. It talks to
 the `op` binary you installed, and refuses to run one that does not carry
 1Password's own Developer ID code signature.
 
-## Link a secret
+## Linking happens by itself during migrate
+
+With `op` installed and signed in, every `jit migrate` run checks the
+values it is about to vault against your 1Password (one authenticated
+check per run, after you confirm the plan): a value that byte-exactly
+matches a concealed 1Password field is stored as a reference, not a
+copy, and the mutation log lists each one under a `[1Password]`
+heading. A `.env` you kept for `op run`, full of `op://` values,
+converts the same way: each reference stays a reference, so it keeps
+resolving after migration. Matching is exact, values shorter than 8
+characters never match, and `--no-1password` restores plain copies.
+If the check fails (signed out, app locked), the run continues with
+copies and says so; nothing breaks because 1Password is unavailable.
+
+## Link a secret by hand
 
 Copy the reference in the 1Password app: open the item, click the field's
 menu, **Copy Secret Reference**. Then:
@@ -84,7 +98,9 @@ is no cached value.
 
 ## Limits
 
-Linking is per-secret and manual today. jit never writes to 1Password,
-and the background service resolves at unlock/refresh time, so linked
-secrets in mounts want you present (the same moments Touch ID already
-wants you).
+jit never writes to 1Password, and the background service resolves at
+unlock/refresh time, so linked secrets in mounts want you present (the
+same moments Touch ID already wants you). Migrate links what it
+touches; there is no bulk import of a whole 1Password vault yet, and
+`jit scan` never contacts 1Password at all (it only notes `op://`
+references it sees in flagged files).

--- a/docs/vault/1password.md
+++ b/docs/vault/1password.md
@@ -96,6 +96,18 @@ locked 1Password fails the resolve with op's own error in front of you
 and in `jit audit`. Nothing falls back to a cached value, because there
 is no cached value.
 
+## Check link health
+
+`jit vault list` counts linked secrets in its footer and, with `-l`,
+tags each linked entry; `jit doctor` automatically checks (prompt-free)
+that the op CLI is installed and carries 1Password's own code
+signature whenever linked secrets exist. `jit doctor --1password` goes
+further and test-resolves every link, so a reference broken by a
+deleted or renamed item surfaces as a finding now rather than the
+moment a tool needed the value. That sweep takes one Touch ID (the
+stored references are encrypted like any secret) and 1Password may
+show its own prompt, which is why it never runs by default.
+
 ## Limits
 
 jit never writes to 1Password, and the background service resolves at

--- a/docs/vault/index.md
+++ b/docs/vault/index.md
@@ -137,8 +137,9 @@ credential helper.
 
 ## More
 
-- **[Use secrets that live in 1Password](./1password.md)** - `vault link`
-  stores an `op://` reference; the value stays in 1Password and jit
+- **[Use secrets that live in 1Password](./1password.md)** - migrate links
+  matching values automatically, `vault link` links one by hand; the vault
+  stores an `op://` reference, the value stays in 1Password, and jit
   resolves it on use
 - **[Back up and restore](./backup-restore.md)** - `vault export` /
   `vault import`, for disaster recovery

--- a/docs/vault/index.md
+++ b/docs/vault/index.md
@@ -137,6 +137,9 @@ credential helper.
 
 ## More
 
+- **[Use secrets that live in 1Password](./1password.md)** - `vault link`
+  stores an `op://` reference; the value stays in 1Password and jit
+  resolves it on use
 - **[Back up and restore](./backup-restore.md)** - `vault export` /
   `vault import`, for disaster recovery
 - **[Maintenance](./maintenance.md)** - `rekey` the master key, find

--- a/docs/why-jit.md
+++ b/docs/why-jit.md
@@ -203,12 +203,15 @@ The clean setup: keep 1Password for shared team secrets and non-developer
 logins, and run jit underneath it to protect the copies that land on your
 machine.
 
-The two also compose directly. `jit vault link` stores a 1Password secret
-reference (`op://vault/item/field`) instead of a value: 1Password stays the
-system of record where you rotate and share, and jit resolves the reference
-through the 1Password CLI at the moment of use, while still deciding which
-process gets it, serving decoys to everything else, and keeping the audit
-trail. No copy of the value ever lands in jit's vault. See
+The two also compose directly, and mostly by themselves. With the
+1Password CLI installed, `jit migrate` checks each value it is about to
+vault against your 1Password and stores a match as a secret reference
+(`op://vault/item/field`) instead of a copy; `jit vault link` does the
+same for one secret by hand. 1Password stays the system of record where
+you rotate and share, and jit resolves the reference through the
+1Password CLI at the moment of use, while still deciding which process
+gets it, serving decoys to everything else, and keeping the audit trail.
+No copy of the value ever lands in jit's vault. See
 [Use secrets that live in 1Password](./vault/1password.md).
 
 ## On the roadmap

--- a/docs/why-jit.md
+++ b/docs/why-jit.md
@@ -203,6 +203,14 @@ The clean setup: keep 1Password for shared team secrets and non-developer
 logins, and run jit underneath it to protect the copies that land on your
 machine.
 
+The two also compose directly. `jit vault link` stores a 1Password secret
+reference (`op://vault/item/field`) instead of a value: 1Password stays the
+system of record where you rotate and share, and jit resolves the reference
+through the 1Password CLI at the moment of use, while still deciding which
+process gets it, serving decoys to everything else, and keeping the audit
+trail. No copy of the value ever lands in jit's vault. See
+[Use secrets that live in 1Password](./vault/1password.md).
+
 ## On the roadmap
 
 jit is a local, per-developer tool by design, and it is still early. Landing

--- a/internal/audit/envfile.go
+++ b/internal/audit/envfile.go
@@ -168,6 +168,7 @@ func buildEnvFileFinding(cfg Config, path string, isTemplate bool) (Finding, boo
 	// whole .env is the problem — so this is "start here", the lead credential's
 	// line, chosen after the loop in the same priority the severity switch uses.
 	var prodLine, ipLine, tokenLine, shapedLine, entropyLine int
+	var opRefs int
 	lineNum := 0
 
 	scanner := newLineScanner(file)
@@ -187,6 +188,9 @@ func buildEnvFileFinding(cfg Config, path string, isTemplate bool) (Finding, boo
 		rawValue := unquote(m[3])
 		if IsAlreadyMasked(rawValue) {
 			continue // per RFC.md §4: already-masked values are never evaluated for these signals
+		}
+		if m[1] == "" && IsOpSecretReference(rawValue) {
+			opRefs++ // counted for the report note only; the value itself is reference-suppressed below
 		}
 		if IsProductionIndicator(key) || IsProductionIndicator(rawValue) {
 			if !prodMatch {
@@ -329,6 +333,7 @@ func buildEnvFileFinding(cfg Config, path string, isTemplate bool) (Finding, boo
 	f.FindingType = FindingTypeEnvFilePresent
 	f.FilePath = path
 	f.claimedRawValues = claimedRaw
+	f.OpRefCount = opRefs
 	f.Confidence = ConfidenceHigh
 	f.ProductionIndicatorMatch = prodMatch
 	if ipMatch {

--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -361,7 +361,15 @@ type Finding struct {
 	// Deliberately NOT serialized, on EndLine's contract: key_name already
 	// carries the human name of the kind for NDJSON consumers, so this
 	// stays a rendering input until a consumer asks for more.
-	KeyKind                  string  `json:"-"`
+	KeyKind string `json:"-"`
+	// OpRefCount counts this file's active values that are 1Password
+	// secret references (op://…). Not exposures — IsOpSecretReference is
+	// part of the unresolved-reference suppression — but worth one report
+	// note on a file that IS flagged for other reasons: `jit migrate`
+	// links these rather than copying, so an `op run` file converts
+	// cleanly. EndLine's contract: a rendering input, not NDJSON schema,
+	// until a consumer asks.
+	OpRefCount               int     `json:"-"`
 	ValuePreview             *string `json:"value_preview"`
 	ProductionIndicatorMatch bool    `json:"production_indicator_match"`
 	PublicIPMatch            *string `json:"public_ip_match"`

--- a/internal/audit/opref_test.go
+++ b/internal/audit/opref_test.go
@@ -1,0 +1,103 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package audit
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestIsOpSecretReference(t *testing.T) {
+	yes := []string{
+		"op://Personal/Stripe/credential",
+		"op://Personal/Stripe/api/credential", // section segment
+		"op://vault-id/item-id/field-id",
+		"  op://Personal/Stripe/credential  ", // surrounding space trims
+	}
+	no := []string{
+		"",
+		"op://Personal/Stripe",  // no field
+		"op://",                 //
+		"op:///item/field",      // empty vault
+		"op://Personal/Stripe/", // empty field
+		"sk_live_abcdef123456",
+		"${STRIPE_KEY}",
+		"https://op.example.com/a/b/c",
+	}
+	for _, v := range yes {
+		if !IsOpSecretReference(v) {
+			t.Errorf("IsOpSecretReference(%q) = false, want true", v)
+		}
+		if !LooksLikeUnresolvedReference(v) {
+			t.Errorf("LooksLikeUnresolvedReference(%q) = false; an op:// reference holds no secret at rest", v)
+		}
+	}
+	for _, v := range no {
+		if IsOpSecretReference(v) {
+			t.Errorf("IsOpSecretReference(%q) = true, want false", v)
+		}
+	}
+}
+
+// A flagged .env that mixes plaintext with op:// references: the reference
+// values never drive a finding (unresolved-reference rule), but the file's
+// finding counts them so the report can say migrate keeps them linked.
+func TestEnvFileFindingCountsOpReferences(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	content := "DB_PASSWORD=hunter2hunter2hunter2\n" +
+		"STRIPE_SECRET_KEY=op://Personal/Stripe/credential\n" +
+		"GITHUB_TOKEN=op://Personal/GitHub/token\n" +
+		"# OLD_KEY=op://Personal/Old/key\n" // commented out: not an active value
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	f, ok, err := buildEnvFileFinding(Config{}, path, false)
+	if err != nil {
+		t.Fatalf("buildEnvFileFinding: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected a finding: DB_PASSWORD holds a plaintext credential")
+	}
+	if f.OpRefCount != 2 {
+		t.Errorf("OpRefCount = %d, want 2 (active references only, never commented ones)", f.OpRefCount)
+	}
+}
+
+func TestWriteHumanReportNotesOpReferences(t *testing.T) {
+	key := "DB_PASSWORD"
+	findings := []Finding{{
+		FindingType: FindingTypeEnvFilePresent,
+		Severity:    SeverityHigh,
+		FilePath:    "/Users/alex/code/myapp/.env",
+		KeyName:     &key,
+		Evidence:    "variable name looks like a real credential",
+		Confidence:  ConfidenceHigh,
+		OpRefCount:  2,
+	}}
+	var buf bytes.Buffer
+	WriteHumanReport(&buf, findings, buildScanSummary(Config{}, findings, 0, 0), "/Users/alex")
+	out := buf.String()
+	// termtext.Wrap may break the note anywhere between words at the
+	// ambient width, so assert on a whitespace-normalized copy.
+	flat := strings.Join(strings.Fields(out), " ")
+	if !strings.Contains(flat, "2 values are 1Password references, not exposed") {
+		t.Errorf("expected the op-reference note, got:\n%s", out)
+	}
+	if !strings.Contains(flat, "jit migrate keeps them linked") {
+		t.Errorf("expected the migrate pointer in the note, got:\n%s", out)
+	}
+
+	// And silence without references: the note must not become boilerplate.
+	findings[0].OpRefCount = 0
+	buf.Reset()
+	WriteHumanReport(&buf, findings, buildScanSummary(Config{}, findings, 0, 0), "/Users/alex")
+	if strings.Contains(buf.String(), "1Password") {
+		t.Errorf("no references, no note, got:\n%s", buf.String())
+	}
+}

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -953,6 +953,24 @@ func writeRenderItemText(w io.Writer, item renderItem, home string, cols columns
 		cols.writeFindingRow(w, f, true)
 		fmt.Fprintln(w)
 	}
+	// One note per file, never per finding: op:// values are reference-
+	// suppressed (IsOpSecretReference), so a 1Password user whose flagged
+	// .env mixes plaintext with references learns here that migrate
+	// converts the whole file cleanly — references stay linked, not copied.
+	opRefs := 0
+	for _, f := range item.findings {
+		if f.OpRefCount > opRefs {
+			opRefs = f.OpRefCount
+		}
+	}
+	if opRefs > 0 {
+		fmt.Fprint(w, findingIndent+style.GlyphBranch+" ")
+		termtext.Wrap(w, len(findingIndent)+2, findingIndent+"  ",
+			highlightCmds(fmt.Sprintf("%s, not exposed; `jit migrate` keeps %s linked",
+				countWord(opRefs, "value is a 1Password reference", "values are 1Password references"),
+				pluralWord(opRefs, "it", "them"))))
+		fmt.Fprintln(w)
+	}
 }
 
 // displayEvidence is Evidence prepared for the terminal: when the pattern

--- a/internal/audit/signals.go
+++ b/internal/audit/signals.go
@@ -492,5 +492,23 @@ func LooksLikeUnresolvedReference(v string) bool {
 	if v == "" {
 		return false
 	}
-	return unresolvedReferenceValue.MatchString(v)
+	return IsOpSecretReference(v) || unresolvedReferenceValue.MatchString(v)
+}
+
+// IsOpSecretReference reports whether v is a 1Password secret reference
+// (op://<vault>/<item>/<field>, optionally with a section segment): a
+// value the 1Password CLI resolves at runtime, holding no secret at
+// rest — the `op run` workflow writes exactly these into .env files, so
+// they were already suppressed by the entropy/placeholder gates by
+// accident; this makes it principled, through the same unresolved-
+// reference rule as ${VAR}. Shape check only, mirroring
+// internal/onepassword.ValidateRef without importing it — this package
+// stays portable and audit-only.
+func IsOpSecretReference(v string) bool {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(v), "op://")
+	if !ok {
+		return false
+	}
+	segs := strings.Split(rest, "/")
+	return len(segs) >= 3 && segs[0] != "" && segs[1] != "" && segs[len(segs)-1] != ""
 }

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/consent"
 	"github.com/jitpass/jit/internal/keychainwrap"
+	"github.com/jitpass/jit/internal/onepassword"
 	"github.com/jitpass/jit/internal/screenlock"
 	"github.com/jitpass/jit/internal/selfpath"
 	"github.com/jitpass/jit/internal/termtext"
@@ -150,7 +151,7 @@ var agentRunCmd = &cobra.Command{
 
 		server := agent.NewServer(agent.SocketPath(root), func() agent.MEKFetcher { return keychainwrap.New() }, agentTTL)
 		home, _ := os.UserHomeDir()
-		mounts := &mountManager{root: root, home: home, keyWrapper: server, stdout: stdout, stderr: stderr}
+		mounts := &mountManager{root: root, home: home, keyWrapper: server, refResolver: onepassword.New(), stdout: stdout, stderr: stderr}
 		if agentConsent {
 			// Align the consent cache lifetime with the unlock session's, so an
 			// approval never outlives the session it rode in on. mounts.consent

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -20,6 +20,10 @@ var (
 	doctorOrphans bool
 	doctorWrap    bool
 	doctorStrict  bool
+	// doctor1Password opts into the explicit resolve sweep of every
+	// 1Password-linked secret — see doctor1password.go for why it can
+	// never be the default.
+	doctor1Password bool
 )
 
 // doctorResult is jit doctor's --format json shape. Problems and Warnings
@@ -43,13 +47,21 @@ type doctorResult struct {
 	// breaking a consumer. It was missing while the doc comment above was
 	// promising stability, which is a promise nothing could keep: the only
 	// way to keep it was never to add a field, and this commit adds three.
-	SchemaVersion   int            `json:"schema_version"`
-	Tool            doctorTool     `json:"tool"`
-	ProfilesChecked int            `json:"profiles_checked"`
-	SecretsChecked  int            `json:"secrets_checked"`
-	OK              bool           `json:"ok"`
-	Problems        []checkFinding `json:"problems"`
-	Warnings        []checkFinding `json:"warnings"`
+	SchemaVersion   int        `json:"schema_version"`
+	Tool            doctorTool `json:"tool"`
+	ProfilesChecked int        `json:"profiles_checked"`
+	SecretsChecked  int        `json:"secrets_checked"`
+	// OpLinksChecked/OpLinksOK report the --1password resolve sweep;
+	// absent when it did not run (additive, no schema bump — a consumer
+	// that never asked for the sweep never sees them). omitempty also
+	// drops op_links_ok when every link failed: the 1password_link
+	// problems are the authoritative failure list, so read successes as
+	// checked minus those.
+	OpLinksChecked int            `json:"op_links_checked,omitempty"`
+	OpLinksOK      int            `json:"op_links_ok,omitempty"`
+	OK             bool           `json:"ok"`
+	Problems       []checkFinding `json:"problems"`
+	Warnings       []checkFinding `json:"warnings"`
 }
 
 // doctorSchemaVersion is bumped when a field is removed or its meaning
@@ -109,6 +121,12 @@ var doctorCmd = &cobra.Command{
 		"complaint that is only true of the shell you happen to be in — a CI job\n" +
 		"that doesn't put the shim dir on PATH is not a broken machine. --strict\n" +
 		"makes those count too.\n\n" +
+		"When vault secrets are linked to 1Password, doctor also checks (prompt-free)\n" +
+		"that the op CLI is installed and signature-verified. --1password goes\n" +
+		"further and test-resolves every link, so a reference broken by a deleted or\n" +
+		"renamed item surfaces here instead of at the moment a tool needed it; that\n" +
+		"sweep costs a Touch ID and 1Password may show its own prompt, which is why\n" +
+		"it never runs by default.\n\n" +
 		"Exit 2 is the FINDINGS code, matching `jit scan --fail-on`; exit 1 means\n" +
 		"doctor itself couldn't run (a bad flag, an unreadable vault root), which a\n" +
 		"pipeline needs to tell apart from a machine that is genuinely broken.\n\n" +
@@ -198,6 +216,21 @@ var doctorCmd = &cobra.Command{
 			systemFindings, wrapOK := gatherSystemFindings(root, cwd, v)
 			outcome.Findings = append(outcome.Findings, systemFindings...)
 			outcome.OKChecks = wrapOK
+			opFindings, opOK := onePasswordFindings(v)
+			outcome.Findings = append(outcome.Findings, opFindings...)
+			outcome.OKChecks = append(outcome.OKChecks, opOK...)
+		}
+
+		// The explicit resolve sweep, only ever on request: it costs a
+		// Touch ID (the stored references are sealed like values) and can
+		// pop 1Password's own prompt — see doctor1password.go.
+		if doctor1Password {
+			swFindings, checked, okLinks, err := onePasswordSweep(cmd.ErrOrStderr(), v)
+			if err != nil {
+				return fmt.Errorf("jit doctor: %w", err)
+			}
+			outcome.Findings = append(outcome.Findings, swFindings...)
+			outcome.OpLinksChecked, outcome.OpLinksOK = checked, okLinks
 		}
 
 		if !doctorOrphans {
@@ -294,9 +327,11 @@ func renderDoctorOutcome(cmd *cobra.Command, outcome checkOutcome) error {
 			// ok stays keyed to hard problems whatever --strict does to the
 			// exit code: the field answers "is anything broken", and a flag
 			// about pipeline strictness must not change what a fact means.
-			OK:       len(problems) == 0,
-			Problems: problems,
-			Warnings: warnings,
+			OpLinksChecked: outcome.OpLinksChecked,
+			OpLinksOK:      outcome.OpLinksOK,
+			OK:             len(problems) == 0,
+			Problems:       problems,
+			Warnings:       warnings,
 		}); err != nil {
 			return fmt.Errorf("jit doctor: %w", err)
 		}
@@ -379,6 +414,19 @@ func renderDoctorText(out io.Writer, outcome checkOutcome, problems, warnings []
 		summary := fmt.Sprintf("%s, %s resolve cleanly",
 			countWord(outcome.ProfilesChecked, "profile", "profiles"),
 			countWord(outcome.SecretsChecked, "secret reference", "secret references"))
+		// The sweep's tally joins the verdict only when it ran: in this
+		// branch there are no problems, so checked == ok and the clause is
+		// a plain count. A run with no links says so rather than nothing —
+		// the user explicitly asked, and silence would read as "not run".
+		if doctor1Password {
+			if outcome.OpLinksChecked > 0 {
+				summary += fmt.Sprintf(" · %s %s",
+					countWord(outcome.OpLinksOK, "1Password link", "1Password links"),
+					pluralWord(outcome.OpLinksOK, "resolves", "resolve"))
+			} else {
+				summary += " · no 1Password links to check"
+			}
+		}
 		if len(warnings) > 0 {
 			summary += fmt.Sprintf(" · %s above", countWord(len(warnings), "warning", "warnings"))
 		}
@@ -636,6 +684,14 @@ func findingLabel(f checkFinding) string {
 		return "[storage format]"
 	case kindAudit:
 		return "[audit]"
+	case kind1Password:
+		return "[1password]"
+	case kind1PasswordLink:
+		// Names what was examined on the header, as "[mount: stale]" does:
+		// these come from the explicit --1password resolve sweep, and a bare
+		// "[1password]" beside the automatic section's findings would read
+		// as the same check twice.
+		return "[1password: link]"
 	case kindMCP:
 		return "[mcp]"
 	case kindInstall:
@@ -711,6 +767,7 @@ func init() {
 	doctorCmd.Flags().BoolVar(&doctorOrphans, "orphans", false, "list each unreferenced vault secret; without it the count alone is reported")
 	doctorCmd.Flags().BoolVar(&doctorWrap, "wrap", false, "check only the wrapped-tool shims, without opening the vault (replaces `jit wrap doctor`)")
 	doctorCmd.Flags().BoolVar(&doctorStrict, "strict", false, "exit non-zero on advisory warnings too, for a pipeline that wants them to gate")
+	doctorCmd.Flags().BoolVar(&doctor1Password, "1password", false, "also test-resolve every 1Password-linked secret (Touch ID, and 1Password may prompt); a dead link becomes a finding")
 	doctorCmd.MarkFlagsMutuallyExclusive("wrap", "profile")
 	doctorCmd.MarkFlagsMutuallyExclusive("wrap", "orphans")
 	_ = doctorCmd.RegisterFlagCompletionFunc("format", completeOutputFormat)

--- a/internal/cli/doctor1password.go
+++ b/internal/cli/doctor1password.go
@@ -1,0 +1,162 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// This file is doctor's 1Password surface (design/1password-adapter.md),
+// in two deliberately different halves. The AUTOMATIC half runs on every
+// full doctor sweep and is prompt-free by construction: counting linked
+// secrets reads envelope metadata (no decrypt), and vetting the op binary
+// runs codesign over it without ever executing op. The EXPLICIT half —
+// the --1password resolve sweep — costs a Touch ID (the stored op://
+// references are sealed like values) and can pop 1Password's own
+// authorization prompt per session, so it runs only when asked, the same
+// line the CLI draws between `vault list` and `vault get`.
+
+// doctorOpVerified/doctorOpVersion are seams so tests can pin the op
+// probe: without them every doctor test's output would depend on whether
+// the machine running it has op installed.
+var (
+	doctorOpVerified = onepassword.InstalledVerified
+	doctorOpVersion  = onepassword.Version
+)
+
+// linkedSecretPaths returns the vault paths whose envelopes carry the
+// op-ref storage marker — auth-free (List + Info read metadata only).
+func linkedSecretPaths(v *vault.Vault) ([]string, error) {
+	paths, err := v.List()
+	if err != nil {
+		return nil, err
+	}
+	var linked []string
+	for _, p := range paths {
+		info, err := v.Info(p)
+		if err != nil {
+			continue // integrity findings already cover unreadable envelopes
+		}
+		if info.Storage == vault.StorageOpRef {
+			linked = append(linked, p)
+		}
+	}
+	return linked, nil
+}
+
+// onePasswordFindings is the automatic section: findings when linked
+// secrets exist but cannot possibly resolve (no op, or an op that fails
+// the signature gate), and a --verbose OK line when they can. A vault
+// with no linked secrets reports nothing — there is no 1Password health
+// to have.
+func onePasswordFindings(v *vault.Vault) ([]checkFinding, []string) {
+	linked, err := linkedSecretPaths(v)
+	if err != nil || len(linked) == 0 {
+		return nil, nil
+	}
+	return onePasswordFindingsFor(len(linked))
+}
+
+// onePasswordFindingsFor is the probe half, split from the vault listing
+// so tests can drive it by count with the doctorOp* seams pinned.
+func onePasswordFindingsFor(linkedCount int) ([]checkFinding, []string) {
+	n := countWord(linkedCount, "secret is", "secrets are")
+
+	path, verr := doctorOpVerified()
+	if verr != nil {
+		if path == "" && !onepassword.Installed() {
+			return []checkFinding{{
+				Kind:   kind1Password,
+				Detail: fmt.Sprintf("%s linked to 1Password but the op CLI is not installed; they cannot resolve until it is", n),
+				Action: "`brew install 1password-cli`",
+			}}, nil
+		}
+		return []checkFinding{{
+			Kind:   kind1Password,
+			Detail: fmt.Sprintf("%s linked to 1Password but the op on PATH is not a signature-verified 1Password CLI; jit refuses to resolve through it", n),
+			Action: "`brew reinstall 1password-cli`",
+		}}, nil
+	}
+
+	ok := fmt.Sprintf("%s linked to 1Password", countWord(linkedCount, "secret", "secrets"))
+	if ver := doctorOpVersion(path); ver != "" {
+		ok += " · op " + ver + " signature-verified"
+	} else {
+		ok += " · op signature-verified"
+	}
+	ok += " (`jit doctor --1password` test-resolves each link)"
+	return nil, []string{ok}
+}
+
+// sweepOpLinks is the explicit sweep's core, factored over its two
+// dependencies so tests can drive it without a keychain or an op binary:
+// getStored unwraps one sealed reference (the Touch ID lives behind it),
+// resolve test-resolves it. Returns per-dead-link findings and the tally.
+func sweepOpLinks(paths []string,
+	getStored func(path string) ([]byte, string, error),
+	resolve func(ref string) ([]byte, error)) (findings []checkFinding, checked, ok int) {
+	for _, p := range paths {
+		ref, storage, err := getStored(p)
+		if err != nil {
+			findings = append(findings, checkFinding{
+				Kind:   kind1PasswordLink,
+				Path:   p,
+				Detail: fmt.Sprintf("%s: could not read the stored reference: %v", p, err),
+			})
+			checked++
+			continue
+		}
+		if storage != vault.StorageOpRef {
+			continue // rotated to a literal since the listing; nothing linked to check
+		}
+		checked++
+		value, rerr := resolve(string(ref))
+		for i := range value {
+			value[i] = 0 // the sweep proves resolvability; it must not keep what it proved
+		}
+		for i := range ref {
+			ref[i] = 0
+		}
+		if rerr != nil {
+			findings = append(findings, checkFinding{
+				Kind:   kind1PasswordLink,
+				Path:   p,
+				Detail: fmt.Sprintf("%s does not resolve: %v", p, rerr),
+				Action: fmt.Sprintf("fix the item in 1Password, or `jit vault link %s <op://...>` to relink", p),
+			})
+			continue
+		}
+		ok++
+	}
+	return findings, checked, ok
+}
+
+// onePasswordSweep runs the explicit --1password resolve sweep: list the
+// linked paths (auth-free, from the read-only vault doctor already
+// holds), then open the vault with a fresh Touch ID and test-resolve each
+// reference through the real, signature-verified op.
+func onePasswordSweep(errOut io.Writer, ro *vault.Vault) ([]checkFinding, int, int, error) {
+	linked, err := linkedSecretPaths(ro)
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if len(linked) == 0 {
+		return nil, 0, 0, nil
+	}
+	fmt.Fprintf(errOut, "test-resolving %s with 1Password (its prompt may appear)...\n",
+		countWord(len(linked), "linked secret", "linked secrets"))
+	av, err := openVaultFreshAuth()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	r := onepassword.New()
+	findings, checked, ok := sweepOpLinks(linked, av.GetStored, r.ResolveRef)
+	return findings, checked, ok, nil
+}

--- a/internal/cli/doctor1password_test.go
+++ b/internal/cli/doctor1password_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// withDoctorOp pins the op probe seams for one test.
+func withDoctorOp(t *testing.T, verified func() (string, error), version func(string) string) {
+	t.Helper()
+	prevV, prevVer := doctorOpVerified, doctorOpVersion
+	doctorOpVerified, doctorOpVersion = verified, version
+	t.Cleanup(func() { doctorOpVerified, doctorOpVersion = prevV, prevVer })
+}
+
+func TestOnePasswordFindingsMissingCLI(t *testing.T) {
+	// InstalledVerified fails AND op is genuinely absent from PATH (the
+	// TestMain default probes the real PATH via onepassword.Installed, so
+	// clear it for a deterministic "not installed").
+	t.Setenv("PATH", t.TempDir())
+	withDoctorOp(t, func() (string, error) { return "", errors.New("not installed") }, func(string) string { return "" })
+
+	findings, okLines := onePasswordFindingsFor(3)
+	if len(okLines) != 0 {
+		t.Errorf("unexpected OK lines: %v", okLines)
+	}
+	if len(findings) != 1 || findings[0].Kind != kind1Password {
+		t.Fatalf("findings = %+v, want one kind1Password", findings)
+	}
+	if !strings.Contains(findings[0].Detail, "not installed") || !strings.Contains(findings[0].Action, "brew install") {
+		t.Errorf("finding %+v does not name the missing CLI and the install step", findings[0])
+	}
+}
+
+func TestOnePasswordFindingsUnverifiedBinary(t *testing.T) {
+	// A binary IS on PATH but fails the signature gate: plant a fake op so
+	// onepassword.Installed() sees one.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "op"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil { // #nosec G306 -- a test's fake executable must be executable
+		t.Fatalf("writing fake op: %v", err)
+	}
+	t.Setenv("PATH", dir)
+	withDoctorOp(t, func() (string, error) { return "", errors.New("is not a signature-verified 1Password CLI") }, func(string) string { return "" })
+
+	findings, _ := onePasswordFindingsFor(2)
+	if len(findings) != 1 || findings[0].Kind != kind1Password {
+		t.Fatalf("findings = %+v, want one kind1Password", findings)
+	}
+	if !strings.Contains(findings[0].Detail, "signature-verified") || !strings.Contains(findings[0].Action, "brew reinstall") {
+		t.Errorf("finding %+v does not name the signature failure and the reinstall step", findings[0])
+	}
+}
+
+func TestOnePasswordFindingsHealthyIsOKLine(t *testing.T) {
+	withDoctorOp(t, func() (string, error) { return "/usr/local/bin/op", nil }, func(string) string { return "2.39.0" })
+
+	findings, okLines := onePasswordFindingsFor(3)
+	if len(findings) != 0 {
+		t.Errorf("healthy setup produced findings: %+v", findings)
+	}
+	if len(okLines) != 1 {
+		t.Fatalf("okLines = %v, want exactly one", okLines)
+	}
+	for _, want := range []string{"3 secrets linked to 1Password", "op 2.39.0 signature-verified", "--1password"} {
+		if !strings.Contains(okLines[0], want) {
+			t.Errorf("OK line %q missing %q", okLines[0], want)
+		}
+	}
+}
+
+func TestSweepOpLinks(t *testing.T) {
+	stored := map[string]struct {
+		ref     string
+		storage string
+	}{
+		"myapp/GOOD":    {"op://v/i/f1", vault.StorageOpRef},
+		"myapp/DEAD":    {"op://Personal/Gone/password", vault.StorageOpRef},
+		"myapp/LITERAL": {"plain-value", ""},
+	}
+	var resolvedValue []byte
+	getStored := func(p string) ([]byte, string, error) {
+		if p == "myapp/UNREADABLE" {
+			return nil, "", errors.New("corrupt envelope")
+		}
+		s := stored[p]
+		return []byte(s.ref), s.storage, nil
+	}
+	resolve := func(ref string) ([]byte, error) {
+		if strings.Contains(ref, "Gone") {
+			return nil, errors.New(`"Gone" isn't an item in the "Personal" vault`)
+		}
+		resolvedValue = []byte("live-secret-value")
+		return resolvedValue, nil
+	}
+
+	findings, checked, ok := sweepOpLinks([]string{"myapp/GOOD", "myapp/DEAD", "myapp/LITERAL", "myapp/UNREADABLE"}, getStored, resolve)
+
+	// LITERAL was rotated to a plain value since the listing: not checked.
+	if checked != 3 || ok != 1 {
+		t.Errorf("checked=%d ok=%d, want 3 checked (literal skipped) and 1 ok", checked, ok)
+	}
+	if len(findings) != 2 {
+		t.Fatalf("findings = %+v, want the dead link and the unreadable envelope", findings)
+	}
+	var dead *checkFinding
+	for i := range findings {
+		if findings[i].Path == "myapp/DEAD" {
+			dead = &findings[i]
+		}
+	}
+	if dead == nil || dead.Kind != kind1PasswordLink {
+		t.Fatalf("no kind1PasswordLink finding for the dead link: %+v", findings)
+	}
+	if !strings.Contains(dead.Detail, "does not resolve") || !strings.Contains(dead.Action, "jit vault link myapp/DEAD") {
+		t.Errorf("dead-link finding %+v missing the diagnosis or the relink action", *dead)
+	}
+	// The sweep proves resolvability and must not keep what it proved.
+	if !bytes.Equal(resolvedValue, make([]byte, len(resolvedValue))) {
+		t.Error("resolved value was not wiped after the check")
+	}
+}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jitpass/jit/internal/guard"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/onepassword"
 	"github.com/jitpass/jit/internal/vault"
 	"github.com/jitpass/jit/internal/wrap"
 )
@@ -32,6 +33,61 @@ var (
 	migrateYes    bool
 	migrateOnly   []string
 	migrateMount  bool
+	// migrateNo1Password opts OUT of the 1Password link dedupe
+	// (design/1password-adapter.md): when op is installed, migrate stores
+	// values that already live in 1Password as references by default, and
+	// this flag restores plain copies. Opt-out, not opt-in — installing
+	// and signing in to `op` was the opt-in.
+	migrateNo1Password bool
+)
+
+// opInventory is what the dedupe needs from onepassword.Index, as an
+// interface so tests can pin a fake index without a real `op`.
+type opInventory interface {
+	RefFor(value []byte) (onepassword.IndexEntry, bool)
+	Items() int
+}
+
+// newOpLinkHook builds the vault.LinkOnSet migrate installs for the
+// 1Password dedupe: a value that already IS an op:// reference links as
+// itself (a .env kept for `op run` needs no index, and vaulting the
+// literal would hand `jit run` an unresolvable string); anything else
+// links iff its bytes match a concealed 1Password field. ix may be nil —
+// the enumeration failed — and verbatim links still work. The stored
+// reference is the rename-proof ID form; the recorded row carries the
+// name form for the mutation log.
+func newOpLinkHook(ix opInventory, linked *[]opLinkedRow, offered *int) func(path string, value []byte, meta vault.Meta) (string, bool) {
+	return func(path string, value []byte, _ vault.Meta) (string, bool) {
+		*offered++
+		if s := string(value); onepassword.ValidateRef(s) == nil {
+			*linked = append(*linked, opLinkedRow{path: path, ref: s})
+			return s, true
+		}
+		if ix == nil {
+			return "", false
+		}
+		e, ok := ix.RefFor(value)
+		if !ok {
+			return "", false
+		}
+		*linked = append(*linked, opLinkedRow{path: path, ref: e.NameRef})
+		return e.IDRef, true
+	}
+}
+
+// migrateOpInstalled/migrateOpInventory are the 1Password seams: the
+// plan's announcement line keys off the cheap PATH probe, the post-confirm
+// dedupe off the real enumeration. Vars so tests pin both — the plan must
+// render identically on machines with and without op installed.
+var (
+	migrateOpInstalled = onepassword.Installed
+	migrateOpInventory = func() (opInventory, error) {
+		ix, err := onepassword.New().Inventory()
+		if err != nil {
+			return nil, err
+		}
+		return ix, nil
+	}
 )
 
 // migrateCategories are the --only tokens real (non---dry-run) migrate
@@ -214,7 +270,12 @@ var migrateCmd = &cobra.Command{
 		"naming a file is itself the decision to convert it. Every run prints the full\n" +
 		"plan and asks for confirmation before touching anything, and every modified\n" +
 		"file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`\n" +
-		"restores a migrated file from that backup.",
+		"restores a migrated file from that backup.\n\n" +
+		"With the 1Password CLI installed and signed in, a value that already lives\n" +
+		"in 1Password is vaulted as an op:// reference instead of a copy (one\n" +
+		"authenticated check per run, after you confirm), and a value that already IS\n" +
+		"an op:// reference stays one; rotate in 1Password and jit follows.\n" +
+		"--no-1password stores plain copies instead.",
 	Example: "  jit migrate                     # protect everything the scan found\n" +
 		"  jit migrate ~/proj/.env         # migrate just one file\n" +
 		"  jit migrate ~/proj              # walk one project for .env/tfvars/mcp/npmrc\n" +
@@ -437,6 +498,18 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 	printSkippedFindings(cmd.OutOrStdout(), home, len(historyKeyOnly), "in "+pluralWord(len(historyKeyOnly), "a history file", "history files")+" holding private key material", historyKeyOnly,
 		"jit only matched the -----BEGIN line; the key body is on the lines around it, so redacting would leave the key behind and make the file look clean. Regenerate the key, then delete those lines by hand.")
 
+	// The 1Password announcement is part of the plan the user confirms
+	// against (and --dry-run's, same rendering), but the plan never
+	// contacts op: the PATH probe is the whole test here, because the plan
+	// must stay free of prompts — 1Password's authorization dialog no less
+	// than Touch ID. The real check runs after [y/N].
+	if migrateOpInstalled() && !migrateNo1Password {
+		w := cmd.OutOrStdout()
+		fmt.Fprintln(w, "1Password CLI detected: values already stored there are linked, not")
+		fmt.Fprintln(w, "copied (--no-1password to copy).")
+		fmt.Fprintln(w)
+	}
+
 	if migrateDryRun {
 		out := cmd.OutOrStdout()
 		fmt.Fprintln(out)
@@ -491,6 +564,31 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 		return false, fmt.Errorf("jit migrate: %w", err)
 	}
 	registryPath := mount.RegistryPath(root)
+
+	// 1Password dedupe (design/1password-adapter.md): one authenticated
+	// enumeration up front, then every value about to be vaulted is offered
+	// to the vault's LinkOnSet hook — a byte-exact match, or a value that
+	// already IS an op:// reference (a .env kept for `op run`), stores the
+	// reference instead of a copy. Fails open on purpose: a signed-out CLI
+	// or a locked app degrades to today's literal copies, reported once in
+	// the mutation log. Runs after [y/N] and Touch ID, never at plan time —
+	// the plan's announcement line above is a PATH probe only.
+	var opLinked []opLinkedRow
+	var opOffered, opItemsChecked int
+	var opSkipNote string
+	if migrateOpInstalled() && !migrateNo1Password {
+		fmt.Fprintln(cmd.ErrOrStderr(), "checking 1Password for already-stored values (its prompt may appear)...")
+		ix, invErr := migrateOpInventory()
+		if invErr != nil {
+			opSkipNote = invErr.Error()
+		} else {
+			opItemsChecked = ix.Items()
+		}
+		// The hook stays installed even when the enumeration failed:
+		// verbatim op:// values need no index, and vaulting one as a
+		// literal would hand `jit run` an unresolvable string.
+		v.LinkOnSet = newOpLinkHook(ix, &opLinked, &opOffered)
+	}
 
 	// producedMount records whether this run registered ANY live mount, so the
 	// closing reportAgentStatus knows to send the running service the Refresh
@@ -1039,6 +1137,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 		fmt.Fprintln(out)
 	}
 
+	printOpLinkResult(out, opLinked, opOffered, opItemsChecked, opSkipNote)
+
 	// Best-effort: an unreadable marker means no nudge, never a failed
 	// migrate — everything above already succeeded.
 	if _, recorded, err := vault.LastExport(root); err == nil && !recorded {
@@ -1053,6 +1153,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 	// file it rewrites through this same vault, and those writes must not feed
 	// back into the needle set (nor matter after collection is done).
 	v.OnSet = nil
+	v.LinkOnSet = nil // the sweep's own backups must never be offered for linking
 	cleanup, cleanErr := migrate.CleanAgentCaches(v, home, vaultedSecrets)
 
 	summary.print(out)
@@ -1768,6 +1869,11 @@ func init() {
 	const mountUsage = "for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content"
 	migrateCmd.Flags().BoolVar(&migrateMount, "mount", false, mountUsage)
 	migratePathCmd.Flags().BoolVar(&migrateMount, "mount", false, mountUsage)
+	// Local like --mount: undo/remove never vault a new value, so there is
+	// nothing for them to link.
+	const no1pUsage = "store plain copies even when a value already lives in 1Password (default: matching values are vaulted as op:// references)"
+	migrateCmd.Flags().BoolVar(&migrateNo1Password, "no-1password", false, no1pUsage)
+	migratePathCmd.Flags().BoolVar(&migrateNo1Password, "no-1password", false, no1pUsage)
 
 	migrateCmd.AddCommand(migratePathCmd)
 	rootCmd.AddCommand(migrateCmd)

--- a/internal/cli/migrate1password_test.go
+++ b/internal/cli/migrate1password_test.go
@@ -26,6 +26,8 @@ func TestMain(m *testing.M) {
 	migrateOpInventory = func() (opInventory, error) {
 		return nil, errors.New("1Password inventory pinned off in tests")
 	}
+	doctorOpVerified = func() (string, error) { return "", errors.New("op pinned off in tests") }
+	doctorOpVersion = func(string) string { return "" }
 	os.Exit(m.Run())
 }
 

--- a/internal/cli/migrate1password_test.go
+++ b/internal/cli/migrate1password_test.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// TestMain pins the 1Password seams OFF for the whole package: without
+// this, every migrate test's output would depend on whether the machine
+// running it happens to have `op` installed, and a future test that
+// reaches the post-confirm dedupe would exec the real CLI and block on
+// 1Password's authorization dialog. Tests that want the feature flip the
+// vars themselves and restore them.
+func TestMain(m *testing.M) {
+	migrateOpInstalled = func() bool { return false }
+	migrateOpInventory = func() (opInventory, error) {
+		return nil, errors.New("1Password inventory pinned off in tests")
+	}
+	os.Exit(m.Run())
+}
+
+// withOpInstalled pins the cheap PATH probe for one test.
+func withOpInstalled(t *testing.T, installed bool) {
+	t.Helper()
+	prev := migrateOpInstalled
+	migrateOpInstalled = func() bool { return installed }
+	t.Cleanup(func() { migrateOpInstalled = prev })
+}
+
+func writePlanEnvFixture(t *testing.T, home string) string {
+	t.Helper()
+	target := filepath.Join(home, "proj", ".env")
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("STRIPE_KEY=sk_test_fixture\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return target
+}
+
+// The plan's announcement line keys off the PATH probe alone — never an
+// exec, never a prompt — and prints in --dry-run and the real plan alike
+// (same rendering path). --no-1password silences it: an announcement for
+// a dedupe the user just disabled would be noise.
+func TestMigratePlanAnnounces1Password(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	target := writePlanEnvFixture(t, home)
+
+	withOpInstalled(t, true)
+	out, err := execMigrate(t, target, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "1Password CLI detected") {
+		t.Errorf("expected the 1Password announcement with op installed, got:\n%s", out)
+	}
+
+	out, err = execMigrate(t, target, "--dry-run", "--no-1password")
+	if err != nil {
+		t.Fatalf("jit migrate --dry-run --no-1password: %v", err)
+	}
+	if strings.Contains(out, "1Password CLI detected") {
+		t.Errorf("--no-1password must silence the announcement, got:\n%s", out)
+	}
+}
+
+func TestMigratePlanSilentWithoutOp(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	target := writePlanEnvFixture(t, home)
+
+	withOpInstalled(t, false)
+	out, err := execMigrate(t, target, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate --dry-run: %v", err)
+	}
+	if strings.Contains(out, "1Password") {
+		t.Errorf("no op on PATH must mean no 1Password mention anywhere in the plan, got:\n%s", out)
+	}
+}
+
+// fakeOpIndex is a test opInventory: a value→entry table.
+type fakeOpIndex struct {
+	entries map[string]onepassword.IndexEntry
+	items   int
+}
+
+func (f *fakeOpIndex) RefFor(value []byte) (onepassword.IndexEntry, bool) {
+	e, ok := f.entries[string(value)]
+	return e, ok
+}
+func (f *fakeOpIndex) Items() int { return f.items }
+
+func TestOpLinkHookMatchesAndRecords(t *testing.T) {
+	ix := &fakeOpIndex{
+		entries: map[string]onepassword.IndexEntry{
+			"sk_live_matching_value": {
+				IDRef:   "op://vault-1/item-a/f1",
+				NameRef: "op://Personal/Stripe/credential",
+			},
+		},
+	}
+	var linked []opLinkedRow
+	var offered int
+	hook := newOpLinkHook(ix, &linked, &offered)
+
+	// A matching value links to the ID form and records the name form.
+	ref, ok := hook("myapp/STRIPE_KEY", []byte("sk_live_matching_value"), vault.Meta{})
+	if !ok || ref != "op://vault-1/item-a/f1" {
+		t.Errorf("match returned (%q, %v), want the ID-form reference", ref, ok)
+	}
+
+	// A non-matching value declines.
+	if _, ok := hook("myapp/OTHER", []byte("no-match-here"), vault.Meta{}); ok {
+		t.Error("hook linked a value the index does not hold")
+	}
+
+	// A verbatim op:// value links as itself, no index consulted.
+	ref, ok = hook("myapp/FROM_OP_RUN", []byte("op://Personal/GitHub/token"), vault.Meta{})
+	if !ok || ref != "op://Personal/GitHub/token" {
+		t.Errorf("verbatim reference returned (%q, %v), want itself", ref, ok)
+	}
+
+	if offered != 3 {
+		t.Errorf("offered = %d, want every SetWithMeta counted", offered)
+	}
+	if len(linked) != 2 {
+		t.Fatalf("linked rows = %d, want 2", len(linked))
+	}
+	if linked[0].ref != "op://Personal/Stripe/credential" {
+		t.Errorf("recorded row ref = %q, want the NAME form for display", linked[0].ref)
+	}
+}
+
+func TestOpLinkHookNilIndexStillLinksVerbatimRefs(t *testing.T) {
+	var linked []opLinkedRow
+	var offered int
+	hook := newOpLinkHook(nil, &linked, &offered)
+
+	if _, ok := hook("myapp/PLAIN", []byte("some-ordinary-value"), vault.Meta{}); ok {
+		t.Error("nil index must never match a plain value")
+	}
+	ref, ok := hook("myapp/REF", []byte("op://Personal/X/field"), vault.Meta{})
+	if !ok || ref != "op://Personal/X/field" {
+		t.Errorf("verbatim link with nil index returned (%q, %v), want itself", ref, ok)
+	}
+}
+
+func TestPrintOpLinkResultBlock(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, []opLinkedRow{
+		{path: "myapp/DB_PASSWORD", ref: "op://Personal/Postgres/password"},
+		{path: "myapp/STRIPE_KEY", ref: "op://Personal/Stripe/credential"},
+	}, 12, 14, "")
+	out := buf.String()
+	for _, want := range []string{
+		"[1Password] 2 of 12 linked, not copied · 14 items checked",
+		"myapp/DB_PASSWORD",
+		"op://Personal/Stripe/credential",
+		"Rotate these in 1Password",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the block, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestPrintOpLinkResultSkipNote(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, nil, 5, 0, "op item list failed: account is not signed in")
+	out := buf.String()
+	if !strings.Contains(out, "1Password check skipped") || !strings.Contains(out, "not signed in") {
+		t.Errorf("expected the skip note carrying op's error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "copied, not linked") {
+		t.Errorf("the note must say what happened instead, got:\n%s", out)
+	}
+}
+
+func TestPrintOpLinkResultSilentWhenNothingLinked(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, nil, 12, 14, "")
+	if buf.Len() != 0 {
+		t.Errorf("a run with no links must print nothing, got:\n%s", buf.String())
+	}
+}

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -73,6 +73,7 @@ func execMigrate(t *testing.T, args ...string) (stdout string, err error) {
 	migrateYes = false
 	migrateOnly = nil
 	migrateMount = false // omitted once, and --mount leaking out of one test made the next one plan a mount it never asked for
+	migrateNo1Password = false
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)                 // confirmation prompts go to stderr, capture both streams in order

--- a/internal/cli/migratesummary.go
+++ b/internal/cli/migratesummary.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/profile"
+	"github.com/jitpass/jit/internal/termtext"
 )
 
 // This file is real migrate's MUTATION LOG rendering — the per-category
@@ -30,6 +31,52 @@ import (
 func printMigrateResultCategory(w io.Writer, label string, n int) {
 	fmt.Fprintf(w, "[%s]", label)
 	_, _ = fmt.Fprintf(w, " %d\n", n)
+}
+
+// opLinkedRow is one linked-instead-of-copied secret for the [1Password]
+// mutation-log block: the vault path, and the reference in its
+// human-readable name form (the stored one is rename-proof ID form; the
+// name form is what the user recognizes from the 1Password app).
+type opLinkedRow struct{ path, ref string }
+
+// printOpLinkResult renders the 1Password dedupe outcome after the
+// per-category results (design/1password-adapter.md). Three cases: the
+// check failed (one amber note — the run continued with copies, fail
+// open), nothing matched (silence; an empty block would be noise on every
+// run op is merely installed for), or N linked (the block naming each
+// path → reference, so the user knows exactly which secrets now follow
+// 1Password rotation).
+func printOpLinkResult(w io.Writer, linked []opLinkedRow, offered, itemsChecked int, skipNote string) {
+	if skipNote != "" {
+		_, _ = cWarn.Fprint(w, glyphWarn)
+		wrapBody(w, 1, "  ", " 1Password check skipped: "+skipNote+"; values were copied, not linked")
+		fmt.Fprintln(w)
+		return
+	}
+	if len(linked) == 0 {
+		return
+	}
+	widest := 0
+	for _, r := range linked {
+		if len(r.path) > widest {
+			widest = len(r.path)
+		}
+	}
+	printMigrateResultCategoryLabel(w, fmt.Sprintf("%d of %d linked, not copied · %s checked", len(linked), offered, countWord(itemsChecked, "item", "items")))
+	for _, r := range linked {
+		// Truncate the variable tail rather than wrap: one row per secret.
+		row := fmt.Sprintf("  %-*s %s %s", widest, r.path, glyphAction, r.ref)
+		fmt.Fprintln(w, truncateEnd(row, termtext.Width()))
+	}
+	fmt.Fprintln(w, "  Rotate these in 1Password; jit follows. The vault holds the")
+	fmt.Fprintln(w, "  reference, never a copy.")
+	fmt.Fprintln(w)
+}
+
+// printMigrateResultCategoryLabel is printMigrateResultCategory for a
+// header whose tail is richer than a bare count.
+func printMigrateResultCategoryLabel(w io.Writer, tail string) {
+	fmt.Fprintf(w, "[1Password] %s\n", tail)
 }
 
 // migrateSummary collects everything that used to print inline, once per

--- a/internal/cli/mountmanager.go
+++ b/internal/cli/mountmanager.go
@@ -98,9 +98,17 @@ type mountManager struct {
 	root       string
 	home       string
 	keyWrapper vault.KeyWrapper
-	consent    readerConsent
-	stdout     io.Writer
-	stderr     io.Writer
+	// refResolver resolves reference-kind secrets (1Password links) during
+	// resolveReal — one shared instance, so the op binary's signature is
+	// verified once per service process, not once per refresh. Resolution
+	// fires only at unlock/refresh (the user just passed Touch ID, so they
+	// are present for a 1Password prompt too) and is bounded by the
+	// resolver's own timeout; a failure keeps the mount on decoys via the
+	// existing lastResolveErr path. Nil in tests that never resolve.
+	refResolver vault.RefResolver
+	consent     readerConsent
+	stdout      io.Writer
+	stderr      io.Writer
 
 	// serveAudit turns mount reads into durable `jit audit` events, collapsed
 	// so a watcher loop can't evict the trail it is being written to. Zero
@@ -806,7 +814,7 @@ func (m *mountManager) start() {
 		fmt.Fprintf(m.stderr, "jit service: determining device recipient ID: %v\n", err)
 		return
 	}
-	v := &vault.Vault{Root: m.root, KeyWrapper: m.keyWrapper, RecipientID: deviceID}
+	v := &vault.Vault{Root: m.root, KeyWrapper: m.keyWrapper, RecipientID: deviceID, RefResolver: m.refResolver}
 	m.resolveReal(entries, v)
 }
 

--- a/internal/cli/mountswap.go
+++ b/internal/cli/mountswap.go
@@ -107,7 +107,7 @@ func (m *mountManager) resumeServing(entry mount.Entry) {
 	if err != nil {
 		return
 	}
-	v := &vault.Vault{Root: m.root, KeyWrapper: m.keyWrapper, RecipientID: deviceID}
+	v := &vault.Vault{Root: m.root, KeyWrapper: m.keyWrapper, RecipientID: deviceID, RefResolver: m.refResolver}
 	// Re-arm real content in memory after a run's swap ends; it stays decoy
 	// to every reader until the next run-scoped grant, never auto-revealed.
 	m.resolveReal([]mount.Entry{entry}, v)

--- a/internal/cli/profilecheck.go
+++ b/internal/cli/profilecheck.go
@@ -172,6 +172,21 @@ const (
 	// that the README calls optional, which means the people who never read
 	// it are exactly the people who never learn the flags exist.
 	kindCompletion checkKind = "completion"
+	// kind1Password: the automatic, prompt-free 1Password section — vault
+	// secrets are linked to 1Password (envelope storage "op-ref") but the
+	// op CLI is missing or the binary on PATH fails the Developer ID
+	// signature gate, so those secrets cannot resolve. A hard problem, not
+	// advisory: a linked secret that cannot resolve is as broken as a
+	// missing one. Emitted only when linked secrets exist; a machine with
+	// no links has no 1Password health to report.
+	kind1Password checkKind = "1password"
+	// kind1PasswordLink: one linked secret whose reference no longer
+	// resolves — the item was deleted, a name-form reference broke on a
+	// rename, or the field is gone. Found only by the explicit
+	// `jit doctor --1password` sweep: the references are sealed like values
+	// (reading them costs a Touch ID) and each resolve can pop 1Password's
+	// own prompt, so this can never run on the default, prompt-free path.
+	kind1PasswordLink checkKind = "1password_link"
 	// kindJitPath: an artifact `jit migrate` rewrote records an absolute jit
 	// path that will not keep working — the binary is already gone, or it is
 	// a version-numbered Homebrew copy the next upgrade deletes.
@@ -213,6 +228,7 @@ var allCheckKinds = []checkKind{
 	kindMountStale, kindVaultKey, kindRekey, kindLegacyEnvelope,
 	kindAudit, kindMCP,
 	kindInstall, kindJitPath, kindJitPathUpgrade, kindCompletion,
+	kind1Password, kind1PasswordLink,
 }
 
 // warning reports whether a finding of this kind is advisory (does not fail
@@ -315,7 +331,13 @@ type checkOutcome struct {
 	// installation is healthy was the one thing it could say that the rollup,
 	// which only ever reported failures, could not.
 	OKChecks []string
-	Findings []checkFinding
+	// OpLinksChecked/OpLinksOK are the `--1password` sweep's tally, for the
+	// closing summary line and the JSON snapshot. Zero checked means the
+	// sweep did not run or found no links; each failure is its own
+	// kind1PasswordLink finding.
+	OpLinksChecked int
+	OpLinksOK      int
+	Findings       []checkFinding
 	// Cwd is where the profile sweep looked, retained so a zero-profile run
 	// can say something more useful than "nothing here".
 	Cwd string

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jitpass/jit/internal/keychainwrap"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/onepassword"
 	"github.com/jitpass/jit/internal/pasteboard"
 	"github.com/jitpass/jit/internal/profile"
 	"github.com/jitpass/jit/internal/termtext"
@@ -2722,6 +2723,7 @@ func openVaultFreshAuth() (*vault.Vault, error) {
 		Root:        root,
 		KeyWrapper:  keychainwrap.New(),
 		RecipientID: deviceID,
+		RefResolver: onepassword.New(),
 	}, nil
 }
 
@@ -2760,6 +2762,7 @@ func openVault() (*vault.Vault, error) {
 		Root:        root,
 		KeyWrapper:  kw,
 		RecipientID: deviceID,
+		RefResolver: onepassword.New(),
 	}, nil
 }
 

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -86,12 +86,16 @@ type vaultListResult struct {
 
 // vaultSecretJSON is one secret in a --format json listing: its path plus the
 // same header metadata Info exposes, never a value (list never decrypts).
+// Storage is the honest "is this a 1Password link" marker for scripts —
+// class covers only born-as-link entries, while a migrate-linked secret
+// keeps its migrator's class and is a link by storage alone.
 type vaultSecretJSON struct {
 	Path           string `json:"path"`
 	Version        int    `json:"version,omitempty"`
 	Class          string `json:"class,omitempty"`
 	GroupID        string `json:"group_id,omitempty"`
 	Origin         string `json:"origin,omitempty"`
+	Storage        string `json:"storage,omitempty"`
 	OriginSeenUnix int64  `json:"origin_seen_unix,omitempty"`
 	CreatedUnix    int64  `json:"created_unix,omitempty"`
 	UpdatedUnix    int64  `json:"updated_unix,omitempty"`
@@ -1277,6 +1281,7 @@ var vaultListCmd = &cobra.Command{
 					OriginSeenUnix: info.OriginSeenUnix,
 					CreatedUnix:    info.CreatedUnix,
 					UpdatedUnix:    info.UpdatedUnix,
+					Storage:        info.Storage,
 				})
 			}
 			return writeJSON(cmd.OutOrStdout(), out)

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -218,17 +218,32 @@ func printVaultList(out io.Writer, secrets, backups []string, showBackups, group
 	}
 	secretsWord := pluralWord(len(secrets), "secret", "secrets")
 	backupsWord := pluralWord(len(backups), "backup", "backups")
+	// The footer states the linked count once for the whole vault — the
+	// prompt-free answer to "which of my secrets follow 1Password" (the
+	// per-row tag needs -l). Absent when nothing is linked.
+	linkedClause := ""
+	if meta != nil {
+		linked := 0
+		for _, p := range secrets {
+			if meta[p].Storage == vault.StorageOpRef {
+				linked++
+			}
+		}
+		if linked > 0 {
+			linkedClause = fmt.Sprintf(", %d linked to 1Password", linked)
+		}
+	}
 	switch {
 	case len(backups) == 0:
-		fmt.Fprintf(out, "\n%d %s stored.\n", len(secrets), secretsWord)
+		fmt.Fprintf(out, "\n%d %s stored%s.\n", len(secrets), secretsWord, linkedClause)
 	case len(secrets) == 0 && showBackups:
 		writeVaultFooter(out, true, hlCmds(fmt.Sprintf("No secrets stored yet, %d encrypted file %s kept for `jit migrate undo`.", len(backups), backupsWord)))
 	case len(secrets) == 0:
 		writeVaultFooter(out, false, hlCmds(fmt.Sprintf("No secrets stored yet, %d encrypted file %s kept for `jit migrate undo` (list with --all).", len(backups), backupsWord)))
 	case showBackups:
-		writeVaultFooter(out, true, hlCmds(fmt.Sprintf("%d %s stored, plus %d encrypted file %s kept for `jit migrate undo`.", len(secrets), secretsWord, len(backups), backupsWord)))
+		writeVaultFooter(out, true, hlCmds(fmt.Sprintf("%d %s stored%s, plus %d encrypted file %s kept for `jit migrate undo`.", len(secrets), secretsWord, linkedClause, len(backups), backupsWord)))
 	default:
-		writeVaultFooter(out, true, hlCmds(fmt.Sprintf("%d %s stored, plus %d encrypted file %s kept for `jit migrate undo` (list with --all).", len(secrets), secretsWord, len(backups), backupsWord)))
+		writeVaultFooter(out, true, hlCmds(fmt.Sprintf("%d %s stored%s, plus %d encrypted file %s kept for `jit migrate undo` (list with --all).", len(secrets), secretsWord, linkedClause, len(backups), backupsWord)))
 	}
 	// Duplicate-group nudge only decorates the default terminal view — a
 	// piped/grep listing (grouped == false) and the provenance axes stay
@@ -860,6 +875,20 @@ func secretMetaSuffix(info vault.SecretInfo) string {
 		class = "unknown"
 	}
 	parts := []string{class}
+	// Linkedness is the storage marker's, never the class's: a migrated
+	// secret keeps its dotenv/aws class when the dedupe links it, so
+	// without this tag nothing in the listing separates a link from a
+	// copy. The two suppressions keep it honest without stuttering: a
+	// born-as-link row's class already says "1password", and the inverse
+	// case — a 1password-class secret whose link was overwritten by a
+	// literal set — is exactly when the reader must be told it is NOT
+	// linked anymore.
+	switch {
+	case info.Storage == vault.StorageOpRef && info.Class != vault.ClassOnePassword:
+		parts = append(parts, "linked to 1Password")
+	case info.Storage == "" && info.Class == vault.ClassOnePassword:
+		parts = append(parts, "local copy")
+	}
 	if info.UpdatedUnix > 0 {
 		parts = append(parts, "updated "+humanAgo(time.Since(time.Unix(info.UpdatedUnix, 0)))+" ago")
 	}

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -112,7 +112,13 @@ type vaultGetResult struct {
 	OriginSeenUnix int64  `json:"origin_seen_unix,omitempty"`
 	CreatedUnix    int64  `json:"created_unix,omitempty"`
 	UpdatedUnix    int64  `json:"updated_unix,omitempty"`
-	Value          string `json:"value"`
+	// Storage/Reference appear only for a linked secret (`jit vault
+	// link`): the storage marker and the op:// reference the value was
+	// resolved through — Value still carries the resolved value, so a
+	// script consuming .value never cares whether the secret is linked.
+	Storage   string `json:"storage,omitempty"`
+	Reference string `json:"reference,omitempty"`
+	Value     string `json:"value"`
 }
 
 // splitBackupPaths separates a vault listing into user secrets and jit
@@ -1051,6 +1057,16 @@ var vaultGetCmd = &cobra.Command{
 			// value is in hand, so a header hiccup drops metadata, never the
 			// whole get.
 			info, _ := v.Info(args[0])
+			// For a linked secret, also show WHICH 1Password field the value
+			// came from. GetStored re-decrypts the stored reference; the
+			// Wrapper's MEK cache means no second prompt (same reason the
+			// Info read above is free).
+			var reference string
+			if info.Storage == vault.StorageOpRef {
+				if ref, _, err := v.GetStored(args[0]); err == nil {
+					reference = string(ref)
+				}
+			}
 			return writeJSON(cmd.OutOrStdout(), vaultGetResult{
 				Path:           args[0],
 				Version:        info.Version,
@@ -1060,6 +1076,8 @@ var vaultGetCmd = &cobra.Command{
 				OriginSeenUnix: info.OriginSeenUnix,
 				CreatedUnix:    info.CreatedUnix,
 				UpdatedUnix:    info.UpdatedUnix,
+				Storage:        info.Storage,
+				Reference:      reference,
 				Value:          string(value),
 			})
 		}

--- a/internal/cli/vaultlink.go
+++ b/internal/cli/vaultlink.go
@@ -39,6 +39,10 @@ var vaultLinkCmd = &cobra.Command{
 		"CLI fails here, not at first use; --no-verify skips that (offline setup).\n" +
 		"Requires the 1Password CLI (`brew install 1password-cli`) with the\n" +
 		"desktop app integration on.\n\n" +
+		"First use in a terminal session may show two prompts: jit's Touch ID\n" +
+		"and 1Password's own authorization dialog. Each gates a different thing\n" +
+		"(jit: this process gets the secret; 1Password: this terminal may use\n" +
+		"its CLI) and both remember, so later uses are quiet.\n\n" +
 		"Requires a fresh Touch ID/passcode on every run, never the cached service\n" +
 		"session, same as `jit vault set`.\n\n" +
 		"Overwriting an existing secret asks first; -y/--yes skips that question,\n" +
@@ -62,6 +66,11 @@ var vaultLinkCmd = &cobra.Command{
 		// it, and where "op is not installed / not signed in / item gone"
 		// surfaces without costing a fingerprint on a doomed link.
 		if !vaultLinkNoVerify {
+			// The cue exists because op can block silently on 1Password's
+			// authorization dialog — without it, first use reads as a hang
+			// and nothing on screen says which prompt belongs to whom.
+			// stderr, so stdout stays byte-clean for pipes.
+			fmt.Fprintln(cmd.ErrOrStderr(), "checking with 1Password (its prompt may appear)...")
 			if _, err := onepassword.New().ResolveRef(ref); err != nil {
 				return fmt.Errorf("jit vault link: %w (use --no-verify to link anyway)", err)
 			}

--- a/internal/cli/vaultlink.go
+++ b/internal/cli/vaultlink.go
@@ -1,0 +1,105 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// jit vault link — store a 1Password secret reference instead of a value
+// (design/1password-adapter.md, issue #60). The vault entry holds the
+// op:// URI, encrypted and consent-gated like any secret; every delivery
+// surface (run, credential helpers, mounts, export) resolves it through
+// the 1Password CLI at the moment of use, so 1Password stays the system
+// of record and jit never keeps a drifting copy of the value.
+
+var (
+	vaultLinkYes      bool
+	vaultLinkNoVerify bool
+)
+
+var vaultLinkCmd = &cobra.Command{
+	Use:   "link <path> <op://vault/item/field>",
+	Short: "Store a 1Password reference instead of a value",
+	Long: "Links <path> to a secret that stays in 1Password: the vault stores the\n" +
+		"op:// reference (encrypted, like any secret), and every use (jit run,\n" +
+		"credential helpers, mounts) resolves it through the 1Password CLI at\n" +
+		"that moment. Rotate and share the value in 1Password; jit never keeps\n" +
+		"a copy that can drift.\n\n" +
+		"Copy the reference from the 1Password app (field menu > Copy Secret\n" +
+		"Reference). Item and vault IDs also work in place of names and survive\n" +
+		"renames.\n\n" +
+		"The link is test-resolved through `op` first, so a typo or a signed-out\n" +
+		"CLI fails here, not at first use; --no-verify skips that (offline setup).\n" +
+		"Requires the 1Password CLI (`brew install 1password-cli`) with the\n" +
+		"desktop app integration on.\n\n" +
+		"Requires a fresh Touch ID/passcode on every run, never the cached service\n" +
+		"session, same as `jit vault set`.\n\n" +
+		"Overwriting an existing secret asks first; -y/--yes skips that question,\n" +
+		"as it does on every other jit command.",
+	Example: "  jit vault link stripe/live \"op://Private/Stripe/credential\"\n" +
+		"  jit vault link deploy/token \"op://dev/GitHub/credentials/token\" --no-verify",
+	Args:              requireArgs(2, 2, "a secret path and an op:// secret reference"),
+	ValidArgsFunction: completeVaultPaths,
+	SilenceUsage:      true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, ref := args[0], args[1]
+
+		// Shape first: a typo'd reference must cost nothing — no op exec,
+		// no Touch ID.
+		if err := onepassword.ValidateRef(ref); err != nil {
+			return fmt.Errorf("jit vault link: %w", err)
+		}
+
+		// Trial resolve BEFORE any Touch ID: this is where 1Password's own
+		// authorization prompt fires, at setup time where the user expects
+		// it, and where "op is not installed / not signed in / item gone"
+		// surfaces without costing a fingerprint on a doomed link.
+		if !vaultLinkNoVerify {
+			if _, err := onepassword.New().ResolveRef(ref); err != nil {
+				return fmt.Errorf("jit vault link: %w (use --no-verify to link anyway)", err)
+			}
+		}
+
+		// Fresh auth on every sensitive vault command, never the cached
+		// agent session — writing a pointer is writing a secret: whoever
+		// controls the reference controls what every consumer of this path
+		// receives.
+		v, err := openVaultFreshAuth()
+		if err != nil {
+			return fmt.Errorf("jit vault link: %w", err)
+		}
+
+		if !vaultLinkYes {
+			exists, err := v.Exists(path)
+			if err != nil {
+				return fmt.Errorf("jit vault link: %w", err)
+			}
+			if exists && !confirmOverwrite(cmd, path) {
+				fmt.Fprintln(cmd.OutOrStdout(), "Aborted.")
+				return nil
+			}
+		}
+
+		// Born as a link: its only source IS 1Password (ClassOnePassword).
+		// A rotation of an existing path keeps its birth class, same as
+		// every Set.
+		if err := v.SetReference(path, ref, vault.Meta{Class: vault.ClassOnePassword}); err != nil {
+			return fmt.Errorf("jit vault link: %w", err)
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Linked %s\n", path)
+		return nil
+	},
+}
+
+func init() {
+	vaultLinkCmd.Flags().BoolVarP(&vaultLinkYes, "yes", "y", false, "overwrite an existing secret without confirmation")
+	vaultLinkCmd.Flags().BoolVar(&vaultLinkNoVerify, "no-verify", false, "skip the trial resolve through `op` (offline setup)")
+	vaultCmd.AddCommand(vaultLinkCmd)
+}

--- a/internal/cli/vaultlink_test.go
+++ b/internal/cli/vaultlink_test.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestVaultLinkRejectsBadReferenceBeforeAnythingElse confirms a malformed
+// reference fails shape validation before the trial resolve and before
+// openVaultFreshAuth — a typo must cost neither an op exec nor a Touch ID
+// prompt (same fail-before-prompting discipline as vault list/import).
+func TestVaultLinkRejectsBadReferenceBeforeAnythingElse(t *testing.T) {
+	vaultLinkYes, vaultLinkNoVerify = false, false
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+
+	for _, ref := range []string{"not-a-reference", "https://example.com/x/y", "op://vault-only"} {
+		rootCmd.SetArgs([]string{"vault", "link", "some/path", ref})
+		err := rootCmd.Execute()
+		if err == nil {
+			t.Fatalf("vault link accepted %q, want a shape error", ref)
+		}
+		if !strings.Contains(err.Error(), "reference") {
+			t.Errorf("error for %q does not explain the reference is bad: %v", ref, err)
+		}
+	}
+}
+
+// TestVaultLinkTrialResolveFailsClosedOnAnUnsignedOp pins the order of
+// operations from the other side: with a PATH-planted fake `op`, the
+// trial resolve must fail on signature verification — before any Touch ID
+// — and the error must point at --no-verify as the offline escape.
+func TestVaultLinkTrialResolveFailsClosedOnAnUnsignedOp(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "op")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nprintf resolved\n"), 0o755); err != nil { // #nosec G306 -- a test's fake executable must be executable
+		t.Fatalf("writing fake op: %v", err)
+	}
+	t.Setenv("PATH", dir)
+
+	vaultLinkYes, vaultLinkNoVerify = false, false
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetArgs([]string{"vault", "link", "some/path", "op://vaultid/itemid/fieldid"})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("vault link succeeded through an unsigned fake op, want a signature failure")
+	}
+	if !strings.Contains(err.Error(), "signature-verified") {
+		t.Errorf("error does not name the signature check: %v", err)
+	}
+	if !strings.Contains(err.Error(), "--no-verify") {
+		t.Errorf("error does not offer --no-verify: %v", err)
+	}
+}

--- a/internal/cli/vaultlist1password_test.go
+++ b/internal/cli/vaultlist1password_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// The -l per-row tag is the storage marker's, with two suppressions that
+// keep it honest without stuttering: a born-as-link row's class already
+// says 1password, and a 1password-class secret whose link was overwritten
+// by a literal is exactly when the reader must be told it ISN'T linked.
+func TestSecretMetaSuffixLinkTag(t *testing.T) {
+	cases := []struct {
+		name    string
+		info    vault.SecretInfo
+		want    string
+		wantNot string
+	}{
+		{"migrate-linked keeps class, gains tag",
+			vault.SecretInfo{Class: vault.ClassDotenv, Storage: vault.StorageOpRef},
+			"linked to 1Password", "local copy"},
+		{"plain literal untouched",
+			vault.SecretInfo{Class: vault.ClassDotenv},
+			"dotenv", "1Password"},
+		{"born-as-link does not stutter",
+			vault.SecretInfo{Class: vault.ClassOnePassword, Storage: vault.StorageOpRef},
+			"1password", "linked to 1Password"},
+		{"overwritten link says local copy",
+			vault.SecretInfo{Class: vault.ClassOnePassword},
+			"local copy", "linked to"},
+	}
+	for _, c := range cases {
+		got := secretMetaSuffix(c.info)
+		if !strings.Contains(got, c.want) {
+			t.Errorf("%s: suffix %q missing %q", c.name, got, c.want)
+		}
+		if c.wantNot != "" && strings.Contains(got, c.wantNot) {
+			t.Errorf("%s: suffix %q must not contain %q", c.name, got, c.wantNot)
+		}
+	}
+}
+
+func TestVaultListFooterCountsLinks(t *testing.T) {
+	secrets := []string{"myapp/A", "myapp/B", "myapp/C"}
+	meta := map[string]vault.SecretInfo{
+		"myapp/A": {Class: vault.ClassDotenv, Storage: vault.StorageOpRef},
+		"myapp/B": {Class: vault.ClassDotenv, Storage: vault.StorageOpRef},
+		"myapp/C": {Class: vault.ClassDotenv},
+	}
+	var buf bytes.Buffer
+	printVaultList(&buf, secrets, nil, false, false, false, meta, "path")
+	if !strings.Contains(buf.String(), "3 secrets stored, 2 linked to 1Password.") {
+		t.Errorf("footer missing the linked count, got:\n%s", buf.String())
+	}
+
+	// And silence when nothing is linked — the clause must not become
+	// boilerplate on every vault.
+	buf.Reset()
+	printVaultList(&buf, secrets, nil, false, false, false, map[string]vault.SecretInfo{}, "path")
+	if strings.Contains(buf.String(), "1Password") {
+		t.Errorf("no links, no clause, got:\n%s", buf.String())
+	}
+}

--- a/internal/consent/policy.go
+++ b/internal/consent/policy.go
@@ -41,6 +41,16 @@ var credentialClasses = map[string]bool{
 	"pypirc":        true,
 	"k8s_secret":    true,
 	"shell_history": true,
+	// 1password is a secret linked from the user's password manager (`jit
+	// vault link` — the vault holds an op:// reference, resolved through
+	// the 1Password CLI at read time). Gated: something kept in a password
+	// manager is the definition of a credential a process should not
+	// obtain silently, and the envelope's class cannot say what KIND of
+	// credential the link points at, so the safe half of the partition is
+	// the only defensible default. 1Password's own biometric authorization
+	// is a different decision (release from ITS vault) and does not
+	// substitute for per-process consent here.
+	"1password": true,
 }
 
 // ungatedClasses is the other half of the partition, listed rather than implied

--- a/internal/onepassword/inventory.go
+++ b/internal/onepassword/inventory.go
@@ -1,0 +1,229 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"sort"
+	"time"
+)
+
+// minLinkableValueLen is the floor under which a 1Password field value is
+// never indexed for matching: a `PASSWORD=admin` line must not silently
+// link to whichever item also says "admin". Byte-exact matching plus this
+// floor is the whole anti-collision story — no fuzz, no normalization.
+const minLinkableValueLen = 8
+
+// Index maps the SHA-256 of each concealed 1Password field value to the
+// reference naming that field. It holds hashes, never the values: the
+// enumeration's plaintext lives only inside Inventory's call frame, and
+// what migrate keeps around for the duration of a run is unlinkable
+// digests plus op:// strings.
+type Index struct {
+	byHash map[[sha256.Size]byte]IndexEntry
+	items  int
+}
+
+// IndexEntry is one linkable 1Password field. IDRef is the rename-proof
+// form built from the item JSON's own vault/item/field ids — what gets
+// stored. NameRef is the human-readable form for display; it may contain
+// spaces or other characters outside the reference charset, which is fine
+// on screen and exactly why it is not the stored one.
+type IndexEntry struct {
+	IDRef   string
+	NameRef string
+}
+
+// RefFor returns the entry for a value, matching byte-exact via hash.
+func (ix *Index) RefFor(value []byte) (IndexEntry, bool) {
+	if ix == nil || len(value) < minLinkableValueLen {
+		return IndexEntry{}, false
+	}
+	e, ok := ix.byHash[sha256.Sum256(value)]
+	return e, ok
+}
+
+// Items reports how many 1Password items the enumeration covered — the
+// honest "checked N items" number for the mutation log.
+func (ix *Index) Items() int {
+	if ix == nil {
+		return 0
+	}
+	return ix.items
+}
+
+// opItem is the slice of `op item get --format json` output this package
+// reads. Fields it doesn't name are ignored on purpose: op's schema is
+// theirs to evolve, and everything here degrades to "field not indexed".
+type opItem struct {
+	ID    string `json:"id"`
+	Vault struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"vault"`
+	Title  string `json:"title"`
+	Fields []struct {
+		ID        string `json:"id"`
+		Type      string `json:"type"`
+		Label     string `json:"label"`
+		Value     string `json:"value"`
+		Reference string `json:"reference"`
+	} `json:"fields"`
+}
+
+// Inventory enumerates every item the signed-in account can read and
+// returns an Index of its concealed field values, for migrate's
+// link-instead-of-copy dedupe (design/1password-adapter.md). One
+// authenticated enumeration — `op item list` piped into `op item get -`,
+// the CLI's own documented bulk pattern — so the user answers at most one
+// 1Password authorization prompt per run. Only fields op marks CONCEALED
+// are indexed: that is 1Password's own "this is a secret" bit, and it
+// naturally excludes usernames, URLs, and Secure Note bodies.
+//
+// The raw JSON (which carries the values) is wiped before returning;
+// Go strings parsed out of it are unwipable, so this is best-effort
+// hygiene on the same terms as migrate's own file parsing, not a
+// guarantee.
+func (r *Resolver) Inventory() (*Index, error) {
+	bin, err := r.bin()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout := r.timeout
+	if timeout <= 0 {
+		timeout = resolveTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	list, err := runOp(ctx, bin, nil, "item", "list", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("op item list failed: %w", err)
+	}
+	defer wipeBytes(list)
+
+	// An account with zero items lists `[]`; don't hand `op item get -`
+	// an empty worklist to choke on.
+	var listed []json.RawMessage
+	if err := json.Unmarshal(bytes.TrimSpace(list), &listed); err != nil {
+		return nil, fmt.Errorf("op item list output not understood: %v", err)
+	}
+	if len(listed) == 0 {
+		return &Index{byHash: map[[sha256.Size]byte]IndexEntry{}}, nil
+	}
+
+	raw, err := runOp(ctx, bin, list, "item", "get", "-", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("op item get failed: %w", err)
+	}
+	defer wipeBytes(raw)
+
+	items, err := parseItems(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deterministic first-wins for a value present in several fields: the
+	// choice is cosmetic (same value, same secret), but it must not change
+	// between runs of the same vault state.
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Vault.ID != items[j].Vault.ID {
+			return items[i].Vault.ID < items[j].Vault.ID
+		}
+		return items[i].ID < items[j].ID
+	})
+
+	ix := &Index{byHash: map[[sha256.Size]byte]IndexEntry{}, items: len(items)}
+	for _, it := range items {
+		for _, f := range it.Fields {
+			if f.Type != "CONCEALED" || len(f.Value) < minLinkableValueLen {
+				continue
+			}
+			if it.Vault.ID == "" || it.ID == "" || f.ID == "" {
+				continue // no rename-proof reference to build; skip rather than store a fragile one
+			}
+			sum := sha256.Sum256([]byte(f.Value))
+			if _, taken := ix.byHash[sum]; taken {
+				continue
+			}
+			name := f.Reference
+			if name == "" {
+				name = fmt.Sprintf("op://%s/%s/%s", it.Vault.Name, it.Title, f.Label)
+			}
+			ix.byHash[sum] = IndexEntry{
+				IDRef:   fmt.Sprintf("op://%s/%s/%s", it.Vault.ID, it.ID, f.ID),
+				NameRef: name,
+			}
+		}
+	}
+	return ix, nil
+}
+
+// parseItems accepts both shapes `op item get - --format json` emits: a
+// JSON array, or a concatenated stream of objects (one per piped item).
+func parseItems(raw []byte) ([]opItem, error) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	if trimmed[0] == '[' {
+		var items []opItem
+		if err := json.Unmarshal(trimmed, &items); err != nil {
+			return nil, fmt.Errorf("op item get output not understood: %v", err)
+		}
+		return items, nil
+	}
+	var items []opItem
+	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	for dec.More() {
+		var it opItem
+		if err := dec.Decode(&it); err != nil {
+			return nil, fmt.Errorf("op item get output not understood: %v", err)
+		}
+		items = append(items, it)
+	}
+	return items, nil
+}
+
+// runOp executes one op invocation under ctx with stdin (nil for none),
+// returning stdout. Errors surface op's own first stderr line — the
+// message a signed-out or locked CLI prints is the actionable one.
+func runOp(ctx context.Context, bin string, stdin []byte, args ...string) ([]byte, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, bin, args...) // #nosec G204 -- bin is signature-verified by the caller's bin(); args are fixed literals
+	if stdin != nil {
+		cmd.Stdin = bytes.NewReader(stdin)
+	}
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Same reasoning as ResolveRef: without WaitDelay, a helper op leaves
+	// behind holds the pipes open past the kill and the bound stops
+	// bounding.
+	cmd.WaitDelay = time.Second
+	if err := cmd.Run(); err != nil {
+		wipeBytes(stdout.Bytes())
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("timed out (waiting for a 1Password unlock that never came?)")
+		}
+		if detail := firstLine(stderr.String()); detail != "" {
+			return nil, fmt.Errorf("%s", detail)
+		}
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+// wipeBytes zeroes b — best-effort plaintext hygiene for buffers that
+// carried field values.
+func wipeBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}

--- a/internal/onepassword/inventory_test.go
+++ b/internal/onepassword/inventory_test.go
@@ -1,0 +1,201 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeOpInventory builds a fake op that answers `item list` with listJSON
+// and `item get -` with getJSON, failing loudly on anything else. When
+// getJSON is empty, an `item get` invocation drops a marker file so the
+// test can assert it never ran.
+func fakeOpInventory(t *testing.T, listJSON, getJSON string) (path, getMarker string) {
+	t.Helper()
+	dir := t.TempDir()
+	getMarker = filepath.Join(dir, "get-ran")
+	script := `
+case "$1 $2" in
+"item list")
+cat <<'JSONEOF'
+` + listJSON + `
+JSONEOF
+;;
+"item get")
+`
+	if getJSON == "" {
+		script += `touch ` + getMarker + `
+echo "item get must not run" >&2
+exit 3
+`
+	} else {
+		script += `cat >/dev/null
+cat <<'JSONEOF'
+` + getJSON + `
+JSONEOF
+`
+	}
+	script += `;;
+*)
+echo "unexpected arguments: $*" >&2
+exit 2
+;;
+esac
+`
+	return fakeOp(t, script), getMarker
+}
+
+const inventoryListTwo = `[{"id":"item-b"},{"id":"item-a"}]`
+
+// Two items, streamed as concatenated objects (op's multi-item shape).
+// Covers: a STRING field (never indexed), a CONCEALED field under the
+// 8-byte floor, a CONCEALED field missing its reference key (NameRef
+// falls back to names), and a field with no id (skipped entirely).
+const inventoryGetStream = `{
+  "id": "item-b",
+  "title": "Stripe",
+  "vault": {"id": "vault-1", "name": "Personal"},
+  "fields": [
+    {"id": "f1", "type": "CONCEALED", "label": "credential", "value": "sk_live_1234567890", "reference": "op://Personal/Stripe/credential"},
+    {"id": "f2", "type": "STRING", "label": "username", "value": "not-a-secret-but-long"},
+    {"id": "f3", "type": "CONCEALED", "label": "pin", "value": "admin"}
+  ]
+}
+{
+  "id": "item-a",
+  "title": "Postgres",
+  "vault": {"id": "vault-1", "name": "Personal"},
+  "fields": [
+    {"id": "f1", "type": "CONCEALED", "label": "password", "value": "correct-horse-battery"},
+    {"id": "", "type": "CONCEALED", "label": "orphan", "value": "no-id-no-reference-possible"}
+  ]
+}`
+
+func TestInventoryIndexesConcealedFieldsOnly(t *testing.T) {
+	bin, _ := fakeOpInventory(t, inventoryListTwo, inventoryGetStream)
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Items() != 2 {
+		t.Errorf("Items() = %d, want 2", ix.Items())
+	}
+
+	e, ok := ix.RefFor([]byte("sk_live_1234567890"))
+	if !ok {
+		t.Fatal("concealed value not indexed")
+	}
+	if e.IDRef != "op://vault-1/item-b/f1" {
+		t.Errorf("IDRef = %q, want the id-form reference", e.IDRef)
+	}
+	if e.NameRef != "op://Personal/Stripe/credential" {
+		t.Errorf("NameRef = %q, want op's own reference key", e.NameRef)
+	}
+
+	if e, ok := ix.RefFor([]byte("correct-horse-battery")); !ok {
+		t.Error("second item's concealed value not indexed")
+	} else if e.NameRef != "op://Personal/Postgres/password" {
+		t.Errorf("NameRef fallback = %q, want name-built reference", e.NameRef)
+	}
+
+	if _, ok := ix.RefFor([]byte("not-a-secret-but-long")); ok {
+		t.Error("STRING-typed field was indexed; only CONCEALED must be")
+	}
+	if _, ok := ix.RefFor([]byte("admin")); ok {
+		t.Error("value under the length floor was indexed")
+	}
+	if _, ok := ix.RefFor([]byte("no-id-no-reference-possible")); ok {
+		t.Error("field with no id was indexed; no rename-proof reference exists for it")
+	}
+}
+
+func TestInventoryFirstWinsIsDeterministic(t *testing.T) {
+	// The same value in two items; item ids arrive in reverse order, and
+	// the index must still pick the lower (vault id, item id) every run.
+	get := `{
+  "id": "item-z",
+  "title": "Copy",
+  "vault": {"id": "vault-1", "name": "Personal"},
+  "fields": [{"id": "f1", "type": "CONCEALED", "label": "token", "value": "shared-value-12345"}]
+}
+{
+  "id": "item-a",
+  "title": "Original",
+  "vault": {"id": "vault-1", "name": "Personal"},
+  "fields": [{"id": "f1", "type": "CONCEALED", "label": "token", "value": "shared-value-12345"}]
+}`
+	bin, _ := fakeOpInventory(t, `[{"id":"item-z"},{"id":"item-a"}]`, get)
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	e, ok := ix.RefFor([]byte("shared-value-12345"))
+	if !ok {
+		t.Fatal("shared value not indexed")
+	}
+	if e.IDRef != "op://vault-1/item-a/f1" {
+		t.Errorf("IDRef = %q, want the deterministic first item (item-a)", e.IDRef)
+	}
+}
+
+func TestInventoryAcceptsArrayOutput(t *testing.T) {
+	get := `[{
+  "id": "item-a",
+  "title": "GitHub",
+  "vault": {"id": "vault-1", "name": "Personal"},
+  "fields": [{"id": "f1", "type": "CONCEALED", "label": "token", "value": "ghp_abcdefgh"}]
+}]`
+	bin, _ := fakeOpInventory(t, `[{"id":"item-a"}]`, get)
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if _, ok := ix.RefFor([]byte("ghp_abcdefgh")); !ok {
+		t.Error("array-shaped item get output not indexed")
+	}
+}
+
+func TestInventoryEmptyVaultSkipsItemGet(t *testing.T) {
+	bin, marker := fakeOpInventory(t, `[]`, "")
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	if err != nil {
+		t.Fatalf("Inventory on empty vault: %v", err)
+	}
+	if ix.Items() != 0 {
+		t.Errorf("Items() = %d, want 0", ix.Items())
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("op item get ran for an empty item list")
+	}
+}
+
+func TestInventorySurfacesSignedOutError(t *testing.T) {
+	bin := fakeOp(t, `
+echo '[ERROR] 2026/08/17 account is not signed in' >&2
+exit 1
+`)
+	_, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	if err == nil {
+		t.Fatal("Inventory succeeded against a signed-out op")
+	}
+	if !strings.Contains(err.Error(), "not signed in") {
+		t.Errorf("error %q does not carry op's own stderr line", err)
+	}
+}
+
+func TestInventoryVerifyFailureIsClosedBeforeExec(t *testing.T) {
+	bin := fakeOp(t, `touch "$0.ran"; exit 0`)
+	failVerify := func(string) error { return errors.New("signature rejected") }
+	_, err := (&Resolver{path: bin, verify: failVerify}).Inventory()
+	if err == nil || !strings.Contains(err.Error(), "signature rejected") {
+		t.Fatalf("err = %v, want the verification failure", err)
+	}
+	if _, statErr := os.Stat(bin + ".ran"); statErr == nil {
+		t.Error("unverified binary was executed")
+	}
+}

--- a/internal/onepassword/onepassword.go
+++ b/internal/onepassword/onepassword.go
@@ -155,6 +155,36 @@ func Installed() bool {
 	return err == nil
 }
 
+// InstalledVerified resolves op on $PATH and runs the Developer ID
+// signature check on it, returning the vetted path. For `jit doctor`'s
+// automatic 1Password section: prompt-free (codesign inspects the binary,
+// op itself is never executed) and fail-closed like every other caller of
+// the verifier.
+func InstalledVerified() (string, error) {
+	path, err := exec.LookPath("op")
+	if err != nil {
+		return "", fmt.Errorf("the 1Password CLI is not installed (`op` not on PATH)")
+	}
+	if err := verifySignature(path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// Version reports the op binary's own version string ("2.39.0"), or "" if
+// it cannot be read. `op --version` needs no session and pops no prompt;
+// the short bound is because a health report must never hang on a
+// misbehaving binary.
+func Version(path string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := runOp(ctx, path, nil, "--version")
+	if err != nil {
+		return ""
+	}
+	return firstLine(string(out))
+}
+
 // ValidateRef checks that ref is a structurally plausible op:// secret
 // reference — scheme op, a vault, and at least item/field path segments.
 // It deliberately validates SHAPE only: whether the reference resolves is

--- a/internal/onepassword/onepassword.go
+++ b/internal/onepassword/onepassword.go
@@ -1,0 +1,169 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+// Package onepassword is the shipped implementation of vault.RefResolver
+// (design/1password-adapter.md, issue #60): it resolves op:// secret
+// references by exec-ing the 1Password CLI, `op`, which the user installed
+// and signed in themselves. jit never holds 1Password credentials — the
+// desktop app's own biometric authorization gates release from 1Password,
+// while jit's consent/Touch ID gates who gets the resolved value and into
+// which process tree. Pure Go, no SDK: the integration is deliberately an
+// exec boundary (TECH_STACK.md §2), consistent with jit's supply-chain
+// stance.
+//
+// Before the first exec, the resolved `op` binary must carry a valid
+// Developer ID signature from 1Password's (AgileBits') Apple team — the
+// same codesign technique and fail-closed stance as jit's own upgrade
+// verification (internal/cli/upgrade.go). The threat is a PATH-planted
+// fake `op`: it never receives a secret, but it learns which references
+// exist and can answer with attacker-chosen values. There is deliberately
+// no override flag.
+package onepassword
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// opTeamID is 1Password's (AgileBits Inc.'s) Apple Developer Team ID,
+// read off the shipping binary (op 2.39.0: "Developer ID Application:
+// AgileBits Inc. (2BUA8C4S2C)", TeamIdentifier=2BUA8C4S2C). Unlike jit's
+// own upgradeTeamIDs this is not a list: if 1Password ever re-issues
+// under a new team, a jit release updates this constant — nothing in the
+// field is bricked in the meantime, linked secrets just fail closed with
+// a clear error until that release ships.
+const opTeamID = "2BUA8C4S2C"
+
+// resolveTimeout bounds one op invocation. Generous on purpose, same
+// class of wait as jit's own Touch ID prompt: a read may legitimately
+// block on 1Password's unlock dialog, and cutting a user off mid-reach
+// for the sensor is worse than a slow failure. Callers on paths where a
+// GUI prompt must never appear (the background service's refresh) get
+// their bound from this same constant — fail closed, never a hung reader.
+const resolveTimeout = 2 * time.Minute
+
+// Resolver implements vault.RefResolver by exec-ing `op read`. Use New()
+// for the real thing; tests construct Resolver{path: ..., verify: ...}
+// directly with a fake binary and a no-op verifier.
+//
+// The zero value is not usable — New wires the real lookup and the real
+// codesign verification, both deferred to the first resolve so
+// constructing a Resolver (which every openVault does) costs nothing and
+// cannot fail on machines that never use a linked secret.
+type Resolver struct {
+	// path locates the op binary; empty means "resolve via $PATH on first
+	// use". verify vets it before the first exec.
+	path   string
+	verify func(path string) error
+
+	once    sync.Once
+	binPath string
+	initErr error
+	timeout time.Duration
+}
+
+var _ vault.RefResolver = (*Resolver)(nil)
+
+// New returns a Resolver backed by the real `op` on $PATH and the real
+// Developer ID signature check.
+func New() *Resolver {
+	return &Resolver{verify: verifySignature, timeout: resolveTimeout}
+}
+
+// ResolveRef resolves one op:// secret reference to the exact bytes of
+// the field it names, via `op read -n` (no trailing newline appended, so
+// injection stays byte-exact).
+func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
+	if err := ValidateRef(ref); err != nil {
+		return nil, err
+	}
+	r.once.Do(func() {
+		path := r.path
+		if path == "" {
+			var err error
+			path, err = exec.LookPath("op")
+			if err != nil {
+				r.initErr = fmt.Errorf("the 1Password CLI is not installed (`op` not on PATH); install it with `brew install 1password-cli`")
+				return
+			}
+		}
+		if err := r.verify(path); err != nil {
+			r.initErr = err
+			return
+		}
+		r.binPath = path
+	})
+	if r.initErr != nil {
+		return nil, r.initErr
+	}
+
+	timeout := r.timeout
+	if timeout <= 0 {
+		timeout = resolveTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, r.binPath, "read", "-n", ref) // #nosec G204 -- binPath is signature-verified above; ref is validated op:// syntax
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// Without WaitDelay, a child op leaves behind (its cache daemon, a
+	// helper) keeps the stdio pipes open past the kill and Run blocks on
+	// them long after the timeout has "fired" — the bound must bound.
+	cmd.WaitDelay = time.Second
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf("op read timed out after %s (waiting for a 1Password unlock that never came?)", timeout)
+		}
+		detail := firstLine(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return nil, fmt.Errorf("op read failed: %s", detail)
+	}
+	return stdout.Bytes(), nil
+}
+
+// ValidateRef checks that ref is a structurally plausible op:// secret
+// reference — scheme op, a vault, and at least item/field path segments.
+// It deliberately validates SHAPE only: whether the reference resolves is
+// op's business, and 1Password's reference charset/ID rules are theirs to
+// evolve. Exported for `jit vault link`, which wants to reject a typo
+// before spending a trial resolve on it.
+func ValidateRef(ref string) error {
+	u, err := url.Parse(ref)
+	if err != nil {
+		return fmt.Errorf("not a valid secret reference: %v", err)
+	}
+	if u.Scheme != "op" {
+		return fmt.Errorf("unsupported reference scheme %q (only op:// references are supported)", u.Scheme)
+	}
+	if u.Host == "" {
+		return fmt.Errorf("reference %q names no 1Password vault (want op://<vault>/<item>/<field>)", ref)
+	}
+	segs := strings.Split(strings.Trim(u.Path, "/"), "/")
+	if len(segs) < 2 || segs[0] == "" || segs[len(segs)-1] == "" {
+		return fmt.Errorf("reference %q is incomplete (want op://<vault>/<item>/<field>)", ref)
+	}
+	return nil
+}
+
+// firstLine trims s to its first non-empty line — op's stderr can carry
+// multi-line advice, and jit's own error surfaces are one clause each.
+func firstLine(s string) string {
+	for _, line := range strings.Split(s, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/onepassword/onepassword.go
+++ b/internal/onepassword/onepassword.go
@@ -85,24 +85,9 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 	if err := ValidateRef(ref); err != nil {
 		return nil, err
 	}
-	r.once.Do(func() {
-		path := r.path
-		if path == "" {
-			var err error
-			path, err = exec.LookPath("op")
-			if err != nil {
-				r.initErr = fmt.Errorf("the 1Password CLI is not installed (`op` not on PATH); install it with `brew install 1password-cli`")
-				return
-			}
-		}
-		if err := r.verify(path); err != nil {
-			r.initErr = err
-			return
-		}
-		r.binPath = path
-	})
-	if r.initErr != nil {
-		return nil, r.initErr
+	bin, err := r.bin()
+	if err != nil {
+		return nil, err
 	}
 
 	timeout := r.timeout
@@ -113,7 +98,7 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 	defer cancel()
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, r.binPath, "read", "-n", ref) // #nosec G204 -- binPath is signature-verified above; ref is validated op:// syntax
+	cmd := exec.CommandContext(ctx, bin, "read", "-n", ref) // #nosec G204 -- bin is signature-verified above; ref is validated op:// syntax
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	// Without WaitDelay, a child op leaves behind (its cache daemon, a
@@ -131,6 +116,43 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 		return nil, fmt.Errorf("op read failed: %s", detail)
 	}
 	return stdout.Bytes(), nil
+}
+
+// bin resolves and vets the op binary exactly once: $PATH lookup (unless
+// a path was injected), then the Developer ID signature check. Shared by
+// every exec-ing entry point (ResolveRef, Inventory) so none can reach
+// an unverified binary.
+func (r *Resolver) bin() (string, error) {
+	r.once.Do(func() {
+		path := r.path
+		if path == "" {
+			var err error
+			path, err = exec.LookPath("op")
+			if err != nil {
+				r.initErr = fmt.Errorf("the 1Password CLI is not installed (`op` not on PATH); install it with `brew install 1password-cli`")
+				return
+			}
+		}
+		if err := r.verify(path); err != nil {
+			r.initErr = err
+			return
+		}
+		r.binPath = path
+	})
+	if r.initErr != nil {
+		return "", r.initErr
+	}
+	return r.binPath, nil
+}
+
+// Installed reports whether an `op` binary is on $PATH at all — the cheap,
+// exec-free probe surfaces use to decide whether 1Password integration is
+// even in play (e.g. migrate's plan line). It deliberately does NOT verify
+// the signature: verification runs before the first exec, and a plan must
+// stay free of side effects and of second-guessing a binary it won't run.
+func Installed() bool {
+	_, err := exec.LookPath("op")
+	return err == nil
 }
 
 // ValidateRef checks that ref is a structurally plausible op:// secret

--- a/internal/onepassword/onepassword_test.go
+++ b/internal/onepassword/onepassword_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeOp writes an executable script standing in for the op binary and
+// returns its path. Tests drive Resolver through a real exec, exactly as
+// production does — only the binary and the signature check are fakes.
+func fakeOp(t *testing.T, script string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "op")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil { // #nosec G306 -- a test's fake executable must be executable
+		t.Fatalf("writing fake op: %v", err)
+	}
+	return path
+}
+
+func noVerify(string) error { return nil }
+
+func TestResolveRefReturnsExactBytes(t *testing.T) {
+	// printf, not echo: the whole point of `op read -n` is byte-exactness,
+	// so the fake must not append a newline either.
+	r := &Resolver{
+		path: fakeOp(t, `
+if [ "$1" != "read" ] || [ "$2" != "-n" ]; then
+  echo "unexpected arguments: $*" >&2
+  exit 2
+fi
+printf 'value-no-trailing-newline'
+`),
+		verify: noVerify,
+	}
+	got, err := r.ResolveRef("op://vaultid/itemid/fieldid")
+	if err != nil {
+		t.Fatalf("ResolveRef: %v", err)
+	}
+	if string(got) != "value-no-trailing-newline" {
+		t.Errorf("ResolveRef = %q, want exact bytes with no trailing newline", got)
+	}
+}
+
+func TestResolveRefSurfacesStderrFirstLine(t *testing.T) {
+	r := &Resolver{
+		path: fakeOp(t, `
+echo '[ERROR] 2026/08/17 account is not signed in' >&2
+echo 'second line of advice' >&2
+exit 1
+`),
+		verify: noVerify,
+	}
+	_, err := r.ResolveRef("op://vaultid/itemid/fieldid")
+	if err == nil {
+		t.Fatal("ResolveRef succeeded, want op's failure surfaced")
+	}
+	if !strings.Contains(err.Error(), "not signed in") {
+		t.Errorf("error %q does not carry op's stderr", err)
+	}
+	if strings.Contains(err.Error(), "second line") {
+		t.Errorf("error %q carries more than the first stderr line", err)
+	}
+}
+
+func TestResolveRefTimesOutOnAHungOp(t *testing.T) {
+	r := &Resolver{
+		path:    fakeOp(t, "sleep 10\n"),
+		verify:  noVerify,
+		timeout: 200 * time.Millisecond,
+	}
+	start := time.Now()
+	_, err := r.ResolveRef("op://vaultid/itemid/fieldid")
+	if err == nil {
+		t.Fatal("ResolveRef succeeded, want a timeout")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("error %q does not name the timeout", err)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("ResolveRef took %s, the timeout did not bound the wait", elapsed)
+	}
+}
+
+func TestResolveRefRejectsBadReferencesWithoutExec(t *testing.T) {
+	// path points at a script that would fail loudly if run: a rejected
+	// reference must never cost an exec.
+	r := &Resolver{path: fakeOp(t, "echo 'must not run' >&2; exit 3\n"), verify: noVerify}
+	for _, ref := range []string{
+		"https://example.com/not/op",
+		"op://",
+		"op://vault-only",
+		"op://vault/item-only",
+		"not a reference at all",
+		"",
+	} {
+		if _, err := r.ResolveRef(ref); err == nil {
+			t.Errorf("ResolveRef(%q) succeeded, want a validation error", ref)
+		} else if strings.Contains(err.Error(), "must not run") {
+			t.Errorf("ResolveRef(%q) exec-ed op before validating", ref)
+		}
+	}
+}
+
+func TestValidateRefAcceptsRealShapes(t *testing.T) {
+	for _, ref := range []string{
+		"op://vault/item/field",
+		"op://vaultid123/itemid456/fieldid789",
+		"op://dev/GitHub/credentials/personal_token",       // section form
+		"op://Private/Stripe/key?attribute=otp",            // query parameter
+		"op://app-prod/ssh/private key?ssh-format=openssh", // space + query
+	} {
+		if err := ValidateRef(ref); err != nil {
+			t.Errorf("ValidateRef(%q) = %v, want accepted", ref, err)
+		}
+	}
+}
+
+func TestVerifyFailsClosedBeforeFirstExec(t *testing.T) {
+	ran := filepath.Join(t.TempDir(), "ran")
+	r := &Resolver{
+		path:   fakeOp(t, "touch "+ran+"\n"),
+		verify: func(string) error { return os.ErrPermission },
+	}
+	if _, err := r.ResolveRef("op://vaultid/itemid/fieldid"); err == nil {
+		t.Fatal("ResolveRef succeeded under a failing signature check")
+	}
+	if _, err := os.Stat(ran); err == nil {
+		t.Fatal("op was exec-ed despite the signature check failing")
+	}
+}
+
+func TestSignatureRequirementFormIsInline(t *testing.T) {
+	req := signatureRequirement()
+	if !strings.HasPrefix(req, "=") {
+		t.Errorf("requirement %q lacks the leading '=' codesign needs for an inline requirement", req)
+	}
+	for _, want := range []string{
+		"anchor apple generic",
+		"1.2.840.113635.100.6.2.6",  // Developer ID intermediate CA marker
+		"1.2.840.113635.100.6.1.13", // Developer ID Application leaf marker
+		`subject.OU] = "` + opTeamID + `"`,
+	} {
+		if !strings.Contains(req, want) {
+			t.Errorf("requirement %q is missing %q", req, want)
+		}
+	}
+}
+
+// TestRealOpBinaryPassesVerification pins the opTeamID constant against
+// the actually-shipping 1Password CLI wherever one is installed (skipped
+// elsewhere, including CI): if AgileBits ever re-issues under a new team,
+// this is the test that says so.
+func TestRealOpBinaryPassesVerification(t *testing.T) {
+	path, err := exec.LookPath("op")
+	if err != nil {
+		t.Skip("op is not installed on this machine")
+	}
+	if err := verifySignature(path); err != nil {
+		t.Errorf("the installed op at %s fails verification: %v", path, err)
+	}
+}

--- a/internal/onepassword/signature.go
+++ b/internal/onepassword/signature.go
@@ -1,0 +1,51 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// signatureRequirement is the codesign requirement one `op` binary must
+// satisfy before this package will exec it: Apple-anchored, carrying the
+// Developer ID marker OIDs (so an Apple DEVELOPMENT cert from the same
+// team does not pass), leaf OU = AgileBits' team. Same shape, same OIDs,
+// and same rationale as internal/cli/upgrade.go's signatureRequirement —
+// the OIDs are Apple-defined constants, duplicated here rather than
+// exported across the cli boundary (cli sits above every other package
+// and cannot be imported from one). The leading "=" marks an INLINE
+// requirement; without it codesign treats the argument as a file path
+// and rejects everything, including genuine binaries — fail closed, but
+// wrong.
+func signatureRequirement() string {
+	return fmt.Sprintf("=anchor apple generic"+
+		" and certificate 1[field.1.2.840.113635.100.6.2.6] exists"+
+		" and certificate leaf[field.1.2.840.113635.100.6.1.13] exists"+
+		" and certificate leaf[subject.OU] = %q", opTeamID)
+}
+
+// verifySignature refuses to exec an `op` that is not a genuine, intact,
+// Developer-ID-signed 1Password CLI. Fails closed on an unsigned binary,
+// a missing codesign, or an unreadable result — and there is deliberately
+// no override: a switch that turns off signature checking on the binary a
+// security tool pipes references through is the thing an attacker asks
+// the user to pass.
+func verifySignature(path string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "/usr/bin/codesign", "--verify", "--strict", "-R", signatureRequirement(), path) // #nosec G204 -- fixed system binary; path is exec.LookPath's result for op
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(string(output))
+	if detail == "" {
+		detail = err.Error()
+	}
+	return fmt.Errorf("%s is not a signature-verified 1Password CLI (%s); refusing to run it", path, detail)
+}

--- a/internal/vault/envelope.go
+++ b/internal/vault/envelope.go
@@ -37,6 +37,18 @@ type envelope struct {
 	GroupID        string `json:"group_id,omitempty"`
 	Origin         string `json:"origin,omitempty"`
 	OriginSeenUnix int64  `json:"origin_seen_unix,omitempty"`
+	// Storage says what the PAYLOAD is (version 4+): "" means the payload
+	// is the secret value itself, StorageOpRef means it is a 1Password
+	// secret reference (an op:// URI) that Get resolves through the
+	// Vault's RefResolver at read time. Unlike the provenance fields it is
+	// NOT birth-immutable — it describes the current payload, and a
+	// literal Set over a linked path deliberately clears it (the user
+	// replaced the pointer with a value). It is deliberately an explicit,
+	// AAD-bound marker rather than a payload sniff: a stored value that
+	// happens to look like "op://…" must never silently morph into a
+	// resolver call, and flipping the marker on disk (either direction)
+	// must fail decryption rather than change what Get does.
+	Storage string `json:"storage,omitempty"`
 	// Recipients maps a recipient ID (this device's hostname in Phase 1;
 	// Phase 2 adds real multi-recipient sharing, RFC.md §5.2) to that
 	// recipient's hex-encoded wrapped DEK.
@@ -86,12 +98,24 @@ const (
 	envelopeVersionAADLess = 1
 	// envelopeVersionMetaOnly is the second schema: created/updated
 	// timestamps bound into the AAD, no provenance. Never written anymore
-	// (Set writes v3), readable forever, same as v1.
+	// (Set writes v4), readable forever, same as v1.
 	envelopeVersionMetaOnly = 2
-	// envelopeVersion is what Set writes today: v2's metadata plus
-	// class/group/origin provenance, all AAD-bound.
-	envelopeVersion = 3
+	// envelopeVersionProvenance is the third schema: v2's metadata plus
+	// class/group/origin provenance, all AAD-bound. Never written anymore
+	// (Set writes v4), readable forever, same as v1 and v2.
+	envelopeVersionProvenance = 3
+	// envelopeVersion is what Set writes today: v3's provenance plus the
+	// storage marker (see envelope.Storage), all AAD-bound.
+	envelopeVersion = 4
 )
+
+// StorageOpRef marks an envelope whose payload is a 1Password secret
+// reference (an op:// URI) rather than the secret value itself — see
+// envelope.Storage and design/1password-adapter.md. The reference is
+// encrypted and consent-gated exactly like a literal value: an op://
+// path names the user's 1Password credential map, and gating its unwrap
+// is what keeps per-process consent meaningful for linked secrets.
+const StorageOpRef = "op-ref"
 
 // Class values name the semantic source a secret came from — the durable,
 // AAD-bound answer to "is this from a .env, an .mcp.json, my shell rc?".
@@ -124,6 +148,12 @@ const (
 	// manifest's data:/stringData: block (distinct from ClassKube, which is
 	// a kubeconfig credential). Origin is the manifest path.
 	ClassK8sSecret = "k8s_secret" // #nosec G101 -- provenance class label, not a credential
+	// ClassOnePassword is a 1Password reference linked from nothing (`jit
+	// vault link`, manual or bulk): born as a link, its only source IS
+	// 1Password. A secret that `jit migrate` links keeps its migrator's
+	// class instead — it was born in that file, and envelope.Storage alone
+	// says how it is fulfilled. See design/1password-adapter.md.
+	ClassOnePassword = "1password"
 	// ClassShellHistory is a credential redacted out of a shell history file
 	// by `jit migrate` (distinct from ClassShell, which is an export line
 	// moved out of a shell rc file). Origin is the history file path. These
@@ -145,16 +175,21 @@ const (
 // admits only [A-Za-z0-9_.-] and '/', so a colon can never appear in it and
 // the encoding is unambiguous.
 //
-// The AAD is version-shaped: a v3 payload was sealed under a string that
+// The AAD is version-shaped: a v4 payload was sealed under a string that
+// appends class:group:storage:origin, a v3 payload under the shape that
 // appends class:group:origin, a v2 payload under the four-field string that
-// predates them. Get MUST reconstruct whichever the stored version used, so
-// the branch here is keyed on version, NOT on whether the provenance fields
-// happen to be non-empty. class and group_id never contain a colon (fixed
-// vocabulary / hex id); origin can in principle, but it is the LAST field, so
-// everything past the final delimiter is origin and the encoding stays
-// unambiguous.
-func envelopeAAD(path string, version int, createdUnix, updatedUnix int64, class, groupID, origin string) []byte {
-	if version >= envelopeVersion {
+// predates them all. Get MUST reconstruct whichever the stored version used,
+// so the branch here is keyed on version, NOT on whether the newer fields
+// happen to be non-empty. class, group_id, and storage never contain a colon
+// (fixed vocabulary / hex id); origin can in principle, which is why origin
+// stays the LAST field in every version's shape — v4 inserts storage BEFORE
+// origin, not after it — so everything past the final delimiter is origin
+// and the encoding stays unambiguous.
+func envelopeAAD(path string, version int, createdUnix, updatedUnix int64, class, groupID, origin, storage string) []byte {
+	switch {
+	case version >= envelopeVersion:
+		return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d:%s:%s:%s:%s", version, path, createdUnix, updatedUnix, class, groupID, storage, origin)
+	case version >= envelopeVersionProvenance:
 		return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d:%s:%s:%s", version, path, createdUnix, updatedUnix, class, groupID, origin)
 	}
 	return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d", version, path, createdUnix, updatedUnix)

--- a/internal/vault/export.go
+++ b/internal/vault/export.go
@@ -76,7 +76,7 @@ type ExportEnvelope struct {
 	Payload string `json:"payload"`
 }
 
-// Export decrypts every secret currently in the vault (via getStored, so
+// Export decrypts every secret currently in the vault (via GetStored, so
 // it needs the same KeyWrapper/local-auth Get always does — but never the
 // RefResolver: an export is a vault backup, and a linked secret exports
 // as its reference, not as a 1Password read) and re-encrypts the whole
@@ -92,7 +92,7 @@ func (v *Vault) Export(passphrase []byte) (*ExportEnvelope, error) {
 	secrets := make(map[string]exportEntry, len(paths))
 	defer wipeEntries(secrets)
 	for _, path := range paths {
-		value, storage, err := v.getStored(path)
+		value, storage, err := v.GetStored(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", path, err)
 		}

--- a/internal/vault/export.go
+++ b/internal/vault/export.go
@@ -14,8 +14,22 @@ import (
 
 // exportVersion is ExportEnvelope's on-disk schema version — bumped if the
 // shape or KDF parameters ever change, so a future Import can tell an old
-// export apart from a new one rather than guessing.
-const exportVersion = 1
+// export apart from a new one rather than guessing. Version 1's payload
+// was a bare path→value map; version 2 wraps each value in an exportEntry
+// so a reference-kind secret (envelope.Storage) exports as the reference
+// it is. Import reads both, forever.
+const exportVersion = 2
+
+// exportEntry is one secret inside a version-2 export payload: the stored
+// payload bytes plus the envelope's storage marker. Carrying storage is
+// what lets a linked secret survive the export/import round trip AS a
+// link — without it, an import would freeze the reference URI into a
+// literal "secret" whose value is the string "op://…", silently breaking
+// the link on the restored machine.
+type exportEntry struct {
+	Value   []byte `json:"value"`
+	Storage string `json:"storage,omitempty"`
+}
 
 // Argon2id parameters for deriving an export's encryption key from a
 // passphrase. Deliberately memory-hard and reasonably slow (not vault
@@ -56,30 +70,33 @@ type ExportEnvelope struct {
 	// passphrase never derive the same key.
 	Salt string `json:"salt"`
 	// Payload is the hex-encoded (nonce || ciphertext) of the JSON-encoded
-	// map[string][]byte of every secret path to its plaintext value,
-	// AES-256-GCM sealed under the Argon2id-derived key.
+	// map of every secret path to its exportEntry (version 2; version 1
+	// mapped straight to plaintext values), AES-256-GCM sealed under the
+	// Argon2id-derived key.
 	Payload string `json:"payload"`
 }
 
-// Export decrypts every secret currently in the vault (via Get, so it
-// needs the same KeyWrapper/local-auth Get always does) and re-encrypts
-// the whole set under a single Argon2id-derived key from passphrase.
-// Callers own passphrase and should wipe() it once done, same as any
-// other secret material.
+// Export decrypts every secret currently in the vault (via getStored, so
+// it needs the same KeyWrapper/local-auth Get always does — but never the
+// RefResolver: an export is a vault backup, and a linked secret exports
+// as its reference, not as a 1Password read) and re-encrypts the whole
+// set under a single Argon2id-derived key from passphrase. Callers own
+// passphrase and should wipe() it once done, same as any other secret
+// material.
 func (v *Vault) Export(passphrase []byte) (*ExportEnvelope, error) {
 	paths, err := v.List()
 	if err != nil {
 		return nil, fmt.Errorf("listing vault: %w", err)
 	}
 
-	secrets := make(map[string][]byte, len(paths))
-	defer wipeValues(secrets)
+	secrets := make(map[string]exportEntry, len(paths))
+	defer wipeEntries(secrets)
 	for _, path := range paths {
-		value, err := v.Get(path)
+		value, storage, err := v.getStored(path)
 		if err != nil {
 			return nil, fmt.Errorf("reading %s: %w", path, err)
 		}
-		secrets[path] = value
+		secrets[path] = exportEntry{Value: value, Storage: storage}
 	}
 
 	plaintext, err := json.Marshal(secrets)
@@ -110,18 +127,30 @@ func (v *Vault) Export(passphrase []byte) (*ExportEnvelope, error) {
 }
 
 // Import decrypts env with passphrase and writes every secret it contains
-// into v via Set (so it needs the same KeyWrapper Set always does),
-// overwriting any existing secret at the same path. Returns the number of
-// secrets restored.
+// into v via Set — or SetReference, for an entry exported from a linked
+// secret, so a link is restored as a link (so it needs the same
+// KeyWrapper Set always does), overwriting any existing secret at the
+// same path. Returns the number of secrets restored.
 func (v *Vault) Import(env *ExportEnvelope, passphrase []byte) (int, error) {
 	secrets, err := decryptExport(env, passphrase)
 	if err != nil {
 		return 0, err
 	}
-	defer wipeValues(secrets)
+	defer wipeEntries(secrets)
 
-	for path, value := range secrets {
-		if err := v.Set(path, value); err != nil {
+	for path, entry := range secrets {
+		switch entry.Storage {
+		case "":
+			err = v.Set(path, entry.Value)
+		case StorageOpRef:
+			err = v.SetReference(path, string(entry.Value), Meta{})
+		default:
+			// Same fail-closed stance as Get's storage gate: restoring a
+			// future marker's payload as a literal secret would silently
+			// change what it means.
+			err = fmt.Errorf("storage kind %q is newer than this jit understands, upgrade jit to import it", entry.Storage)
+		}
+		if err != nil {
 			return 0, fmt.Errorf("restoring %s: %w", path, err)
 		}
 	}
@@ -141,16 +170,18 @@ func VerifyExportPassphrase(env *ExportEnvelope, passphrase []byte) error {
 	if err != nil {
 		return err
 	}
-	wipeValues(secrets)
+	wipeEntries(secrets)
 	return nil
 }
 
 // decryptExport is Import and VerifyExportPassphrase's shared core: derive
 // the key, open the AEAD payload, and parse the resulting JSON into a
-// secret-path-to-value map.
-func decryptExport(env *ExportEnvelope, passphrase []byte) (map[string][]byte, error) {
-	if env.Version != exportVersion {
-		return nil, fmt.Errorf("unsupported export version %d (this jit understands version %d)", env.Version, exportVersion)
+// secret-path-to-entry map. Version 1 files (a bare path→value map, from
+// every jit before the storage marker existed) parse forever, as
+// literal-value entries.
+func decryptExport(env *ExportEnvelope, passphrase []byte) (map[string]exportEntry, error) {
+	if env.Version < 1 || env.Version > exportVersion {
+		return nil, fmt.Errorf("unsupported export version %d (this jit understands versions 1 to %d)", env.Version, exportVersion)
 	}
 	salt, err := hex.DecodeString(env.Salt)
 	if err != nil {
@@ -170,7 +201,18 @@ func decryptExport(env *ExportEnvelope, passphrase []byte) (map[string][]byte, e
 	}
 	defer wipe(plaintext)
 
-	var secrets map[string][]byte
+	if env.Version == 1 {
+		var values map[string][]byte
+		if err := json.Unmarshal(plaintext, &values); err != nil {
+			return nil, fmt.Errorf("parsing decrypted export: %w", err)
+		}
+		secrets := make(map[string]exportEntry, len(values))
+		for path, value := range values {
+			secrets[path] = exportEntry{Value: value}
+		}
+		return secrets, nil
+	}
+	var secrets map[string]exportEntry
 	if err := json.Unmarshal(plaintext, &secrets); err != nil {
 		return nil, fmt.Errorf("parsing decrypted export: %w", err)
 	}
@@ -181,13 +223,13 @@ func deriveExportKey(passphrase, salt []byte) []byte {
 	return argon2.IDKey(passphrase, salt, argon2Time, argon2MemoryKiB, argon2Threads, argon2KeyLen)
 }
 
-// wipeValues zeroes every value in a map[string][]byte — Export/Import's
+// wipeEntries zeroes every entry's value bytes — Export/Import's
 // secret-bearing maps, so their contents don't linger in memory any
 // longer than crypto.go's own wipe() convention already accepts elsewhere
 // in this package (best-effort, not a hard guarantee against a GC-moved
 // copy — see wipe's own doc comment).
-func wipeValues(m map[string][]byte) {
-	for _, v := range m {
-		wipe(v)
+func wipeEntries(m map[string]exportEntry) {
+	for _, e := range m {
+		wipe(e.Value)
 	}
 }

--- a/internal/vault/export_test.go
+++ b/internal/vault/export_test.go
@@ -193,21 +193,22 @@ func TestVerifyExportPassphrase(t *testing.T) {
 	}
 }
 
-func TestWipeValuesZeroesEveryEntry(t *testing.T) {
-	m := map[string][]byte{
-		"a": bytes.Repeat([]byte{0xAA}, 8),
-		"b": bytes.Repeat([]byte{0xBB}, 8),
+func TestWipeEntriesZeroesEveryEntry(t *testing.T) {
+	m := map[string]exportEntry{
+		"a": {Value: bytes.Repeat([]byte{0xAA}, 8)},
+		"b": {Value: bytes.Repeat([]byte{0xBB}, 8), Storage: StorageOpRef},
 	}
 	// Hold the slices BEFORE the call. Re-reading through m would prove
-	// nothing about the property: wipeValues has to scrub in place, because
+	// nothing about the property: wipeEntries has to scrub in place, because
 	// what it protects is exported plaintext still resident in the backing
 	// array (export.go defer-calls it over the decrypted maps in Export,
 	// Import and VerifyExportPassphrase). An implementation doing
-	// `m[k] = make([]byte, len(v))` hands a range loop over m fresh zeroed
-	// slices and passes while every secret stays live in memory; a delete-based
-	// one makes the loop body never execute at all. Both used to pass here.
-	a, b := m["a"], m["b"]
-	wipeValues(m)
+	// `m[k] = exportEntry{Value: make([]byte, len(v))}` hands a range loop
+	// over m fresh zeroed slices and passes while every secret stays live in
+	// memory; a delete-based one makes the loop body never execute at all.
+	// Both used to pass here.
+	a, b := m["a"].Value, m["b"].Value
+	wipeEntries(m)
 	for name, held := range map[string][]byte{"a": a, "b": b} {
 		for i, byteVal := range held {
 			if byteVal != 0 {

--- a/internal/vault/linkonset_test.go
+++ b/internal/vault/linkonset_test.go
@@ -1,0 +1,127 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import (
+	"testing"
+)
+
+// TestLinkOnSetInterceptStoresReference is the dedupe seam end to end: a
+// hook claiming a SetWithMeta write must produce a reference envelope
+// carrying the MIGRATOR'S meta (class stays, storage alone marks
+// linkedness), resolving through the RefResolver like any linked secret.
+func TestLinkOnSetInterceptStoresReference(t *testing.T) {
+	v := newTestVault(t)
+	r := &fakeResolver{value: []byte("live-credential")}
+	v.RefResolver = r
+	v.LinkOnSet = func(path string, value []byte, meta Meta) (string, bool) {
+		if string(value) == "plaintext-from-dotenv" {
+			return testRef, true
+		}
+		return "", false
+	}
+
+	meta := Meta{Class: ClassDotenv, GroupID: "g1", Origin: "file:///home/x/.env"}
+	if err := v.SetWithMeta("myapp/DB_PASSWORD", []byte("plaintext-from-dotenv"), meta); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+
+	info, err := v.Info("myapp/DB_PASSWORD")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != StorageOpRef {
+		t.Errorf("Storage = %q, want %q (hook claimed the write)", info.Storage, StorageOpRef)
+	}
+	if info.Class != ClassDotenv {
+		t.Errorf("Class = %q, want the migrator's %q, not the link's", info.Class, ClassDotenv)
+	}
+
+	got, err := v.Get("myapp/DB_PASSWORD")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "live-credential" {
+		t.Errorf("Get = %q, want the resolver's value", got)
+	}
+	if len(r.asked) != 1 || r.asked[0] != testRef {
+		t.Errorf("resolver asked %v, want exactly [%s]", r.asked, testRef)
+	}
+}
+
+func TestLinkOnSetDecliningStoresLiteral(t *testing.T) {
+	v := newTestVault(t)
+	v.LinkOnSet = func(string, []byte, Meta) (string, bool) { return "", false }
+
+	if err := v.SetWithMeta("myapp/PLAIN", []byte("no-match-value"), Meta{Class: ClassDotenv}); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+	info, err := v.Info("myapp/PLAIN")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != "" {
+		t.Errorf("Storage = %q, want a literal envelope when the hook declines", info.Storage)
+	}
+	got, err := v.Get("myapp/PLAIN")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "no-match-value" {
+		t.Errorf("Get = %q, want the literal value", got)
+	}
+}
+
+// TestLinkOnSetFiresOnSetWithOriginalValue: the agent-cache sweep hunts
+// copies of the REAL value, which was on disk regardless of where the
+// vault now points — so an intercepted write must report the plaintext,
+// exactly once, and never the op:// string.
+func TestLinkOnSetFiresOnSetWithOriginalValue(t *testing.T) {
+	v := newTestVault(t)
+	v.LinkOnSet = func(string, []byte, Meta) (string, bool) { return testRef, true }
+	var reported []string
+	v.OnSet = func(path string, value []byte) {
+		reported = append(reported, string(value))
+	}
+
+	if err := v.SetWithMeta("myapp/TOKEN", []byte("the-real-value"), Meta{}); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+	if len(reported) != 1 || reported[0] != "the-real-value" {
+		t.Errorf("OnSet saw %q, want exactly [the-real-value]", reported)
+	}
+}
+
+func TestSetReferenceNeverFiresOnSetOrConsultsHook(t *testing.T) {
+	v := newTestVault(t)
+	v.LinkOnSet = func(string, []byte, Meta) (string, bool) {
+		t.Error("LinkOnSet consulted by SetReference; the caller already chose the reference")
+		return "", false
+	}
+	v.OnSet = func(path string, value []byte) {
+		t.Errorf("OnSet fired for a reference write with %q; a reference is not a credential", value)
+	}
+	if err := v.SetReference("stripe/live", testRef, Meta{Class: ClassOnePassword}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+}
+
+func TestLinkOnSetSkipsReservedNamespaces(t *testing.T) {
+	v := newTestVault(t)
+	v.LinkOnSet = func(path string, _ []byte, _ Meta) (string, bool) {
+		t.Errorf("LinkOnSet consulted for reserved path %q; jit's own bookkeeping must never be diverted", path)
+		return "", false
+	}
+	backup := BackupPathPrefix + "home/x/.env/1234567890"
+	if err := v.SetWithMeta(backup, []byte("KEY=whole-file-backup-content\n"), Meta{}); err != nil {
+		t.Fatalf("SetWithMeta backup: %v", err)
+	}
+	info, err := v.Info(backup)
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != "" {
+		t.Errorf("backup Storage = %q, want literal", info.Storage)
+	}
+}

--- a/internal/vault/reference_test.go
+++ b/internal/vault/reference_test.go
@@ -1,0 +1,306 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import (
+	"bytes"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeResolver resolves any op:// reference to a canned value, recording
+// what it was asked for.
+type fakeResolver struct {
+	value []byte
+	err   error
+	asked []string
+}
+
+func (r *fakeResolver) ResolveRef(ref string) ([]byte, error) {
+	r.asked = append(r.asked, ref)
+	if r.err != nil {
+		return nil, r.err
+	}
+	return bytes.Clone(r.value), nil
+}
+
+const testRef = "op://vaultid123/itemid456/fieldid789"
+
+func TestReferenceRoundTripResolvesThroughResolver(t *testing.T) {
+	v := newTestVault(t)
+	r := &fakeResolver{value: []byte("live-credential")}
+	v.RefResolver = r
+
+	if err := v.SetReference("stripe/live", testRef, Meta{Class: ClassOnePassword}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	got, err := v.Get("stripe/live")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "live-credential" {
+		t.Errorf("Get = %q, want the resolver's value", got)
+	}
+	if len(r.asked) != 1 || r.asked[0] != testRef {
+		t.Errorf("resolver asked for %v, want exactly [%s]", r.asked, testRef)
+	}
+
+	info, err := v.Info("stripe/live")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != StorageOpRef {
+		t.Errorf("Info.Storage = %q, want %q", info.Storage, StorageOpRef)
+	}
+	if info.Class != ClassOnePassword {
+		t.Errorf("Info.Class = %q, want %q", info.Class, ClassOnePassword)
+	}
+}
+
+func TestReferenceGetWithoutResolverFailsTyped(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.SetReference("stripe/live", testRef, Meta{}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	_, err := v.Get("stripe/live")
+	if !errors.Is(err, ErrRefUnresolvable) {
+		t.Fatalf("Get without a resolver = %v, want ErrRefUnresolvable", err)
+	}
+	// The typed failure must not leak the reference URI into the error: an
+	// op:// path names the user's 1Password layout and the caller may print
+	// this error anywhere.
+	if err != nil && strings.Contains(err.Error(), "op://") {
+		t.Errorf("error %q leaks the reference URI", err)
+	}
+}
+
+func TestReferenceResolverErrorSurfaces(t *testing.T) {
+	v := newTestVault(t)
+	v.RefResolver = &fakeResolver{err: errors.New("1password is locked")}
+	if err := v.SetReference("stripe/live", testRef, Meta{}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	_, err := v.Get("stripe/live")
+	if err == nil || !strings.Contains(err.Error(), "1password is locked") {
+		t.Fatalf("Get = %v, want the resolver's error surfaced", err)
+	}
+}
+
+// TestStorageMarkerIsAADBound is the property the explicit-marker design
+// exists for: flipping storage on disk (either direction) must fail
+// decryption, never change what Get does.
+func TestStorageMarkerIsAADBound(t *testing.T) {
+	flip := func(t *testing.T, v *Vault, path, newStorage string) {
+		t.Helper()
+		file := filepath.Join(v.Root, "vault", path+".enc")
+		data, err := os.ReadFile(file)
+		if err != nil {
+			t.Fatalf("reading envelope: %v", err)
+		}
+		var env envelope
+		if err := json.Unmarshal(data, &env); err != nil {
+			t.Fatalf("parsing envelope: %v", err)
+		}
+		env.Storage = newStorage
+		edited, err := json.Marshal(env)
+		if err != nil {
+			t.Fatalf("re-encoding envelope: %v", err)
+		}
+		if err := os.WriteFile(file, edited, 0o600); err != nil {
+			t.Fatalf("writing edited envelope: %v", err)
+		}
+	}
+
+	t.Run("literal marked as reference", func(t *testing.T) {
+		v := newTestVault(t)
+		v.RefResolver = &fakeResolver{value: []byte("attacker-controlled")}
+		if err := v.Set("db/password", []byte("op://looks/like/a-ref")); err != nil {
+			t.Fatalf("Set: %v", err)
+		}
+		flip(t, v, "db/password", StorageOpRef)
+		if _, err := v.Get("db/password"); err == nil {
+			t.Fatal("Get succeeded on a literal flipped to reference, want AAD failure")
+		}
+	})
+
+	t.Run("reference marked as literal", func(t *testing.T) {
+		v := newTestVault(t)
+		if err := v.SetReference("db/password", testRef, Meta{}); err != nil {
+			t.Fatalf("SetReference: %v", err)
+		}
+		flip(t, v, "db/password", "")
+		if _, err := v.Get("db/password"); err == nil {
+			t.Fatal("Get succeeded on a reference flipped to literal, want AAD failure")
+		}
+	})
+}
+
+// A literal Set over a linked path replaces the pointer with a value: the
+// storage marker must clear, and Get must return the new literal without
+// consulting any resolver.
+func TestLiteralSetOverReferenceClearsStorage(t *testing.T) {
+	v := newTestVault(t)
+	r := &fakeResolver{value: []byte("resolved")}
+	v.RefResolver = r
+
+	if err := v.SetReference("api/key", testRef, Meta{Class: ClassOnePassword}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	if err := v.Set("api/key", []byte("literal-now")); err != nil {
+		t.Fatalf("Set over reference: %v", err)
+	}
+
+	got, err := v.Get("api/key")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "literal-now" {
+		t.Errorf("Get = %q, want the literal value", got)
+	}
+	if len(r.asked) != 0 {
+		t.Errorf("resolver was consulted %v times for a literal secret", r.asked)
+	}
+	info, err := v.Info("api/key")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != "" {
+		t.Errorf("Info.Storage = %q after literal Set, want empty", info.Storage)
+	}
+	// Provenance rotates as always: birth class survives the overwrite.
+	if info.Class != ClassOnePassword {
+		t.Errorf("Info.Class = %q, want birth class preserved on rotation", info.Class)
+	}
+}
+
+// TestRekeyCarriesStorage pins that a rekey round-trips the storage
+// marker: rewrapFile re-encodes the whole envelope struct, and a dropped
+// field here would silently turn a pointer into garbage.
+func TestRekeyCarriesStorage(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.SetReference("linked/secret", testRef, Meta{}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+
+	oldKW := v.KeyWrapper
+	newKW := newFakeKeyWrapper()
+	if _, _, err := v.RewrapAll(oldKW, newKW); err != nil {
+		t.Fatalf("RewrapAll: %v", err)
+	}
+
+	v.KeyWrapper = newKW
+	r := &fakeResolver{value: []byte("still-linked")}
+	v.RefResolver = r
+	got, err := v.Get("linked/secret")
+	if err != nil {
+		t.Fatalf("Get after rekey: %v", err)
+	}
+	if string(got) != "still-linked" {
+		t.Errorf("Get after rekey = %q, want the resolver's value", got)
+	}
+	if len(r.asked) != 1 || r.asked[0] != testRef {
+		t.Errorf("resolver asked for %v after rekey, want exactly [%s]", r.asked, testRef)
+	}
+}
+
+// Export must carry the reference, not a resolved value (an export is a
+// vault backup, not a 1Password read), and Import must restore a link AS
+// a link.
+func TestExportImportRoundTripsReference(t *testing.T) {
+	v := newTestVault(t)
+	// No resolver on either side: if export or import tried to resolve,
+	// it would fail with ErrRefUnresolvable and the test would catch it.
+	if err := v.SetReference("linked/secret", testRef, Meta{}); err != nil {
+		t.Fatalf("SetReference: %v", err)
+	}
+	if err := v.Set("plain/secret", []byte("value")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	env, err := v.Export([]byte("passphrase"))
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	restored := newTestVault(t)
+	n, err := restored.Import(env, []byte("passphrase"))
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("Import restored %d secrets, want 2", n)
+	}
+
+	info, err := restored.Info("linked/secret")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.Storage != StorageOpRef {
+		t.Errorf("restored Info.Storage = %q, want %q — the link froze into a literal", info.Storage, StorageOpRef)
+	}
+	r := &fakeResolver{value: []byte("resolved-on-new-machine")}
+	restored.RefResolver = r
+	got, err := restored.Get("linked/secret")
+	if err != nil {
+		t.Fatalf("Get restored reference: %v", err)
+	}
+	if string(got) != "resolved-on-new-machine" {
+		t.Errorf("Get = %q, want resolution through the restored link", got)
+	}
+	if len(r.asked) != 1 || r.asked[0] != testRef {
+		t.Errorf("resolver asked for %v, want the original reference", r.asked)
+	}
+
+	plain, err := restored.Get("plain/secret")
+	if err != nil {
+		t.Fatalf("Get restored literal: %v", err)
+	}
+	if string(plain) != "value" {
+		t.Errorf("restored literal = %q, want %q", plain, "value")
+	}
+}
+
+// A version-1 export (bare path→value map, written by every jit before
+// the storage marker existed) must import forever.
+func TestImportReadsVersionOneExports(t *testing.T) {
+	v := newTestVault(t)
+
+	// Hand-build a v1 export exactly as the old Export wrote it.
+	values := map[string][]byte{"old/secret": []byte("v1-value")}
+	plaintext, err := json.Marshal(values)
+	if err != nil {
+		t.Fatalf("encoding v1 payload: %v", err)
+	}
+	salt := bytes.Repeat([]byte{0x01}, argon2SaltSize)
+	key := deriveExportKey([]byte("passphrase"), salt)
+	sealed, err := seal(key, plaintext, nil)
+	if err != nil {
+		t.Fatalf("sealing v1 payload: %v", err)
+	}
+	env := &ExportEnvelope{
+		Version: 1,
+		Salt:    hex.EncodeToString(salt),
+		Payload: hex.EncodeToString(sealed),
+	}
+
+	n, err := v.Import(env, []byte("passphrase"))
+	if err != nil {
+		t.Fatalf("Import of v1 export: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("Import restored %d secrets, want 1", n)
+	}
+	got, err := v.Get("old/secret")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != "v1-value" {
+		t.Errorf("Get = %q, want %q", got, "v1-value")
+	}
+}

--- a/internal/vault/refresolver.go
+++ b/internal/vault/refresolver.go
@@ -1,0 +1,29 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import "errors"
+
+// ErrRefUnresolvable is returned (wrapped, with the secret's path and
+// reference kind) when Get opens a reference-kind envelope on a Vault with
+// no RefResolver. It exists so surfaces that must never block on an
+// external tool's GUI prompt can opt out by construction — they simply
+// build their Vault without a resolver — and still fail with a typed,
+// explainable error instead of a mystery.
+var ErrRefUnresolvable = errors.New("secret is a reference but this vault has no resolver")
+
+// RefResolver resolves a reference-kind payload (see envelope.Storage) to
+// the secret bytes it names. It mirrors the KeyWrapper seam: this package
+// has no opinion about WHERE references resolve — internal/onepassword is
+// the shipped implementation, exec-ing the `op` CLI — and dispatches on
+// nothing but the stored, AAD-bound storage marker. Reference schemes are
+// the resolver's business: a resolver must reject a reference it does not
+// recognize rather than guess.
+//
+// A resolver may block on user interaction (1Password's own unlock
+// prompt), so callers on interaction-free paths must leave the Vault's
+// RefResolver nil rather than wrap a resolver in a timeout of their own.
+type RefResolver interface {
+	ResolveRef(ref string) ([]byte, error)
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -31,6 +31,13 @@ type Vault struct {
 	KeyWrapper  KeyWrapper
 	RecipientID string
 
+	// RefResolver, when non-nil, is what Get uses to resolve a
+	// reference-kind envelope (envelope.Storage) into the secret bytes it
+	// names. Nil is a valid configuration meaning "this surface never
+	// resolves": Get then fails a reference read with ErrRefUnresolvable
+	// instead of blocking on an external tool. See refresolver.go.
+	RefResolver RefResolver
+
 	// OnSet, when non-nil, is called with every secret this Vault stores,
 	// after the write succeeds. It exists so a caller can act on the set of
 	// credentials IT just vaulted without every writer having to hand them
@@ -109,7 +116,33 @@ func (v *Vault) Set(path string, value []byte) error {
 // still that key, born where it was born. A genuinely new path gets
 // CreatedUnix == UpdatedUnix and takes its provenance from meta (with Origin,
 // when present, stamped as seen now).
+//
+// The storage marker does NOT rotate like provenance: SetWithMeta always
+// writes a literal-value envelope, so a literal Set over a linked path
+// (see SetReference) deliberately turns the pointer back into a value —
+// the caller explicitly replaced it.
 func (v *Vault) SetWithMeta(path string, value []byte, meta Meta) error {
+	return v.setEnvelope(path, value, meta, "")
+}
+
+// SetReference stores ref (a 1Password op:// secret reference) at path as
+// a reference-kind envelope: encrypted, provenance-stamped, and rotated
+// exactly like any secret, but marked (AAD-bound, see envelope.Storage)
+// so Get resolves it through the Vault's RefResolver instead of returning
+// it. The reference is deliberately sealed like a value — an op:// URI
+// names the user's 1Password credential map, and gating its unwrap is
+// what keeps per-process consent meaningful for linked secrets.
+//
+// SetReference validates nothing about ref beyond the caller's own
+// checks: whether it resolves is the resolver's business (the CLI's
+// `jit vault link` trial-resolves before writing).
+func (v *Vault) SetReference(path, ref string, meta Meta) error {
+	return v.setEnvelope(path, []byte(ref), meta, StorageOpRef)
+}
+
+// setEnvelope is SetWithMeta and SetReference's shared core; storage says
+// what the payload is (see envelope.Storage).
+func (v *Vault) setEnvelope(path string, value []byte, meta Meta, storage string) error {
 	dest, err := sanitizeSecretPath(v.vaultDir(), path)
 	if err != nil {
 		return err
@@ -146,7 +179,7 @@ func (v *Vault) SetWithMeta(path string, value []byte, meta Meta) error {
 	}
 	defer wipe(dek)
 
-	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, created, now, class, groupID, origin))
+	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, created, now, class, groupID, origin, storage))
 	if err != nil {
 		return fmt.Errorf("encrypting secret: %w", err)
 	}
@@ -177,6 +210,7 @@ func (v *Vault) SetWithMeta(path string, value []byte, meta Meta) error {
 		GroupID:        groupID,
 		Origin:         origin,
 		OriginSeenUnix: originSeen,
+		Storage:        storage,
 		Recipients: map[string]string{
 			v.RecipientID: hex.EncodeToString(wrappedDEK),
 		},
@@ -220,11 +254,48 @@ func (v *Vault) readEnvelope(path string) (envelope, error) {
 	return env, nil
 }
 
-// Get decrypts and returns the secret stored at path.
+// Get decrypts and returns the secret stored at path. A reference-kind
+// envelope (envelope.Storage) is resolved through RefResolver, so every
+// caller receives the secret VALUE and cannot tell a linked secret from a
+// stored one; a Vault built without a resolver fails such a read with
+// ErrRefUnresolvable instead. Export is the one caller that must NOT
+// resolve (an export is a vault backup, not a 1Password read) and uses
+// getStored directly.
 func (v *Vault) Get(path string) ([]byte, error) {
-	env, err := v.readEnvelope(path)
+	plaintext, storage, err := v.getStored(path)
 	if err != nil {
 		return nil, err
+	}
+	switch storage {
+	case "":
+		return plaintext, nil
+	case StorageOpRef:
+		if v.RefResolver == nil {
+			wipe(plaintext)
+			return nil, fmt.Errorf("secret %s: %w", path, ErrRefUnresolvable)
+		}
+		resolved, err := v.RefResolver.ResolveRef(string(plaintext))
+		wipe(plaintext)
+		if err != nil {
+			return nil, fmt.Errorf("resolving %s: %w", path, err)
+		}
+		return resolved, nil
+	default:
+		// Fail closed on a storage kind this build doesn't know, exactly
+		// like the version gate: returning the payload would hand a caller
+		// expecting a credential some future marker's raw pointer.
+		wipe(plaintext)
+		return nil, fmt.Errorf("secret %s has storage kind %q, newer than this jit understands, upgrade jit to read it", path, storage)
+	}
+}
+
+// getStored decrypts and returns the payload stored at path exactly as
+// stored, plus its storage marker, never touching RefResolver — Get's
+// core, and Export's non-resolving read.
+func (v *Vault) getStored(path string) ([]byte, string, error) {
+	env, err := v.readEnvelope(path)
+	if err != nil {
+		return nil, "", err
 	}
 
 	// The AAD the payload must open under is decided by the envelope's own
@@ -238,22 +309,23 @@ func (v *Vault) Get(path string) ([]byte, error) {
 	switch env.Version {
 	case envelopeVersionAADLess:
 		// v1: no AAD, no metadata. Readable forever.
-	case envelopeVersionMetaOnly, envelopeVersion:
-		// v2 and v3 both bind their metadata into the AAD; envelopeAAD
+	case envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersion:
+		// v2, v3, and v4 all bind their metadata into the AAD; envelopeAAD
 		// reconstructs the exact shape the stored version sealed under
-		// (v3 appends class/group/origin, which are empty on a v2 file).
-		aad = envelopeAAD(path, env.Version, env.CreatedUnix, env.UpdatedUnix, env.Class, env.GroupID, env.Origin)
+		// (v3 appends class/group/origin, v4 adds storage — all empty on
+		// the versions that predate them).
+		aad = envelopeAAD(path, env.Version, env.CreatedUnix, env.UpdatedUnix, env.Class, env.GroupID, env.Origin, env.Storage)
 	default:
-		return nil, fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
+		return nil, "", fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
 	}
 
 	wrappedHex, err := env.wrappedDEKFor(v.RecipientID, path)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	wrappedDEK, err := hex.DecodeString(wrappedHex)
 	if err != nil {
-		return nil, fmt.Errorf("corrupt envelope %s: invalid recipient encoding: %w", path, err)
+		return nil, "", fmt.Errorf("corrupt envelope %s: invalid recipient encoding: %w", path, err)
 	}
 	// Payload decoded BEFORE unwrapKey: that call is where a Touch
 	// ID/passcode prompt can fire, and a corrupt envelope should fail
@@ -261,20 +333,20 @@ func (v *Vault) Get(path string) ([]byte, error) {
 	// watch turn into an error.
 	sealedPayload, err := hex.DecodeString(env.Payload)
 	if err != nil {
-		return nil, fmt.Errorf("corrupt envelope %s: invalid payload encoding: %w", path, err)
+		return nil, "", fmt.Errorf("corrupt envelope %s: invalid payload encoding: %w", path, err)
 	}
 
 	dek, err := v.unwrapKey(wrappedDEK, path, env.Class)
 	if err != nil {
-		return nil, fmt.Errorf("unwrapping data encryption key: %w", err)
+		return nil, "", fmt.Errorf("unwrapping data encryption key: %w", err)
 	}
 	defer wipe(dek)
 
 	plaintext, err := open(dek, sealedPayload, aad)
 	if err != nil {
-		return nil, fmt.Errorf("decrypting %s: %w", path, err)
+		return nil, "", fmt.Errorf("decrypting %s: %w", path, err)
 	}
-	return plaintext, nil
+	return plaintext, env.Storage, nil
 }
 
 // WrappedDEK returns the wrapped data key this device would use to open the
@@ -321,6 +393,12 @@ type SecretInfo struct {
 	GroupID        string
 	Origin         string
 	OriginSeenUnix int64
+	// Storage is the envelope's payload-kind marker ("" for a literal
+	// value, StorageOpRef for a 1Password reference) — what lets listings
+	// tag a linked secret without decrypting anything. Like the rest of
+	// Info it reports what the file claims; the AAD check that keeps the
+	// claim honest runs in Get.
+	Storage string
 }
 
 // Verify checks that the secret at path is structurally intact and readable
@@ -344,7 +422,7 @@ func (v *Vault) Verify(path string) error {
 	// "corruption" that isn't corruption at all, so name it as such rather
 	// than letting it read as a damaged file.
 	switch env.Version {
-	case envelopeVersionAADLess, envelopeVersionMetaOnly, envelopeVersion:
+	case envelopeVersionAADLess, envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersion:
 	default:
 		return fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
 	}
@@ -386,6 +464,7 @@ func (v *Vault) Info(path string) (SecretInfo, error) {
 		GroupID:        env.GroupID,
 		Origin:         env.Origin,
 		OriginSeenUnix: env.OriginSeenUnix,
+		Storage:        env.Storage,
 	}, nil
 }
 

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -260,9 +260,9 @@ func (v *Vault) readEnvelope(path string) (envelope, error) {
 // stored one; a Vault built without a resolver fails such a read with
 // ErrRefUnresolvable instead. Export is the one caller that must NOT
 // resolve (an export is a vault backup, not a 1Password read) and uses
-// getStored directly.
+// GetStored directly.
 func (v *Vault) Get(path string) ([]byte, error) {
-	plaintext, storage, err := v.getStored(path)
+	plaintext, storage, err := v.GetStored(path)
 	if err != nil {
 		return nil, err
 	}
@@ -289,10 +289,10 @@ func (v *Vault) Get(path string) ([]byte, error) {
 	}
 }
 
-// getStored decrypts and returns the payload stored at path exactly as
+// GetStored decrypts and returns the payload stored at path exactly as
 // stored, plus its storage marker, never touching RefResolver — Get's
 // core, and Export's non-resolving read.
-func (v *Vault) getStored(path string) ([]byte, string, error) {
+func (v *Vault) GetStored(path string) ([]byte, string, error) {
 	env, err := v.readEnvelope(path)
 	if err != nil {
 		return nil, "", err

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -38,8 +38,10 @@ type Vault struct {
 	// instead of blocking on an external tool. See refresolver.go.
 	RefResolver RefResolver
 
-	// OnSet, when non-nil, is called with every secret this Vault stores,
-	// after the write succeeds. It exists so a caller can act on the set of
+	// OnSet, when non-nil, is called with every secret VALUE this Vault
+	// stores, after the write succeeds (reference writes carry no
+	// credential and never fire it — except through LinkOnSet's intercept,
+	// which fires it with the intercepted plaintext; see below). It exists so a caller can act on the set of
 	// credentials IT just vaulted without every writer having to hand them
 	// back: `jit migrate` uses it to find and remove the copies AI agents
 	// keep of the values it has just moved (internal/migrate/agentcache.go),
@@ -53,6 +55,24 @@ type Vault struct {
 	// the trust boundary, where a callback in the writer's own process would
 	// prove nothing.
 	OnSet func(path string, value []byte)
+
+	// LinkOnSet, when non-nil, is consulted by SetWithMeta before a literal
+	// value is sealed: returning (ref, true) stores that op:// reference at
+	// the path instead of the value — SetReference semantics, the caller's
+	// meta untouched, so the secret keeps its migrator's class and only the
+	// AAD-bound storage marker records the linkedness. It exists for the
+	// same reason OnSet does: `jit migrate` dedupes what it vaults against
+	// the user's 1Password (design/1password-adapter.md), and the
+	// alternative was threading a matcher through nineteen Apply*
+	// signatures. Paths in jit's own bookkeeping namespaces
+	// (IsReservedPath — whole-file backups, history) are never offered to
+	// the hook: they are jit's copies, not credentials to dedupe.
+	//
+	// On an intercepted write, OnSet still fires with the ORIGINAL
+	// plaintext, never the reference — OnSet's consumer hunts stray copies
+	// of the real value, which existed on disk regardless of where the
+	// vault now points.
+	LinkOnSet func(path string, value []byte, meta Meta) (ref string, ok bool)
 }
 
 func (v *Vault) vaultDir() string {
@@ -117,11 +137,24 @@ func (v *Vault) Set(path string, value []byte) error {
 // CreatedUnix == UpdatedUnix and takes its provenance from meta (with Origin,
 // when present, stamped as seen now).
 //
-// The storage marker does NOT rotate like provenance: SetWithMeta always
-// writes a literal-value envelope, so a literal Set over a linked path
+// The storage marker does NOT rotate like provenance: SetWithMeta writes
+// a literal-value envelope, so a literal Set over a linked path
 // (see SetReference) deliberately turns the pointer back into a value —
-// the caller explicitly replaced it.
+// the caller explicitly replaced it. The one exception is LinkOnSet:
+// when that hook claims the write, the value is stored as the op://
+// reference it returned instead (see the field's doc comment).
 func (v *Vault) SetWithMeta(path string, value []byte, meta Meta) error {
+	if v.LinkOnSet != nil && !IsReservedPath(path) {
+		if ref, ok := v.LinkOnSet(path, value, meta); ok {
+			if err := v.setEnvelope(path, []byte(ref), meta, StorageOpRef); err != nil {
+				return err
+			}
+			if v.OnSet != nil {
+				v.OnSet(path, value)
+			}
+			return nil
+		}
+	}
 	return v.setEnvelope(path, value, meta, "")
 }
 
@@ -225,8 +258,12 @@ func (v *Vault) setEnvelope(path string, value []byte, meta Meta, storage string
 		return err
 	}
 	// After the write succeeds, never before: a caller acting on "what did I
-	// just vault" must not be told about a secret that failed to land.
-	if v.OnSet != nil {
+	// just vault" must not be told about a secret that failed to land. And
+	// only for VALUES: an op:// reference is not a credential, so a
+	// reference write reports nothing here — SetWithMeta's link path
+	// reports the plaintext it intercepted itself, and a direct
+	// SetReference has no plaintext to report.
+	if v.OnSet != nil && storage == "" {
 		v.OnSet(path, value)
 	}
 	return nil

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -458,7 +458,7 @@ func TestVaultOverwritePreservesCreatedUnix(t *testing.T) {
 func rewriteEnvelopeTimestamps(v *Vault, path string, value []byte, createdUnix, updatedUnix int64) error {
 	kw := v.KeyWrapper.(*fakeKeyWrapper)
 	dek := bytes.Repeat([]byte{0x0a}, dekSize)
-	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, createdUnix, updatedUnix, "", "", ""))
+	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, createdUnix, updatedUnix, "", "", "", ""))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #60.

jit can now use 1Password as the system of record for a secret: the vault stores an `op://` secret reference (encrypted like any value, AAD-bound), and every delivery surface — `jit run`, credential helpers, mounts, `jit export` — resolves it through the 1Password CLI at the moment of use. No copy that could drift is ever created, jit is never given a 1Password credential, and jit never writes to 1Password.

## What's in it

**Storage: envelope v4** (`internal/vault`). A new AAD-bound `storage` marker distinguishes a literal value from a reference; v1–v3 envelopes stay readable forever. A `RefResolver` seam mirrors `KeyWrapper` (nil = this surface never resolves, typed `ErrRefUnresolvable`). Rekey, history/restore, and export/import all round-trip linkedness; export carries the reference, never the value.

**Resolver: exec boundary, no SDK** (`internal/onepassword`). Resolves via `op read -n` (byte-exact), and refuses to run any `op` that does not carry 1Password's (AgileBits') Developer ID code signature — fail closed, no override flag. Zero new Go modules (TECH_STACK.md §2.13).

**Manual linking**: `jit vault link <path> <op://...>` trial-resolves first (typos and signed-out CLIs fail at link time, not first use), then stores under a fresh Touch ID. The `1password` class is consent-gated like every credential class.

**Automatic linking**: with `op` installed, every `jit migrate` run dedupes against 1Password by default (`--no-1password` opts out). One authenticated enumeration after the plan's [y/N] — the plan itself never contacts op, only a PATH probe — then values that byte-exactly match a concealed 1Password field are vaulted as rename-proof ID-form references, and values that already ARE `op://` references (a `.env` kept for `op run`) stay references instead of becoming dead literal strings. The mutation log lists every link; a signed-out or locked CLI fails open to plain copies with one amber note. Matching floor: 8 bytes, so `PASSWORD=admin` never links.

**Scan**: `op://` values are formally non-findings via the unresolved-reference rule (they were unflagged by accident before), and a flagged `.env` that mixes plaintext with references gets one note that migrate keeps them linked. Scan never contacts 1Password.

**Visibility**: `vault list -l` tags linked rows and the footer counts them; `jit doctor` grows an automatic, prompt-free `[1password]` section (missing/unverified `op` with linked secrets = hard problem, codesign only, op never executed) and an explicit `jit doctor --1password` sweep that test-resolves every link — a reference broken by a deleted or renamed item becomes a finding with exit 2 instead of a delivery-time failure.

## Verified live

Full end-to-end suite against a real 1Password account (174 items), recorded in `design/1password-adapter.md`: match/verbatim/copy paths, rotation without re-link, the rename split (ID-form links survive an item rename; verbatim name-form links fail loud with op's own error — the user's `op run` fragility preserved, not silently rewritten), duplicate values, the match floor with a real concealed "admin" field present, `--no-1password`, dry-run parity, decoy mounts without an op session, byte-exact undo, a PATH-planted fake `op` rejected before execution, dead-link doctor findings, and a complete `jit audit` trail.

## Design doc

`design/1password-adapter.md` carries the full design, the verified claims (against both the codebase and the 1Password CLI docs), both dogfood records, and the out-of-scope list (`--from-op` bulk import, multi-account pinning, resolve audit kind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01THjo8pbPsHVDfnm6gUKZzT