### PR TITLE
Dry-run refactor: one frame, a complete plan, a scan that keeps its promises

### DIFF
--- a/design/dry-run-refactor.md
+++ b/design/dry-run-refactor.md
@@ -1,8 +1,8 @@
 # Dry-run refactor: one frame, a complete plan, a scan that keeps its promises
 
-**Status: approved design, unimplemented. Preview rendering approved by
-eye 2026-08-17 (scratchpad `dryrun-preview.zsh`); this document is the
-spec for the implementation.**
+**Status: implemented, 2026-08-17 (branch dryrun-frame, five commits —
+one per phase). Preview rendering approved by eye 2026-08-17; this
+document is the spec the implementation followed.**
 
 `--dry-run` is the product's consent surface: the plan it prints is the
 thing a real run's `[y/N]` commits to, byte for byte (GAPS.md #26). A

--- a/design/dry-run-refactor.md
+++ b/design/dry-run-refactor.md
@@ -1,0 +1,160 @@
+# Dry-run refactor: one frame, a complete plan, a scan that keeps its promises
+
+**Status: approved design, unimplemented. Preview rendering approved by
+eye 2026-08-17 (scratchpad `dryrun-preview.zsh`); this document is the
+spec for the implementation.**
+
+`--dry-run` is the product's consent surface: the plan it prints is the
+thing a real run's `[y/N]` commits to, byte for byte (GAPS.md #26). A
+live dogfood run (bare `jit migrate --dry-run`, 2026-08-17) showed that
+surface fraying in four ways at once, and a code sweep found the frame
+was never owned by anyone. This refactor makes three guarantees:
+
+1. **One frame.** Every dry-run prints exactly two `[DRY RUN]` markers:
+   a banner as the first line, a trailer as the last. Nothing else
+   carries a prefix, no lowercase `[dry-run]` variant exists anywhere.
+2. **A complete plan.** Everything a real run will do appears as a plan
+   row and is counted in the subtotal: file rewrites, CLI wraps (with
+   kind-specific consequences, including the shell-rc PATH edit), the
+   history guard, and the post-migrate agent-cache sweep.
+3. **scan and migrate agree.** `jit scan` never counts a finding as
+   "jit will protect these" that `jit migrate` will then refuse.
+
+## What the dogfood run showed
+
+- Three `[DRY RUN]` banners plus a stray lowercase `[dry-run] would
+  wrap clisso` AFTER the "No files were changed" trailer. Cause: the
+  banner/trailer live inside `applyMigrate`, but `runMigrateAll`
+  prints wrap/guard disclosures before calling it and wrap lines after
+  it returns. In a wraps-only run (`d.total()==0`) there is no banner
+  and no trailer at all.
+- The clisso wrap appeared in two prose paragraphs but never in the
+  plan body; "2 changes planned across 2 categories" excluded it.
+- `jit scan` promised `Secret.yaml` under "jit will protect these"
+  (+3%); migrate then skipped it as complex (mixed
+  `data:`/`stringData:`). `remedy.go` gives every ConfidenceHigh k8s
+  manifest `RemedyMigrate` without running migrate's classifier.
+- A real run rewrites files the plan never listed: the agent-cache
+  sweep (`CleanAgentCaches`) redacts copies of just-vaulted values,
+  and `ensureShimOnPath` appends a PATH line to the shell rc. Neither
+  was previewed. `jit wrap <tool>` has no `--dry-run` at all.
+
+## Decisions
+
+**D1. The command runner owns the frame, not `applyMigrate`.**
+Two helpers, `printDryRunBanner(out)` and
+`printDryRunTrailer(out, applyCmd, hint)`, are called by each runner
+(`runMigratePath`, `runMigrateAll`, `migrate undo`, `migrate caches`)
+as the first and last output of a dry run. `applyMigrate` stops
+printing either; its dry-run early-return (before the confirm, before
+`openVault`) is unchanged. This closes the wraps-only no-frame hole by
+construction.
+
+**D2. Banner text unchanged; trailer slimmed.** The banner keeps its
+reported-bug rationale (GAPS.md #32) verbatim. The trailer stops
+restating "changes nothing" and carries only what the banner cannot:
+the apply command and the scope hint.
+
+    [DRY RUN] Apply this plan: <the user's own argv, minus --dry-run>
+    This only covers what jit migrate can act on; run jit scan for the
+    complete picture, including findings it can never auto-fix, like
+    private keys.
+
+The apply command echoes the real invocation (path args, `--only`,
+`--mount` preserved), so it is always copy-pasteable. `undo` and
+`caches` pass their own apply command and no scan hint.
+
+**D3. Wraps and the guard become plan categories.** Rendered inside
+`printMigratePlan`, counted in the subtotal, for both `--dry-run` and
+the real confirm, so parity holds by construction. The pre-plan prose
+paragraphs and the post-trailer `[dry-run] would ...` duplicates are
+deleted; the plan row IS the consent line. `printMigratePlan` takes a
+new `planExtras` struct (wrap rows, guard offer, cache preview)
+alongside `discovered`; `runMigratePath` passes an empty one.
+
+Wrap rows state the kind-specific consequence, sourced from the
+compiled-in catalog (no prompts, no network):
+
+- `KindShim`: token discovered from the tool's config moves to the
+  vault; the config is scrubbed (backed up encrypted first).
+- `KindCapture` (clisso): shim reroutes each mint into the vault; the
+  long-lived client-secret in the tool's config moves to the vault.
+- `KindNative`: delegates to the named native-helper migrate flow.
+- `KindRunGrant`: shim only; the k8s migration owns the vaulting.
+
+Every wrap row that would install a first shim also discloses the rc
+edit: "adds the shim PATH line to ~/.zshrc if missing". Detail lines
+use the `└` evidence glyph per `design/output-style.md`.
+
+**D4. The agent-cache sweep is previewed as a plan category.** The
+sweep's needles are plaintext values sitting in the files being
+migrated, readable at plan time without the vault. The plan parses
+them with the existing per-category previews and calls
+`migrate.PreviewAgentCaches` to render an `[AI agent caches]` category
+with the real files, counted in the subtotal. Best-effort: a preview
+error degrades to one note line ("agent caches are swept after
+vaulting; preview unavailable: <err>") and never blocks the plan.
+The real run keeps computing needles from `v.OnSet` as today; the
+preview is disclosure, not the apply path.
+
+**D5. scan asks migrate about k8s manifests.** `audit.Config` gains
+`K8sMigratable func(path) (reason string, ok bool)` (the
+`vault.KeyWrapper` pattern; audit cannot import migrate). cli wires it
+to `migrate.ClassifyK8sSecretManifest`. A refused manifest flips to
+`RemedyManual` with the refusal reason as its evidence line, moving it
+to "only you can fix" and out of the percent promise. Nil hook (tests,
+other callers) keeps today's behavior.
+
+**D6. `--dry-run` is promoted to the wrap and guard surfaces.**
+`jit wrap <tool> --dry-run`, `jit wrap undo <tool> --dry-run`, and
+`jit guard history --dry-run` reuse the same plan-row renderers and
+the same frame helpers. One dry-run vocabulary across the CLI. Native
+wraps preview the delegated command instead of running it.
+
+**D7. Catalog-owned config files route to their wrap.** A named path
+that a catalog tool owns (e.g. `~/.clisso.yaml`) no longer falls
+through to the loose-secret "mixes a secret with other content" skip;
+its skip hint names the real fix: `jit wrap clisso`.
+
+**D8. Style sweep.** `printSkippedFindings` hints go through
+`wrapBody`; skipped paths are middle-truncated with the same helper
+scan uses; the 1Password notice and the wrap disclosure lose their
+hand-placed line breaks; bare-run group headers say "flagged by the
+scan" instead of "you named" (targeted runs keep "you named");
+`migratecaches`' lowercase `[dry-run]` marker is deleted with the
+rest.
+
+## Invariants preserved (do not regress)
+
+- GAPS.md #26: `--dry-run` preview and the real confirm plan are the
+  same rendering; the parity test extends to the new categories.
+- GAPS.md #17: the confirm (and the dry-run early-return) precede
+  `openVault`; declining or previewing never costs a Touch ID prompt.
+- GAPS.md #32: the banner precedes the plan.
+- The plan never prompts: no `op` contact (PATH probe only), no vault
+  open, no agent contact. The cache preview reads files only.
+- `jit scan` stays strictly read-only in every mode (D5 adds a parse,
+  not a write).
+
+## Phases
+
+1. **Frame** (D1, D2): helpers in `migrate.go`; runners own
+   banner/trailer; `undo.go`, `migratecaches.go` adopt them; delete
+   the stray tail prints. Test: exactly two `[DRY RUN]` markers per
+   run, including the wraps-only run.
+2. **Plan completeness** (D3, D4): `planExtras`, wrap/guard/cache
+   categories, subtotal counts them; delete prose disclosures.
+3. **Wrap/guard dry-run** (D6) and skip-hint routing (D7).
+4. **scan coherence** (D5): the hook, remedy flip, evidence line.
+5. **Style** (D8) and the full gate: parity test update,
+   `migrate1password_test`, undo/caches tests, new wraps-only-frame
+   and k8s-remedy-flip tests; `go run ./cmd/jit docs-gen` for the new
+   flags; gofmt/vet/staticcheck/govulncheck/gosec.
+
+## Out of scope
+
+- Previewing which values 1Password will link: requires `op`'s auth
+  prompt, and the plan must stay prompt-free. The notice line is the
+  honest ceiling.
+- Any change to what migrate refuses (complex tfvars/k8s, mixed
+  loose files): this work makes refusals visible earlier, not fewer.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -87,13 +87,21 @@ the plan fixes:
 
 ```
 $ jit migrate ~/code/myapp/.env --dry-run
+[DRY RUN] Preview, this run changes nothing; the plan below is what a real run would do.
+
 jit migrate, plan
 Each modified file is backed up before it's rewritten.
 
-[.env file(s) → secrets move to the vault; the file keeps working as a live, auto-updating mount] (1)
-  • ~/code/myapp/.env
+Project files you named
 
-[DRY RUN] No files were changed. Run without --dry-run to apply this plan.
+[.env file] 1
+  → EVERY variable moves to the vault (ordinary config too, so the file still works); the file keeps working as a live, auto-updating mount
+  • ~/code/myapp/.env (3 variables, 2 secret-shaped)
+
+────────────────────────────────────────────
+  1 change planned across 1 category
+
+[DRY RUN] Apply this plan: jit migrate ~/code/myapp/.env
 ```
 
 Then apply it by dropping `--dry-run`. The same plan prints again, followed

--- a/docs/migrate/index.md
+++ b/docs/migrate/index.md
@@ -76,19 +76,38 @@ is accurate:
 
 ```
 $ jit migrate ~/code/myapp/.env --dry-run
+[DRY RUN] Preview, this run changes nothing; the plan below is what a real run would do.
+
 jit migrate, plan
 Each modified file is backed up before it's rewritten.
 
-[.env file(s) → secrets move to the vault; the file keeps working as a live, auto-updating mount] (1)
-  • /Users/alex/code/myapp/.env
+Project files you named
 
-[DRY RUN] No files were changed. Run without --dry-run to apply this plan.
+[.env file] 1
+  → EVERY variable moves to the vault (ordinary config too, so the file still works); the file keeps working as a live, auto-updating mount
+  • ~/code/myapp/.env (3 variables, 2 secret-shaped)
+
+────────────────────────────────────────────
+  1 change planned across 1 category
+
+[DRY RUN] Apply this plan: jit migrate ~/code/myapp/.env
+This only covers what jit migrate can act on; run jit scan for the complete
+picture, including findings it can never auto-fix, like private keys.
 ```
 
-Then apply it by dropping `--dry-run`. The same plan prints again, followed
+The plan is complete: everything the run will do appears as a counted
+category — including CLI wraps, the shell history guard, and AI-agent
+cache files holding copies of the values being vaulted, when those
+apply. The closing line is your own command minus `--dry-run`, ready to
+paste.
+
+Then apply it by running that command. The same plan prints again, followed
 by a `Proceed? [y/N]` confirmation; answering `y` triggers the vault writes
 (one Touch ID prompt if the service isn't unlocked yet). Declining aborts
 with nothing changed.
+
+`jit wrap <tool>`, `jit wrap undo <tool>`, and `jit guard history` take
+`--dry-run` too, with the same banner-and-trailer frame.
 
 ## The safety model
 

--- a/docs/reference/commands/jit_guard_history.md
+++ b/docs/reference/commands/jit_guard_history.md
@@ -43,7 +43,8 @@ jit guard history [flags]
 ### Options
 
 ```
-      --remove   remove the guard: delete the hook file and take the source line out of ~/.zshrc
+      --dry-run   preview what installing (or --remove: removing) the guard would do without changing anything
+      --remove    remove the guard: delete the hook file and take the source line out of ~/.zshrc
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/commands/jit_wrap.md
+++ b/docs/reference/commands/jit_wrap.md
@@ -15,7 +15,13 @@ Store the secret first (`jit vault set`), then describe the tool:
 catalog of known tools with automatic discovery.
 
 ```
-jit wrap
+jit wrap [flags]
+```
+
+### Options
+
+```
+      --dry-run   preview what wrapping would do without changing anything
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/commands/jit_wrap_undo.md
+++ b/docs/reference/commands/jit_wrap_undo.md
@@ -3,7 +3,13 @@
 Unwrap a tool: remove its shim and wrap profile
 
 ```
-jit wrap undo <tool>
+jit wrap undo <tool> [flags]
+```
+
+### Options
+
+```
+      --dry-run   preview what unwrapping would do without changing anything
 ```
 
 ### Options inherited from parent commands

--- a/internal/audit/credfile_test.go
+++ b/internal/audit/credfile_test.go
@@ -785,7 +785,7 @@ providers:
 	// finding), and annotateRemedies must respect it — the
 	// selfRotatingCaches entry for this file exists for OTHER findings,
 	// not to override this one.
-	annotateRemedies(findings, home)
+	annotateRemedies(findings, home, nil)
 	f = findings[0]
 	if f.Remedy != RemedyWrap {
 		t.Errorf("Remedy = %q, want %q", f.Remedy, RemedyWrap)

--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -676,6 +676,21 @@ type Config struct {
 	// a full home-directory scan runs. nil (the default, and in every test)
 	// means no reporting and identical behavior.
 	Progress func(category string)
+
+	// K8sMigratable, when non-nil, answers whether `jit migrate <path>`
+	// can actually rewrite a structurally parsed Kubernetes Secret
+	// manifest — ok=false comes with migrate's own refusal reason (block
+	// scalars, data: mixed with stringData:, a Helm template that isn't
+	// valid YAML). annotateRemedies consults it so scan never counts a
+	// manifest under "jit will protect these" that migrate will then
+	// refuse (design/dry-run-refactor.md D5 — the +N% promise was
+	// unachievable). A hook rather than an import, the vault.KeyWrapper
+	// pattern: internal/migrate imports this package, so the classifier
+	// can't be called from here directly; the CLI wires it. nil (tests,
+	// other callers) keeps the optimistic pre-hook behavior. Must be
+	// read-only and prompt-free — it runs inside `jit scan`, whose
+	// every mode is strictly read-only.
+	K8sMigratable func(path string) (reason string, ok bool)
 }
 
 // NewConfig builds a Config for a real run against the actual machine.

--- a/internal/audit/fixture_test.go
+++ b/internal/audit/fixture_test.go
@@ -62,7 +62,7 @@ func TestFixtureNotChargedToLedger(t *testing.T) {
 	}
 
 	findings := []Finding{fixture, real}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 	cov := ComputeCoverage("", "", findings)
 	if cov.Exposed != 1 {
 		t.Errorf("exposed = %d, want 1 (the fixture must not inflate the ledger)", cov.Exposed)

--- a/internal/audit/manualaction_test.go
+++ b/internal/audit/manualaction_test.go
@@ -38,7 +38,7 @@ func TestManualActionAgreesPerFile(t *testing.T) {
 			FilePath: "/Users/alex/reports/dump-b.html", KeyName: str("JSON Web Token"),
 			ValuePreview: str("eyJh**********")},
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 2 {
@@ -70,7 +70,7 @@ func TestManualActionCopiesBeatMount(t *testing.T) {
 			ValuePreview: str("pgpw**********"),
 		})
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 1 {
@@ -102,7 +102,7 @@ func TestManualActionStillOffersMountWhereItWorks(t *testing.T) {
 			FilePath: "/Users/alex/bin/deploy.sh", KeyName: str("Database connection string"),
 			ValuePreview: str("pgpw**********")},
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 1 {

--- a/internal/audit/remedy.go
+++ b/internal/audit/remedy.go
@@ -62,7 +62,7 @@ const (
 //     command as THE fix would dress the wound without treating it. The
 //     migrate result output carries the rotation advice for the ordinary
 //     case; for production, rotation IS the remedy and the report says so.
-func annotateRemedies(findings []Finding, home string) {
+func annotateRemedies(findings []Finding, home string, k8sMigratable func(string) (string, bool)) {
 	// Purity is per file and can involve a re-read; cache it, since copies
 	// of one dump produce many findings for the same path.
 	pureCache := map[string]bool{}
@@ -73,6 +73,24 @@ func annotateRemedies(findings []Finding, home string) {
 		v := isPureTokenFile(path)
 		pureCache[path] = v
 		return v
+	}
+	// The migratability probe re-parses the manifest; cache per path, since
+	// one manifest can carry several findings.
+	type k8sVerdict struct {
+		reason string
+		ok     bool
+	}
+	k8sCache := map[string]k8sVerdict{}
+	k8sRefusal := func(path string) (string, bool) {
+		if k8sMigratable == nil {
+			return "", true // no hook wired: keep the optimistic pre-hook behavior
+		}
+		v, cached := k8sCache[path]
+		if !cached {
+			v.reason, v.ok = k8sMigratable(path)
+			k8sCache[path] = v
+		}
+		return v.reason, v.ok
 	}
 	for i := range findings {
 		f := &findings[i]
@@ -93,9 +111,7 @@ func annotateRemedies(findings []Finding, home string) {
 			// wouldn't parse as YAML, line-scanned at ConfidenceMedium) stays
 			// manual: migrate needs a parseable manifest. A structurally
 			// parsed Secret manifest (ConfidenceHigh, buildK8sSecretFinding)
-			// falls through to RemedyMigrate — `jit migrate <path>` either
-			// converts it to a rejectable-decoy mount or explains exactly why
-			// it refused (block scalars, mixed data:/stringData:).
+			// is asked about below.
 			f.Remedy = RemedyManual
 		case f.FindingType == FindingTypeShellHistorySecret && f.ProductionIndicatorMatch:
 			f.Remedy = RemedyManual
@@ -113,6 +129,24 @@ func annotateRemedies(findings []Finding, home string) {
 		case f.FindingType == FindingTypeExposedSecret &&
 			(f.ProductionIndicatorMatch || !isPure(f.FilePath)):
 			f.Remedy = RemedyManual
+		case f.FindingType == FindingTypeIACVariableFile &&
+			!strings.HasSuffix(f.FilePath, ".tfvars") &&
+			f.Confidence == ConfidenceHigh:
+			// A structurally parsed Secret manifest migrate itself refuses
+			// (Config.K8sMigratable) must not be promised as "jit will
+			// protect these": the user runs the recommended command and
+			// gets a skip note for a percent gain that was never
+			// achievable (design/dry-run-refactor.md D5). Manual, with
+			// migrate's own refusal reason in the evidence. When the hook
+			// says ok — or isn't wired — this is RemedyMigrate exactly as
+			// before the hook existed.
+			if reason, ok := k8sRefusal(f.FilePath); !ok {
+				f.Remedy = RemedyManual
+				f.Evidence = "kubernetes Secret manifest `jit migrate` can't rewrite provably right (" + reason + "); sealed-secrets/SOPS or a hand edit is the fix"
+			} else {
+				f.Remedy = RemedyMigrate
+				f.FixCommand = "jit migrate " + shellSafePath(home, f.FilePath)
+			}
 		default:
 			f.Remedy = RemedyMigrate
 			f.FixCommand = "jit migrate " + shellSafePath(home, f.FilePath)

--- a/internal/audit/remedy_test.go
+++ b/internal/audit/remedy_test.go
@@ -42,7 +42,7 @@ func TestAnnotateRemedies(t *testing.T) {
 		{FindingType: FindingTypeWrappableCLIToken, FilePath: filepath.Join(home, ".config/gh/hosts.yml"),
 			Remedy: RemedyWrap, FixCommand: "jit wrap gh", KeyName: str("oauth_token")},
 	}
-	annotateRemedies(findings, home)
+	annotateRemedies(findings, home, nil)
 
 	want := []struct {
 		remedy, fixContains string
@@ -333,5 +333,66 @@ func TestShellSafePathTildeFormResolvesInARealShell(t *testing.T) {
 		if _, err := os.Stat(string(out)); err != nil {
 			t.Errorf("%s: resolved path does not exist: %v", sh, err)
 		}
+	}
+}
+
+// TestK8sMigratableHookFlipsRefusedManifests: Config.K8sMigratable is how
+// scan stops promising a Secret manifest that migrate will refuse
+// (design/dry-run-refactor.md D5). Refused: RemedyManual, migrate's
+// reason in the evidence. ok or nil hook: RemedyMigrate with a
+// FixCommand, the pre-hook behavior.
+func TestK8sMigratableHookFlipsRefusedManifests(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "code", "k8s")
+	mkdirAll(t, dir)
+	manifest := filepath.Join(dir, "secrets.yaml")
+	writeFile(t, manifest, `apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  password: aHVudGVyMg==
+`)
+
+	find := func(cfg Config) Finding {
+		t.Helper()
+		findings, _, err := TargetedScan(cfg, []string{manifest})
+		if err != nil {
+			t.Fatalf("TargetedScan: %v", err)
+		}
+		for _, f := range findings {
+			if f.FindingType == FindingTypeIACVariableFile {
+				return f
+			}
+		}
+		t.Fatalf("no IAC finding for the manifest, got %d findings", len(findings))
+		return Finding{}
+	}
+
+	refused := find(Config{HomeDir: home, K8sMigratable: func(path string) (string, bool) {
+		if path != manifest {
+			t.Errorf("hook asked about %q, want %q", path, manifest)
+		}
+		return "a Secret document uses both data: and stringData:", false
+	}})
+	if refused.Remedy != RemedyManual {
+		t.Errorf("refused manifest remedy = %q, want %q", refused.Remedy, RemedyManual)
+	}
+	if !strings.Contains(refused.Evidence, "can't rewrite provably right") ||
+		!strings.Contains(refused.Evidence, "both data: and stringData:") {
+		t.Errorf("refused evidence should carry migrate's reason, got: %q", refused.Evidence)
+	}
+	if refused.FixCommand != "" {
+		t.Errorf("refused manifest must not carry a FixCommand, got %q", refused.FixCommand)
+	}
+
+	okFinding := find(Config{HomeDir: home, K8sMigratable: func(string) (string, bool) { return "", true }})
+	if okFinding.Remedy != RemedyMigrate || okFinding.FixCommand == "" {
+		t.Errorf("ok verdict: remedy=%q fix=%q, want migrate with a FixCommand", okFinding.Remedy, okFinding.FixCommand)
+	}
+
+	nilHook := find(Config{HomeDir: home})
+	if nilHook.Remedy != RemedyMigrate {
+		t.Errorf("nil hook must keep the pre-hook optimistic remedy, got %q", nilHook.Remedy)
 	}
 }

--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -452,7 +452,7 @@ func TestFirstFindingPathSkipsUnfixable(t *testing.T) {
 		{FindingType: FindingTypePrivateKeyRisk, FilePath: "/home/u/.ssh/id_ed25519", KeyName: &key},
 		{FindingType: FindingTypeCredentialFile, FilePath: "/home/u/.mcp-auth/mcp-remote-0.1.37/abc_tokens.json", KeyName: &key},
 	}
-	annotateRemedies(unfixable, "/home/u")
+	annotateRemedies(unfixable, "/home/u", nil)
 	if got := firstFindingPath(unfixable); got != "" {
 		t.Errorf("firstFindingPath = %q, want \"\" so the trailer falls back to its <path> placeholder", got)
 	}
@@ -464,7 +464,7 @@ func TestFirstFindingPathSkipsUnfixable(t *testing.T) {
 		FilePath:    "/home/u/proj/.streamlit/secrets.toml",
 		KeyName:     &key,
 	})
-	annotateRemedies(mixed, "/home/u")
+	annotateRemedies(mixed, "/home/u", nil)
 	if got := firstFindingPath(mixed); got != "/home/u/proj/.streamlit/secrets.toml" {
 		t.Errorf("firstFindingPath = %q, want the migratable file", got)
 	}

--- a/internal/audit/scan.go
+++ b/internal/audit/scan.go
@@ -145,7 +145,7 @@ func Scan(cfg Config) ([]Finding, ScanSummary, error) {
 	// Same seam, same reason: who can act on each finding (and the id that
 	// groups copies of one secret) is set once, centrally, so every renderer
 	// and consumer reads identical answers.
-	annotateRemedies(all, cfg.HomeDir)
+	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable)
 
 	summary := buildScanSummary(cfg, all, countProtectedMounts(cfg.MountRegistryPath), time.Since(start))
 	summary.FilesScanned = filesWalked

--- a/internal/audit/selfrotating_test.go
+++ b/internal/audit/selfrotating_test.go
@@ -47,7 +47,7 @@ func TestSelfRotatingCacheIsNeverMigrated(t *testing.T) {
 			FilePath: "/Users/alex/.gemini/oauth_creds.json",
 			KeyName:  str("JSON Web Token"), ValuePreview: str("eyJh**********")},
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 
 	if findings[0].Remedy != RemedyManual {
 		t.Errorf("remedy = %q, want %q", findings[0].Remedy, RemedyManual)
@@ -128,7 +128,7 @@ func TestTerraformStateIsManualWithBackendAdvice(t *testing.T) {
 			FilePath: "/Users/alex/infra/terraform.tfstate",
 			KeyName:  str("AWS Secret Access Key"), ValuePreview: str("wJal**********")},
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 	if findings[0].Remedy != RemedyManual {
 		t.Errorf("remedy = %q, want %q", findings[0].Remedy, RemedyManual)
 	}

--- a/internal/audit/shellhistory_test.go
+++ b/internal/audit/shellhistory_test.go
@@ -460,7 +460,7 @@ func TestShellHistoryRemedySplitsOnProductionFlag(t *testing.T) {
 			ProductionIndicatorMatch: true,
 		},
 	}
-	annotateRemedies(findings, home)
+	annotateRemedies(findings, home, nil)
 	if findings[0].Remedy != RemedyMigrate {
 		t.Errorf("ordinary history remedy = %q, want %q", findings[0].Remedy, RemedyMigrate)
 	}

--- a/internal/audit/target.go
+++ b/internal/audit/target.go
@@ -80,7 +80,7 @@ func TargetedScan(cfg Config, targets []string) ([]Finding, ScanSummary, error) 
 	// be handed a repository full of test fixtures.
 	tagArchivedAndFixtures(all)
 	// And the same remedy/cause annotation, for the same no-drift reason.
-	annotateRemedies(all, cfg.HomeDir)
+	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable)
 
 	summary := buildScanSummary(cfg, all, countProtectedMounts(cfg.MountRegistryPath), time.Since(start))
 	summary.Targets = targets

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -40,7 +40,7 @@ func triageFixture() ([]Finding, ScanSummary, Coverage) {
 			FilePath: "/Users/alex/Documents/archive/old/.env", KeyName: str("OLD_KEY"),
 			ValuePreview: str("xk92**********"), Archived: true},
 	}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 	cov := ComputeCoverage("", "", findings)
 	summary := buildScanSummary(Config{Endpoint: Endpoint{Username: "alex", Hostname: "mbp"}}, findings, 0, 2300)
 	summary.FilesScanned = 47312
@@ -518,7 +518,7 @@ func TestWriteTriageReportNeverLeaksRawValue(t *testing.T) {
 		RecordID: "x", FindingType: FindingTypeExposedSecret, Severity: SeverityHigh,
 		FilePath: "/Users/alex/creds.txt", KeyName: &key, ValuePreview: &preview,
 	}}
-	annotateRemedies(findings, "/Users/alex")
+	annotateRemedies(findings, "/Users/alex", nil)
 	cov := ComputeCoverage("", "", findings)
 	summary := buildScanSummary(Config{}, findings, 0, 0)
 

--- a/internal/cli/firstrun.go
+++ b/internal/cli/firstrun.go
@@ -12,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 
-	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/audit"
 	"github.com/jitpass/jit/internal/keychainwrap"
 	"github.com/jitpass/jit/internal/mount"
@@ -171,7 +170,7 @@ func prodFirstRunDeps(cmd *cobra.Command) firstRunDeps {
 // the current directory yields a project-scoped report from the exact same
 // engine and renderer `jit scan` uses.
 func scanRoot(root string) ([]audit.Finding, audit.ScanSummary, error) {
-	cfg, err := audit.NewConfig(agent.Version())
+	cfg, err := newAuditConfig()
 	if err != nil {
 		return nil, audit.ScanSummary{}, err
 	}

--- a/internal/cli/guard.go
+++ b/internal/cli/guard.go
@@ -19,6 +19,7 @@ import (
 )
 
 var guardHistoryRemove bool
+var guardHistoryDryRun bool
 
 var guardCmd = &cobra.Command{
 	Use:     "guard",
@@ -63,6 +64,41 @@ var guardHistoryCmd = &cobra.Command{
 			return fmt.Errorf("jit guard history: %w", err)
 		}
 		out := cmd.OutOrStdout()
+		// --dry-run: the same frame every migrate preview uses
+		// (design/dry-run-refactor.md D6). The no-op answers stay
+		// frameless, matching migrate's "Nothing to migrate" runs — a
+		// banner over "nothing to do" would promise a plan that isn't
+		// there.
+		if guardHistoryDryRun {
+			installed := guard.Installed(home)
+			switch {
+			case guardHistoryRemove && !installed:
+				wrapBody(out, 0, "", "The history guard is not installed, nothing to remove.")
+			case guardHistoryRemove:
+				printDryRunBanner(out)
+				fmt.Fprintln(out, "Remove the history guard:")
+				fmt.Fprintf(out, "  "+glyphBullet+" delete %s\n", displayPath(home, guard.HookPath(home)))
+				if guard.RcCarriesJitLine(home) {
+					fmt.Fprintf(out, "  "+glyphBullet+" take the source line out of %s\n", displayPath(home, guard.RcPath(home)))
+				} else {
+					fmt.Fprint(out, "  ")
+					wrapBody(out, 2, "    ", glyphBullet+" "+displayPath(home, guard.RcPath(home))+" sources the hook by a line jit did not write; it would be left alone")
+				}
+				printDryRunTrailer(out, "jit guard history --remove", false)
+			case installed:
+				wrapBody(out, 0, "", hlCmds(fmt.Sprintf("The history guard is already installed (%s, sourced from %s). Nothing to do.",
+					displayPath(home, guard.HookPath(home)), displayPath(home, guard.RcPath(home)))))
+			default:
+				printDryRunBanner(out)
+				fmt.Fprintln(out, "Install the history guard:")
+				fmt.Fprintf(out, "  "+glyphBullet+" write the zsh hook to %s\n", displayPath(home, guard.HookPath(home)))
+				fmt.Fprintf(out, "  "+glyphBullet+" append its source line to %s\n", displayPath(home, guard.RcPath(home)))
+				fmt.Fprint(out, "  ")
+				wrapBody(out, 2, "    ", glyphBullet+" from then on, a command carrying a recognized credential stays usable in that session but is never written to your history file")
+				printDryRunTrailer(out, "jit guard history", false)
+			}
+			return nil
+		}
 		// Every prose line goes through wrapBody at the indent that owns it
 		// (design/output-style.md rule 6): hard-wrapping at a source-file
 		// width leaves the terminal to break these at column 0 in a narrow
@@ -197,6 +233,7 @@ func guardCheckStdin(r io.Reader) ([]string, error) {
 
 func init() {
 	guardHistoryCmd.Flags().BoolVar(&guardHistoryRemove, "remove", false, "remove the guard: delete the hook file and take the source line out of ~/.zshrc")
+	guardHistoryCmd.Flags().BoolVar(&guardHistoryDryRun, "dry-run", false, "preview what installing (or --remove: removing) the guard would do without changing anything")
 	guardCmd.AddCommand(guardHistoryCmd)
 	guardCmd.AddCommand(guardCheckCmd)
 	rootCmd.AddCommand(guardCmd)

--- a/internal/cli/guard_test.go
+++ b/internal/cli/guard_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/jitpass/jit/internal/auditlog"
+	"github.com/jitpass/jit/internal/guard"
 )
 
 func TestGuardCheckStdinFindsVendors(t *testing.T) {
@@ -115,5 +117,71 @@ func TestGuardInstallBySideEffectIsAudited(t *testing.T) {
 	joined := strings.Join(r.Args, " ")
 	if !strings.Contains(joined, "by jit migrate") {
 		t.Errorf("args = %q, want them to name the command that did it", joined)
+	}
+}
+
+// execGuardHistory drives `jit guard history <args...>` through rootCmd,
+// resetting the package-level flag vars first (same discipline as
+// execMigrate/execWrap).
+func execGuardHistory(t *testing.T, args ...string) (stdout string, err error) {
+	t.Helper()
+	guardHistoryRemove = false
+	guardHistoryDryRun = false
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs(append([]string{"guard", "history"}, args...))
+	err = rootCmd.Execute()
+	return buf.String(), err
+}
+
+// TestGuardHistoryDryRun: install and remove previews carry the shared
+// two-marker frame and change nothing on disk; the no-op answers
+// (already installed / not installed) stay frameless.
+func TestGuardHistoryDryRun(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	out, err := execGuardHistory(t, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit guard history --dry-run: %v", err)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers, got %d:\n%s", got, out)
+	}
+	for _, want := range []string{"Install the history guard:", "guard.zsh", "Apply this plan: jit guard history"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the install preview, got:\n%s", want, out)
+		}
+	}
+	if _, statErr := os.Stat(guard.HookPath(home)); !os.IsNotExist(statErr) {
+		t.Errorf("dry-run must not write the hook (stat err=%v)", statErr)
+	}
+
+	// --remove with nothing installed: a plain answer, no frame.
+	out, err = execGuardHistory(t, "--remove", "--dry-run")
+	if err != nil {
+		t.Fatalf("jit guard history --remove --dry-run: %v", err)
+	}
+	if strings.Contains(out, "[DRY RUN]") || !strings.Contains(out, "not installed") {
+		t.Errorf("expected a frameless not-installed answer, got:\n%s", out)
+	}
+
+	// Install for real, then preview the removal.
+	if _, err := guard.Install(home); err != nil {
+		t.Fatalf("guard.Install: %v", err)
+	}
+	out, err = execGuardHistory(t, "--remove", "--dry-run")
+	if err != nil {
+		t.Fatalf("jit guard history --remove --dry-run (installed): %v", err)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers on the remove preview, got %d:\n%s", got, out)
+	}
+	if !strings.Contains(out, "Remove the history guard:") || !strings.Contains(out, "Apply this plan: jit guard history --remove") {
+		t.Errorf("expected the remove preview, got:\n%s", out)
+	}
+	if !guard.Installed(home) {
+		t.Error("remove --dry-run must leave the guard installed")
 	}
 }

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/audit"
 	"github.com/jitpass/jit/internal/guard"
 	"github.com/jitpass/jit/internal/migrate"
@@ -1371,7 +1370,7 @@ func runMigrateAll(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("jit migrate: %w", err)
 	}
-	cfg, err := audit.NewConfig(agent.Version())
+	cfg, err := newAuditConfig()
 	if err != nil {
 		return fmt.Errorf("jit migrate: %w", err)
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -211,6 +211,63 @@ func printSkippedFindings(w io.Writer, home string, count int, reason string, pa
 	}
 }
 
+// printDryRunBanner is the head of the dry-run frame: the FIRST line a
+// dry run prints, before any plan or disclosure (GAPS.md #32 — the
+// preview-vs-real signal used to live only at the very end, and a reader
+// skimming a long plan mistook it for changes already made). Every
+// dry-run surface prints exactly two [DRY RUN] markers: this banner and
+// printDryRunTrailer's closing line. Nothing else carries the marker —
+// design/dry-run-refactor.md D1/D2, and TestDryRunFrameExactlyTwoMarkers
+// fails the build on a third.
+func printDryRunBanner(w io.Writer) {
+	_, _ = cPathBold.Fprintln(w, "[DRY RUN] Preview, this run changes nothing; the plan below is what a real run would do.")
+	fmt.Fprintln(w)
+}
+
+// printDryRunTrailer is the tail of the dry-run frame: the LAST line(s) a
+// dry run prints. It no longer restates the banner's "changes nothing";
+// it carries only what the banner cannot — the copy-pasteable apply
+// command (the caller's own invocation minus --dry-run) and, for migrate
+// itself, the pointer back to `jit scan` for findings migrate can never
+// act on.
+func printDryRunTrailer(w io.Writer, applyCmd string, scanHint bool) {
+	fmt.Fprintln(w)
+	_, _ = cPathBold.Fprint(w, "[DRY RUN]")
+	fmt.Fprintln(w, hlCmds(fmt.Sprintf(" Apply this plan: `%s`", applyCmd)))
+	if scanHint {
+		wrapBody(w, 0, "", hlCmds("This only covers what jit migrate can act on; run `jit scan` for the complete picture, including findings it can never auto-fix, like private keys."))
+	}
+}
+
+// migrateApplyCommand reconstructs the invocation the trailer tells the
+// user to run: base + the targets they named + the scope flags that
+// shaped this plan (--only, --mount). --yes is deliberately dropped even
+// when set: the suggested command should re-show the plan and ask [y/N],
+// never propagate a consent skip out of a preview.
+func migrateApplyCommand(base string, args []string) string {
+	parts := []string{base}
+	for _, a := range args {
+		parts = append(parts, shellQuoteArg(a))
+	}
+	if len(migrateOnly) > 0 {
+		parts = append(parts, "--only="+strings.Join(migrateOnly, ","))
+	}
+	if migrateMount {
+		parts = append(parts, "--mount")
+	}
+	return strings.Join(parts, " ")
+}
+
+// shellQuoteArg single-quotes an argument that would not survive a paste
+// into a shell as-is. Everyday paths pass through untouched so the
+// trailer stays readable.
+func shellQuoteArg(a string) string {
+	if a != "" && !strings.ContainsAny(a, " \t'\"\\$`(){}[]*?;&|<>#~") {
+		return a
+	}
+	return "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
+}
+
 // filterMigrateOnly validates only (the raw --only tokens) against
 // migrateCategories and returns the set of selected categories. An unknown
 // token fails loud rather than being silently ignored — a typo'd category
@@ -325,7 +382,14 @@ var migratePathCmd = &cobra.Command{
 // directory: an explicitly named target can sit under any project, so
 // deriving from the invoking cwd would produce a nonsensical profile name
 // disconnected from the secret's real home.
-func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) {
+// dryRunApplyCmd carries the frame contract (design/dry-run-refactor.md
+// D1): non-empty means applyMigrate owns the dry-run frame and prints the
+// banner/trailer itself, with this as the trailer's apply command
+// (runMigratePath). Empty means the caller owns the frame — runMigrateAll
+// prints the banner BEFORE its wrap/guard disclosures and the trailer
+// after its own tail, so the frame still brackets everything the run
+// discloses.
+func applyMigrate(cmd *cobra.Command, home string, d *discovered, dryRunApplyCmd string) (bool, error) {
 	// Locals aliased to d's fields so the --only filter, plan, and apply
 	// loops below read exactly as they did before this function was split
 	// out. categorySlices points at these locals, and the --only nil-out
@@ -437,24 +501,15 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 		return false, nil
 	}
 
-	// A real, reported point of confusion: the ONLY "this is a preview"
-	// signal used to be the "[DRY RUN]" disclaimer at the very END of the
-	// plan — after every category, every file, every scope note. A
-	// reader skimming a long plan (or one who stops reading partway
-	// through) could easily mistake it for a description of changes
-	// already made, especially once the plan's own leading line ("Each
-	// modified file is backed up before it's rewritten.") reads like a
-	// statement of fact rather than a preview of what a real run would
-	// do. Printing the same cyan/bold "[DRY RUN]" banner BEFORE the plan
-	// too — not just after — means that risk exists for at most one line,
-	// not the whole plan. printMigratePlan itself stays unaware of
-	// migrateDryRun (this banner is printed here, at the call site, not
-	// inside it) specifically so it keeps rendering the exact same plan
-	// for --dry-run and the real confirmation prompt (GAPS.md #26's core
-	// guarantee) — see TestMigrateLocalDryRunMatchesRealPlanExactly.
-	if migrateDryRun {
-		_, _ = cPathBold.Fprintln(cmd.OutOrStdout(), "[DRY RUN] Preview, this run changes nothing; the plan below is what a real run would do.")
-		fmt.Fprintln(cmd.OutOrStdout())
+	// The banner prints here only when this function owns the frame (a
+	// targeted `jit migrate <path>` run); see printDryRunBanner for the
+	// GAPS.md #32 rationale. printMigratePlan itself stays unaware of
+	// migrateDryRun (the banner is printed at the call site, not inside
+	// it) specifically so it keeps rendering the exact same plan for
+	// --dry-run and the real confirmation prompt (GAPS.md #26's core
+	// guarantee) — see TestMigrateDryRunMatchesRealPlanExactly.
+	if migrateDryRun && dryRunApplyCmd != "" {
+		printDryRunBanner(cmd.OutOrStdout())
 	}
 
 	// Confirm before touching anything — vault set/rm both gate a single
@@ -511,12 +566,9 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered) (bool, error) 
 	}
 
 	if migrateDryRun {
-		out := cmd.OutOrStdout()
-		fmt.Fprintln(out)
-		_, _ = cPathBold.Fprint(out, "[DRY RUN]")
-		fmt.Fprintln(out, " No files were changed. Run without --dry-run to apply this plan.")
-		wrapBody(out, 0, "", hlCmds("This only covers what jit migrate can act on, run `jit scan` for a complete "+
-			"picture, including findings it can never auto-fix, like private keys."))
+		if dryRunApplyCmd != "" {
+			printDryRunTrailer(cmd.OutOrStdout(), dryRunApplyCmd, true)
+		}
 		return false, nil
 	}
 
@@ -1309,12 +1361,18 @@ func runMigrateAll(cmd *cobra.Command) error {
 		return nil
 	}
 
+	// The frame opens before ANY disclosure: the wrap/guard lines below are
+	// part of what the run proposes, so the banner must precede them
+	// (design/dry-run-refactor.md D1 — the old per-line "[DRY RUN]"
+	// prefixes existed only because the banner printed after these lines,
+	// inside applyMigrate).
+	if migrateDryRun {
+		printDryRunBanner(out)
+	}
+
 	// The wrap half of the plan prints ABOVE applyMigrate's file plan so the
 	// one [y/N] below covers everything this run will do.
 	if len(tools) > 0 {
-		if migrateDryRun {
-			_, _ = cPathBold.Fprint(out, "[DRY RUN] ")
-		}
 		fmt.Fprint(out, hlCmds(fmt.Sprintf("Will also wrap %s (token into the vault, tool keeps working; each is\nreversible with `jit wrap undo <tool>`): %s\n\n",
 			pluralWord(len(tools), "CLI", "CLIs"), strings.Join(tools, ", "))))
 	}
@@ -1325,14 +1383,7 @@ func runMigrateAll(cmd *cobra.Command) error {
 	// guess what it does, and a line they cannot evaluate is one they should
 	// not be agreeing to.
 	if offerGuard {
-		if migrateDryRun {
-			_, _ = cPathBold.Fprint(out, "[DRY RUN] ")
-		}
-		used := 0
-		if migrateDryRun {
-			used = len("[DRY RUN] ")
-		}
-		wrapBody(out, used, "", hlCmds("Will also install the shell history guard, so this cannot happen again: a "+
+		wrapBody(out, 0, "", hlCmds("Will also install the shell history guard, so this cannot happen again: a "+
 			"zsh hook keeps a command carrying a credential out of your history file, "+
 			"while leaving it usable in that session (reversible with "+
 			"`jit guard history --remove`)."))
@@ -1341,7 +1392,7 @@ func runMigrateAll(cmd *cobra.Command) error {
 
 	applied := true
 	if d.total() > 0 {
-		applied, err = applyMigrate(cmd, home, d)
+		applied, err = applyMigrate(cmd, home, d, "") // "" — this function owns the dry-run frame
 		if err != nil {
 			return err
 		}
@@ -1354,34 +1405,31 @@ func runMigrateAll(cmd *cobra.Command) error {
 		return nil // declined at the plan — wraps and the guard must not run either
 	}
 
-	if offerGuard {
-		switch {
-		case migrateDryRun:
-			fmt.Fprintln(out, "[dry-run] would install the shell history guard (undo: jit guard history --remove)")
-		default:
-			if _, guardErr := guard.Install(home); guardErr != nil {
-				// One failed hook must not fail a migrate that already moved
-				// real secrets into the vault.
-				fmt.Fprintf(cmd.ErrOrStderr(), "installing the history guard failed: %v\n", guardErr)
-			} else {
-				// The hook runs on every command the user types from now on,
-				// and they agreed to it as one line in a plan. The trail has
-				// to say where it came from.
-				recordSideEffect("jit guard history", []string{"guard", "history"}, "jit migrate")
-				fmt.Fprintln(out)
-				_, _ = cOK.Fprintf(out, "%s ", glyphDone)
-				wrapBody(out, 2, "  ", hlCmds(fmt.Sprintf("history guard installed (%s, sourced from %s). New shells pick it up; "+
-					"run `source ~/.jit/guard.zsh` in ones already open. Reverse with `jit guard history --remove`.",
-					displayPath(home, guard.HookPath(home)), displayPath(home, guard.RcPath(home)))))
-			}
+	// In a dry run the guard and the wraps were already disclosed above the
+	// plan, inside the frame — the old post-trailer "[dry-run] would ..."
+	// echoes printed a third marker after the line that claimed to be last.
+	if offerGuard && !migrateDryRun {
+		if _, guardErr := guard.Install(home); guardErr != nil {
+			// One failed hook must not fail a migrate that already moved
+			// real secrets into the vault.
+			fmt.Fprintf(cmd.ErrOrStderr(), "installing the history guard failed: %v\n", guardErr)
+		} else {
+			// The hook runs on every command the user types from now on,
+			// and they agreed to it as one line in a plan. The trail has
+			// to say where it came from.
+			recordSideEffect("jit guard history", []string{"guard", "history"}, "jit migrate")
+			fmt.Fprintln(out)
+			_, _ = cOK.Fprintf(out, "%s ", glyphDone)
+			wrapBody(out, 2, "  ", hlCmds(fmt.Sprintf("history guard installed (%s, sourced from %s). New shells pick it up; "+
+				"run `source ~/.jit/guard.zsh` in ones already open. Reverse with `jit guard history --remove`.",
+				displayPath(home, guard.HookPath(home)), displayPath(home, guard.RcPath(home)))))
 		}
 	}
 
 	wrapped := 0
 	for _, tool := range tools {
 		if migrateDryRun {
-			fmt.Fprintf(out, "[dry-run] would wrap %s (undo: jit wrap undo %s)\n", tool, tool)
-			continue
+			break // disclosed above the plan, inside the frame
 		}
 		fmt.Fprintln(out)
 		if wrapErr := runCatalogWrap(cmd, tool); wrapErr != nil {
@@ -1414,6 +1462,12 @@ func runMigrateAll(cmd *cobra.Command) error {
 		before := summary.SecretsProtected * 100 / summary.SecretsTotal
 		after := (summary.SecretsProtected + summary.SecretsMigratable) * 100 / summary.SecretsTotal
 		fmt.Fprint(out, hlCmds(fmt.Sprintf("\ncoverage: %d%% "+glyphAction+" up to %d%% — run `jit scan` to see the new number\n", before, after)))
+	}
+	// The frame closes after everything the run disclosed — including the
+	// wraps-only case, which never enters applyMigrate at all and used to
+	// print no frame whatsoever.
+	if migrateDryRun {
+		printDryRunTrailer(out, migrateApplyCommand("jit migrate", nil), true)
 	}
 	return nil
 }
@@ -1479,7 +1533,7 @@ func runMigratePath(cmd *cobra.Command, targets []string) error {
 	d.dedupe()
 
 	progress.Stop() // settle the discovery trail before the plan/prompt prints
-	_, err = applyMigrate(cmd, home, d)
+	_, err = applyMigrate(cmd, home, d, migrateApplyCommand("jit migrate", targets))
 	return err
 }
 

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -135,6 +135,15 @@ type discovered struct {
 	// files whose only finding is private-key material, which migrate reports
 	// and refuses to redact (see migrate.HasOnlyPrivateKeyMaterial).
 	historyKeyOnly []string
+	// wrapOwnedSkipped is note-only: explicitly named files that belong to
+	// a wrappable CLI (a catalog tool's token Source, or clisso's config).
+	// Their fix is `jit wrap <tool>`, not loose-secret surgery — routing
+	// them into the "mixes a secret with other content" note sent the user
+	// at --mount for a file the wrap flow protects whole
+	// (design/dry-run-refactor.md D7). The owning tool is re-derived at
+	// print time (wrapOwnerForPath) rather than stored beside the path, so
+	// dedupe() can treat this like every other []string.
+	wrapOwnedSkipped []string
 }
 
 // noteNamespaceMove explains a claimNamespace bump (GAPS.md #55) directly
@@ -266,6 +275,41 @@ func shellQuoteArg(a string) string {
 		return a
 	}
 	return "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
+}
+
+// wrapOwnerForPath names the catalog tool whose credential file an
+// explicitly named path is: a KindShim entry's token Source, or clisso's
+// config (KindCapture, so it has no Sources entry for its long-lived
+// client-secret).
+func wrapOwnerForPath(home, path string) (string, bool) {
+	if tool, ok := wrap.WrappableToolForPath(home, path); ok {
+		return tool, true
+	}
+	if path == migrate.ClissoConfigPath(home) {
+		return "clisso", true
+	}
+	return "", false
+}
+
+// printSkippedWrapOwned renders the skip note for files a wrappable CLI
+// owns, naming the per-tool command that actually protects each one —
+// the whole point of the note is the redirect, so the command carries it.
+func printSkippedWrapOwned(w io.Writer, home string, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	_, _ = cWarn.Fprintf(w, "\nSkipped %s in %s a wrappable CLI owns:\n", countWord(len(paths), "finding", "findings"), pluralWord(len(paths), "a file", "files"))
+	var cmds []string
+	seen := map[string]bool{}
+	for _, p := range paths {
+		fmt.Fprintf(w, "  - %s\n", displayPath(home, p))
+		if tool, ok := wrapOwnerForPath(home, p); ok && !seen[tool] {
+			seen[tool] = true
+			cmds = append(cmds, "`jit wrap "+tool+"`")
+		}
+	}
+	fmt.Fprint(w, "  ")
+	wrapBody(w, 2, "  ", hlCmds("Protect "+pluralWord(len(paths), "it", "them")+" with "+strings.Join(cmds, ", ")+" instead: the token moves to the vault and the tool keeps working through a shim."))
 }
 
 // wrapPlanDetail states what wrapping this catalog tool actually DOES,
@@ -462,6 +506,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	looseSecretFiles := d.looseSecretFiles
 	looseEmbeddedSkipped := d.looseEmbeddedSkipped
 	historyKeyOnly := d.historyKeyOnly
+	wrapOwnedSkipped := d.wrapOwnedSkipped
 
 	// --only scopes a run to just the named categories (GAPS.md #21) —
 	// validated against migrateCategories BEFORE anything else, including
@@ -544,6 +589,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 			"Re-run with --mount to protect them in place as a live mount (the non-secret content is preserved); otherwise they stay put and `jit scan` keeps reporting them.")
 		printSkippedFindings(cmd.OutOrStdout(), home, len(historyKeyOnly), "in "+pluralWord(len(historyKeyOnly), "a history file", "history files")+" holding private key material", historyKeyOnly,
 			"jit only matched the -----BEGIN line; the key body is on the lines around it, so redacting would leave the key behind and make the file look clean. Regenerate the key, then delete those lines by hand.")
+		printSkippedWrapOwned(cmd.OutOrStdout(), home, wrapOwnedSkipped)
 		return false, nil
 	}
 
@@ -614,6 +660,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		"Re-run with --mount to protect them in place as a live mount (the non-secret content is preserved); otherwise they stay put and `jit scan` keeps reporting them.")
 	printSkippedFindings(cmd.OutOrStdout(), home, len(historyKeyOnly), "in "+pluralWord(len(historyKeyOnly), "a history file", "history files")+" holding private key material", historyKeyOnly,
 		"jit only matched the -----BEGIN line; the key body is on the lines around it, so redacting would leave the key behind and make the file look clean. Regenerate the key, then delete those lines by hand.")
+	printSkippedWrapOwned(cmd.OutOrStdout(), home, wrapOwnedSkipped)
 
 	// The 1Password announcement is part of the plan the user confirms
 	// against (and --dry-run's, same rendering), but the plan never
@@ -1816,6 +1863,16 @@ func discoverFileTarget(d *discovered, home, path string) error {
 	// scan keeps reporting it). Never runs on a directory walk, only on a file
 	// the user named directly, matching the intent gate scan uses.
 	if d.total() == before {
+		// A file a wrappable CLI owns (a catalog tool's token Source, or
+		// clisso's config) has a better fix than loose-secret surgery:
+		// `jit wrap <tool>` vaults the token and keeps the tool working
+		// through a shim. Routing it into the "mixes a secret with other
+		// content" note sent the user at --mount instead — the wrong tool
+		// for a file the wrap flow protects whole (D7).
+		if _, owned := wrapOwnerForPath(home, path); owned {
+			d.wrapOwnedSkipped = append(d.wrapOwnedSkipped, path)
+			return nil
+		}
 		if tokens, pure, err := migrate.ClassifyLooseSecretFile(path); err == nil && len(tokens) > 0 {
 			switch {
 			case pure || migrateMount:
@@ -1899,7 +1956,7 @@ func (d *discovered) dedupe() {
 		&d.historyFiles, &d.mcpConfigs, &d.awsProfiles, &d.k8sUsers, &d.terraformHosts,
 		&d.dockerRegistries, &d.gitHosts, &d.gcpADCFiles, &d.sopsAgeFiles,
 		&d.npmrcFiles, &d.netrcFiles, &d.pypircFiles, &d.looseSecretFiles, &d.looseEmbeddedSkipped,
-		&d.historyKeyOnly,
+		&d.historyKeyOnly, &d.wrapOwnedSkipped,
 	} {
 		dedupeStrings(s)
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -351,7 +351,8 @@ func wrapPlanDetail(home, tool string) string {
 	// shell rc — a file edit the plan must disclose (ensureShimOnPath).
 	if entry.Kind != wrap.KindNative {
 		rc := wrap.RcFile(home, os.Getenv("SHELL"))
-		if data, err := os.ReadFile(rc); err != nil || !wrap.RcMentionsShimDir(string(data)) {
+		data, err := os.ReadFile(rc) // #nosec G304 G703 -- rc is derived from the user's own home dir and $SHELL (same read wrap.EnsurePathLine makes), never external input; read-only probe for the plan's disclosure
+		if err != nil || !wrap.RcMentionsShimDir(string(data)) {
 			detail += "; adds the shim PATH line to " + displayPath(home, rc)
 		}
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
 	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/termtext"
 	"github.com/jitpass/jit/internal/vault"
 	"github.com/jitpass/jit/internal/wrap"
 )
@@ -212,10 +213,14 @@ func printSkippedFindings(w io.Writer, home string, count int, reason string, pa
 	}
 	_, _ = cWarn.Fprintf(w, "\nSkipped %s %s:\n", countWord(count, "finding", "findings"), reason)
 	for _, p := range paths {
-		fmt.Fprintf(w, "  - %s\n", displayPath(home, p))
+		// Middle-truncated like scan's own path lists: truncate variable
+		// content rather than let a 140-char repo path wrap and shear the
+		// list's alignment (design/output-style.md).
+		fmt.Fprintf(w, "  - %s\n", termtext.TruncMid(displayPath(home, p), outputWidth()-4))
 	}
 	if hint != "" {
-		fmt.Fprintf(w, "  %s\n", hint)
+		fmt.Fprint(w, "  ")
+		wrapBody(w, 2, "  ", hlCmds(hint))
 	}
 }
 
@@ -301,7 +306,7 @@ func printSkippedWrapOwned(w io.Writer, home string, paths []string) {
 	var cmds []string
 	seen := map[string]bool{}
 	for _, p := range paths {
-		fmt.Fprintf(w, "  - %s\n", displayPath(home, p))
+		fmt.Fprintf(w, "  - %s\n", termtext.TruncMid(displayPath(home, p), outputWidth()-4))
 		if tool, ok := wrapOwnerForPath(home, p); ok && !seen[tool] {
 			seen[tool] = true
 			cmds = append(cmds, "`jit wrap "+tool+"`")
@@ -668,9 +673,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	// than Touch ID. The real check runs after [y/N].
 	if migrateOpInstalled() && !migrateNo1Password {
 		w := cmd.OutOrStdout()
-		fmt.Fprintln(w, "1Password CLI detected: values already stored there are linked, not")
-		fmt.Fprintln(w, "copied (--no-1password to copy).")
 		fmt.Fprintln(w)
+		wrapBody(w, 0, "", "1Password CLI detected: values already stored there are linked, not copied (--no-1password to copy).")
 	}
 
 	if migrateDryRun {
@@ -680,6 +684,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		return false, nil
 	}
 
+	fmt.Fprintln(cmd.OutOrStdout())
 	if !migrateYes && !confirmPrompt(cmd, "Proceed? [y/N] ") {
 		fmt.Fprintln(cmd.OutOrStdout(), "Aborted. Nothing was changed.")
 		return false, nil
@@ -1480,7 +1485,7 @@ func runMigrateAll(cmd *cobra.Command) error {
 	// the OUTCOME per catalog kind — a reader who has never seen `jit wrap`
 	// or `jit guard history` cannot evaluate a bare command name, and a
 	// line they cannot evaluate is one they should not be agreeing to.
-	extras := &planExtras{}
+	extras := &planExtras{scanDriven: true}
 	for _, tool := range tools {
 		extras.wraps = append(extras.wraps, wrapPlanRow{tool: tool, detail: wrapPlanDetail(home, tool)})
 	}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -268,6 +268,47 @@ func shellQuoteArg(a string) string {
 	return "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"
 }
 
+// wrapPlanDetail states what wrapping this catalog tool actually DOES,
+// per kind, for the plan's └ evidence line — "would wrap clisso" hides
+// four materially different behaviors, and informed consent needs the
+// right one. Everything here is read-only and prompt-free: the catalog
+// is compiled in, and the two probes (clisso's config, the shell rc)
+// are plain file reads.
+func wrapPlanDetail(home, tool string) string {
+	entry, ok := wrap.Lookup(tool)
+	if !ok {
+		return ""
+	}
+	var detail string
+	switch entry.Kind {
+	case wrap.KindShim:
+		detail = entry.Doc + " moves to the vault; its plaintext source is scrubbed (backed up encrypted first)"
+	case wrap.KindCapture:
+		detail = entry.Doc + ": each mint goes to the vault instead of a plaintext credentials file"
+		if tool == "clisso" {
+			// The capture flow also moves clisso's own long-lived
+			// client-secret out of ~/.clisso.yaml (see runCatalogWrap);
+			// disclose it only when the probe says it will happen.
+			if found, err := migrate.DiscoverClissoSecrets(home); err == nil && len(found) > 0 {
+				detail += "; the client-secret in ~/.clisso.yaml moves to the vault too"
+			}
+		}
+	case wrap.KindNative:
+		detail = entry.Doc + ": no shim; delegates to jit's native credential flow for this tool"
+	case wrap.KindRunGrant:
+		detail = entry.Doc + ": shim only; every run happens inside a jit run grant"
+	}
+	// A first shim also puts ~/.jit/shims on PATH by appending to the
+	// shell rc — a file edit the plan must disclose (ensureShimOnPath).
+	if entry.Kind != wrap.KindNative {
+		rc := wrap.RcFile(home, os.Getenv("SHELL"))
+		if data, err := os.ReadFile(rc); err != nil || !wrap.RcMentionsShimDir(string(data)) {
+			detail += "; adds the shim PATH line to " + displayPath(home, rc)
+		}
+	}
+	return detail
+}
+
 // filterMigrateOnly validates only (the raw --only tokens) against
 // migrateCategories and returns the set of selected categories. An unknown
 // token fails loud rather than being silently ignored — a typo'd category
@@ -382,14 +423,19 @@ var migratePathCmd = &cobra.Command{
 // directory: an explicitly named target can sit under any project, so
 // deriving from the invoking cwd would produce a nonsensical profile name
 // disconnected from the secret's real home.
+// extras carries the plan's non-file categories (wraps and the guard
+// offer, from runMigrateAll's scan; nil on targeted runs). applyMigrate
+// adds the agent-cache sweep preview itself, AFTER the --only filter,
+// because the preview's needles are the values of exactly the files
+// this run will vault (design/dry-run-refactor.md D4).
+//
 // dryRunApplyCmd carries the frame contract (design/dry-run-refactor.md
 // D1): non-empty means applyMigrate owns the dry-run frame and prints the
 // banner/trailer itself, with this as the trailer's apply command
 // (runMigratePath). Empty means the caller owns the frame — runMigrateAll
-// prints the banner BEFORE its wrap/guard disclosures and the trailer
-// after its own tail, so the frame still brackets everything the run
-// discloses.
-func applyMigrate(cmd *cobra.Command, home string, d *discovered, dryRunApplyCmd string) (bool, error) {
+// prints the banner BEFORE calling here and the trailer after its own
+// tail, so the frame still brackets everything the run discloses.
+func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planExtras, dryRunApplyCmd string) (bool, error) {
 	// Locals aliased to d's fields so the --only filter, plan, and apply
 	// loops below read exactly as they did before this function was split
 	// out. categorySlices points at these locals, and the --only nil-out
@@ -543,7 +589,23 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, dryRunApplyCmd
 		pypircFiles:      pypircFiles,
 		looseSecretFiles: looseSecretFiles,
 	}
-	printMigratePlan(cmd.OutOrStdout(), home, &planned)
+	// The cache-sweep preview joins the plan HERE, after the --only
+	// filter: its needles are the plaintext values of exactly the files
+	// this run will vault, so a scoped-out category must not feed it.
+	// Best-effort by design — a failed preview becomes a note, never a
+	// failed (or prompting) plan; the apply-time sweep is unaffected
+	// either way, its needles come from Vault.OnSet.
+	if extras == nil {
+		extras = &planExtras{}
+	}
+	if needles := migrate.PlanNeedles(envFiles, looseSecretFiles); len(needles) > 0 {
+		if preview, err := migrate.PreviewAgentCaches(home, needles); err != nil {
+			extras.cacheNote = err.Error()
+		} else {
+			extras.cacheEdits = preview.Edited
+		}
+	}
+	printMigratePlan(cmd.OutOrStdout(), home, &planned, extras)
 	printSkippedFindings(cmd.OutOrStdout(), home, len(tfvarsComplexOnly), "in Terraform "+pluralWord(len(tfvarsComplexOnly), "variable file", "variable files")+" whose secret-shaped values aren't simple one-line strings", tfvarsComplexOnly,
 		"Nothing migrate can move safely; they stay in place, and `jit scan` keeps reporting them.")
 	printSkippedFindings(cmd.OutOrStdout(), home, len(k8sManifestsComplexOnly), "in "+pluralWord(len(k8sManifestsComplexOnly), "Kubernetes Secret manifest", "Kubernetes Secret manifests")+" migrate can't rewrite provably right", k8sManifestsComplexOnly,
@@ -1361,45 +1423,41 @@ func runMigrateAll(cmd *cobra.Command) error {
 		return nil
 	}
 
-	// The frame opens before ANY disclosure: the wrap/guard lines below are
-	// part of what the run proposes, so the banner must precede them
-	// (design/dry-run-refactor.md D1 — the old per-line "[DRY RUN]"
-	// prefixes existed only because the banner printed after these lines,
-	// inside applyMigrate).
+	// The frame opens before the plan (design/dry-run-refactor.md D1).
 	if migrateDryRun {
 		printDryRunBanner(out)
 	}
 
-	// The wrap half of the plan prints ABOVE applyMigrate's file plan so the
-	// one [y/N] below covers everything this run will do.
-	if len(tools) > 0 {
-		fmt.Fprint(out, hlCmds(fmt.Sprintf("Will also wrap %s (token into the vault, tool keeps working; each is\nreversible with `jit wrap undo <tool>`): %s\n\n",
-			pluralWord(len(tools), "CLI", "CLIs"), strings.Join(tools, ", "))))
+	// The wraps and the guard enter the plan as counted categories rather
+	// than prose above it (design/dry-run-refactor.md D3): the plan row is
+	// the consent line the single [y/N] below commits to, and it states
+	// the OUTCOME per catalog kind — a reader who has never seen `jit wrap`
+	// or `jit guard history` cannot evaluate a bare command name, and a
+	// line they cannot evaluate is one they should not be agreeing to.
+	extras := &planExtras{}
+	for _, tool := range tools {
+		extras.wraps = append(extras.wraps, wrapPlanRow{tool: tool, detail: wrapPlanDetail(home, tool)})
 	}
-
-	// Announced ABOVE applyMigrate's plan, like the wraps, so the single
-	// [y/N] below is the consent for it too. Stated as an outcome rather than
-	// a command name: a reader who has never seen `jit guard history` cannot
-	// guess what it does, and a line they cannot evaluate is one they should
-	// not be agreeing to.
 	if offerGuard {
-		wrapBody(out, 0, "", hlCmds("Will also install the shell history guard, so this cannot happen again: a "+
-			"zsh hook keeps a command carrying a credential out of your history file, "+
-			"while leaving it usable in that session (reversible with "+
-			"`jit guard history --remove`)."))
-		fmt.Fprintln(out)
+		extras.guardItems = []string{displayPath(home, guard.HookPath(home)) + " (sourced from " + displayPath(home, guard.RcPath(home)) + ")"}
 	}
 
 	applied := true
 	if d.total() > 0 {
-		applied, err = applyMigrate(cmd, home, d, "") // "" — this function owns the dry-run frame
+		applied, err = applyMigrate(cmd, home, d, extras, "") // "" — this function owns the dry-run frame
 		if err != nil {
 			return err
 		}
-	} else if !migrateDryRun && !migrateYes && !confirmPrompt(cmd, "Proceed? [y/N] ") {
-		// Only wraps in the plan: applyMigrate never ran, so gate here.
-		fmt.Fprintln(out, "Aborted. Nothing was changed.")
-		return nil
+	} else {
+		// Wraps/guard only: applyMigrate never runs, so render the same
+		// plan shape it would (extras as its only categories) and gate on
+		// the same [y/N] — this run installs shims and shell hooks, which
+		// is exactly what the plan-then-consent discipline exists for.
+		printMigratePlan(out, home, d, extras)
+		if !migrateDryRun && !migrateYes && !confirmPrompt(cmd, "Proceed? [y/N] ") {
+			fmt.Fprintln(out, "Aborted. Nothing was changed.")
+			return nil
+		}
 	}
 	if !applied && !migrateDryRun {
 		return nil // declined at the plan — wraps and the guard must not run either
@@ -1533,7 +1591,7 @@ func runMigratePath(cmd *cobra.Command, targets []string) error {
 	d.dedupe()
 
 	progress.Stop() // settle the discovery trail before the plan/prompt prints
-	_, err = applyMigrate(cmd, home, d, migrateApplyCommand("jit migrate", targets))
+	_, err = applyMigrate(cmd, home, d, nil, migrateApplyCommand("jit migrate", targets))
 	return err
 }
 

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -273,9 +273,10 @@ func migrateApplyCommand(base string, args []string) string {
 
 // shellQuoteArg single-quotes an argument that would not survive a paste
 // into a shell as-is. Everyday paths pass through untouched so the
-// trailer stays readable.
+// trailer stays readable — including a leading ~/, which jit expands
+// itself (expandTilde) whether or not the shell got to it first.
 func shellQuoteArg(a string) string {
-	if a != "" && !strings.ContainsAny(a, " \t'\"\\$`(){}[]*?;&|<>#~") {
+	if a != "" && !strings.ContainsAny(a, " \t'\"\\$`(){}[]*?;&|<>#") {
 		return a
 	}
 	return "'" + strings.ReplaceAll(a, "'", `'\''`) + "'"

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -83,6 +83,17 @@ func execMigrate(t *testing.T, args ...string) (stdout string, err error) {
 	return buf.String(), err
 }
 
+// dryRunPlanOnly strips the dry-run trailer from captured output. The
+// trailer's apply command faithfully echoes EVERY target the user named —
+// including ones --only scoped out of the plan — so assertions about what
+// the PLAN contains must not scan the trailer.
+func dryRunPlanOnly(out string) string {
+	if i := strings.LastIndex(out, "\n[DRY RUN] Apply this plan:"); i >= 0 {
+		return out[:i]
+	}
+	return out
+}
+
 // TestMigrateBareRunsProtectPlan: bare `jit migrate` executes the scan's
 // protect plan (2026-07-28 redesign — it is the command the scan report's
 // green section points at). Consent is preserved: the plan prints and the
@@ -399,8 +410,8 @@ func TestMigrateOnlyWorksWithDryRun(t *testing.T) {
 	if strings.Contains(out, "shell config") {
 		t.Errorf("expected --only=env to exclude the shell-config category from the preview too, got:\n%s", out)
 	}
-	if !strings.Contains(out, "[DRY RUN] No files were changed.") {
-		t.Errorf("expected the dry-run disclaimer, got:\n%s", out)
+	if !strings.Contains(out, "[DRY RUN] Apply this plan:") {
+		t.Errorf("expected the dry-run trailer, got:\n%s", out)
 	}
 }
 
@@ -442,6 +453,59 @@ func TestMigrateDryRunMatchesRealPlanExactly(t *testing.T) {
 	if dryPlan != realPlan {
 		t.Errorf("dry-run plan and real-run plan differ:\n--dry-run:\n%s\n--real:\n%s", dryPlan, realPlan)
 	}
+}
+
+// TestDryRunFrameExactlyTwoMarkers locks in the dry-run frame contract
+// (design/dry-run-refactor.md D1/D2): a dry run prints exactly two
+// [DRY RUN] markers — the banner as its first plan-facing line and the
+// trailer at the end — and never the retired lowercase [dry-run] spelling.
+// A third marker means some printer regrew its own prefix; one means a
+// surface lost half its frame (the wraps-only hole this refactor closed).
+func TestDryRunFrameExactlyTwoMarkers(t *testing.T) {
+	withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	envPath := filepath.Join(cwd, ".env")
+	if err := os.WriteFile(envPath, []byte("STRIPE_KEY=sk_test_fixture\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out, err := execMigrate(t, envPath, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate <env> --dry-run: %v", err)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers (banner + trailer), got %d:\n%s", got, out)
+	}
+	if strings.Contains(out, "[dry-run]") {
+		t.Errorf("lowercase [dry-run] marker resurfaced:\n%s", out)
+	}
+	if !strings.HasPrefix(out, "[DRY RUN] Preview") {
+		t.Errorf("expected the banner as the first output line, got:\n%s", out)
+	}
+	// The trailer must be the LAST [DRY RUN] content — nothing after it
+	// but its own hint lines.
+	tail := out[strings.LastIndex(out, "[DRY RUN]"):]
+	if !strings.Contains(tail, "Apply this plan:") {
+		t.Errorf("expected the closing trailer last, got tail:\n%s", tail)
+	}
+	// The trailer's apply command echoes the invocation minus --dry-run.
+	if !strings.Contains(out, "Apply this plan: jit migrate "+envPath) {
+		t.Errorf("expected the trailer to name the target %s, got:\n%s", envPath, out)
+	}
+}
+
+// TestMigrateRemoveRejectsDryRun: --dry-run is a persistent flag on the
+// migrate group, so it PARSES on remove — where no preview exists. It
+// must fail loud, never silently proceed to a [y/N] on the command that
+// writes plaintext back and deletes vault secrets.
+func TestMigrateRemoveRejectsDryRun(t *testing.T) {
+	withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	out, err := execMigrateRemove(t, "", cwd, "--dry-run")
+	if err == nil || !strings.Contains(err.Error(), "--dry-run isn't supported here yet") {
+		t.Errorf("expected a loud --dry-run refusal from migrate remove, got err=%v output:\n%s", err, out)
+	}
+	migrateDryRun = false // this test set the persistent flag; scrub it for whoever runs next
 }
 
 func TestMigrateDryRunCleanTarget(t *testing.T) {
@@ -703,8 +767,8 @@ func TestMigrateTerraformCredentialsDiscoveryAndOnlyFlag(t *testing.T) {
 	if !strings.Contains(onlyOut, "app.terraform.io") {
 		t.Errorf("expected --only terraform to keep the Terraform finding, got:\n%s", onlyOut)
 	}
-	if strings.Contains(onlyOut, envPath) {
-		t.Errorf("expected --only terraform to exclude the .env finding, got:\n%s", onlyOut)
+	if strings.Contains(dryRunPlanOnly(onlyOut), envPath) {
+		t.Errorf("expected --only terraform to exclude the .env finding from the plan, got:\n%s", onlyOut)
 	}
 }
 
@@ -746,8 +810,8 @@ func TestMigrateGCPADCDiscoveryAndOnlyFlag(t *testing.T) {
 	if !strings.Contains(onlyOut, displayPath(home, adcPath)) {
 		t.Errorf("expected --only gcp to keep the ADC finding, got:\n%s", onlyOut)
 	}
-	if strings.Contains(onlyOut, envPath) {
-		t.Errorf("expected --only gcp to exclude the .env finding, got:\n%s", onlyOut)
+	if strings.Contains(dryRunPlanOnly(onlyOut), envPath) {
+		t.Errorf("expected --only gcp to exclude the .env finding from the plan, got:\n%s", onlyOut)
 	}
 }
 
@@ -789,8 +853,8 @@ func TestMigrateDockerDiscoveryAndOnlyFlag(t *testing.T) {
 	if !strings.Contains(onlyOut, "registry.example.com") {
 		t.Errorf("expected --only docker to keep the Docker finding, got:\n%s", onlyOut)
 	}
-	if strings.Contains(onlyOut, envPath) {
-		t.Errorf("expected --only docker to exclude the .env finding, got:\n%s", onlyOut)
+	if strings.Contains(dryRunPlanOnly(onlyOut), envPath) {
+		t.Errorf("expected --only docker to exclude the .env finding from the plan, got:\n%s", onlyOut)
 	}
 }
 

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -579,6 +579,31 @@ func TestPlanExtrasWrapAndGuardRows(t *testing.T) {
 	}
 }
 
+// TestMigrateWrapOwnedConfigRoutesToWrap: naming a file a wrappable CLI
+// owns (clisso's config, a catalog tool's token Source) gets the skip
+// note pointing at `jit wrap <tool>` — not the loose-secret "mixes a
+// secret with other content" hint, which sent the user at --mount for a
+// file the wrap flow protects whole (design/dry-run-refactor.md D7).
+func TestMigrateWrapOwnedConfigRoutesToWrap(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	clisso := filepath.Join(home, ".clisso.yaml")
+	if err := os.WriteFile(clisso, []byte("providers:\n  onelogin:\n    client-secret: 9f8e7d6c5b4a39281706f5e4d3c2b1a0\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out, err := execMigrate(t, clisso, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate ~/.clisso.yaml --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "a wrappable CLI owns") || !strings.Contains(out, "jit wrap clisso") {
+		t.Errorf("expected the wrap-owned skip note naming jit wrap clisso, got:\n%s", out)
+	}
+	if strings.Contains(out, "mixes") {
+		t.Errorf("wrap-owned file must not fall through to the mixed-content note, got:\n%s", out)
+	}
+}
+
 func TestMigrateDryRunCleanTarget(t *testing.T) {
 	home := withFixtureHome(t) // empty fixture, nothing planted
 	withFixtureCwd(t)

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -508,6 +508,77 @@ func TestMigrateRemoveRejectsDryRun(t *testing.T) {
 	migrateDryRun = false // this test set the persistent flag; scrub it for whoever runs next
 }
 
+// TestMigrateDryRunPreviewsAgentCacheSweep: the post-migrate agent-cache
+// sweep rewrites files, so the plan must disclose them as a counted
+// category (design/dry-run-refactor.md D4) — a real run editing files
+// the plan never listed was the gap. The needles are the plaintext
+// values of the files being migrated, readable at plan time.
+func TestMigrateDryRunPreviewsAgentCacheSweep(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	const secret = "vlt09zXcVbNm2qWe4rTy6uIo8p42" // realistic shape: placeholder-looking values are ineligible needles
+	envPath := filepath.Join(cwd, ".env")
+	if err := os.WriteFile(envPath, []byte("STRIPE_KEY="+secret+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	pasteDir := filepath.Join(home, ".claude", "paste-cache")
+	if err := os.MkdirAll(pasteDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pastePath := filepath.Join(pasteDir, "paste1.txt")
+	if err := os.WriteFile(pastePath, []byte("here is the key: "+secret+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out, err := execMigrate(t, envPath, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate <env> --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "[AI agent cache file] 1") {
+		t.Errorf("expected the agent-cache category in the plan, got:\n%s", out)
+	}
+	if !strings.Contains(out, displayPath(home, pastePath)) {
+		t.Errorf("expected the cache copy's path in the plan, got:\n%s", out)
+	}
+	if !strings.Contains(out, "2 changes planned across 2 categories") {
+		t.Errorf("expected the subtotal to count the cache copy, got:\n%s", out)
+	}
+	if data, readErr := os.ReadFile(pastePath); readErr != nil || !strings.Contains(string(data), secret) {
+		t.Errorf("dry-run must not touch the cache file (err=%v):\n%s", readErr, data)
+	}
+}
+
+// TestPlanExtrasWrapAndGuardRows: wraps and the guard render as counted
+// plan categories with the outcome stated per row — the plan row is the
+// consent line (design/dry-run-refactor.md D3). Driven through
+// printMigratePlan directly because bare `jit migrate` needs a full scan
+// to produce a wraps plan.
+func TestPlanExtrasWrapAndGuardRows(t *testing.T) {
+	home := t.TempDir()
+	var buf bytes.Buffer
+	extras := &planExtras{
+		wraps:      []wrapPlanRow{{tool: "clisso", detail: "temporary AWS credentials minted via OneLogin/Okta SAML: each mint goes to the vault"}},
+		guardItems: []string{"~/.jit/guard.zsh (sourced from ~/.zshrc)"},
+	}
+	printMigratePlan(&buf, home, &discovered{}, extras)
+	out := buf.String()
+
+	for _, want := range []string{
+		"[CLI wrap] 1",
+		"jit wrap undo <tool>",
+		"clisso",
+		"each mint goes", // wrapBody may break the line inside the phrase
+		"[shell history guard] 1",
+		"jit guard history --remove",
+		"~/.jit/guard.zsh (sourced from ~/.zshrc)",
+		"2 changes planned across 2 categories",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the extras plan, got:\n%s", want, out)
+		}
+	}
+}
+
 func TestMigrateDryRunCleanTarget(t *testing.T) {
 	home := withFixtureHome(t) // empty fixture, nothing planted
 	withFixtureCwd(t)

--- a/internal/cli/migratecaches.go
+++ b/internal/cli/migratecaches.go
@@ -97,10 +97,16 @@ func runMigrateCaches(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 
+	// The frame brackets the plan like every other migrate dry-run
+	// (design/dry-run-refactor.md D1); the vault open above it is
+	// inherent — the needles ARE vault values — and reads only.
+	if migrateDryRun {
+		printDryRunBanner(out)
+	}
 	renderAgentCleanupPlan(out, home, plan)
 
 	if migrateDryRun {
-		fmt.Fprintln(out, "\n[dry-run] Nothing was changed.")
+		printDryRunTrailer(out, migrateApplyCommand("jit migrate caches", nil), false)
 		return nil
 	}
 	if !migrateYes && !confirmPrompt(cmd, "Redact these copies? [y/N] ") {

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -44,6 +44,48 @@ import (
 // item-by-item (splitMCPByScope/splitNpmrcByScope) since Claude Desktop's
 // config / the global ~/.npmrc belong in the machine-wide group while a
 // project mcp.json/.npmrc belongs with the scoped files.
+// planExtras carries the non-file halves of a migrate plan — the CLI
+// wraps, the shell-history-guard offer, and the agent-cache sweep
+// preview — so they render as counted plan categories instead of prose
+// around the plan (design/dry-run-refactor.md D3/D4). The plan row IS
+// the consent line, for --dry-run and the real [y/N] alike, so anything
+// the run will do that isn't a file category must arrive here or not
+// happen. nil means a run with no extras (targeted runs without a cache
+// preview yet, tests).
+type planExtras struct {
+	wraps      []wrapPlanRow
+	guardItems []string // non-empty offers the guard; each item is one bullet
+	cacheEdits []migrate.AgentCacheEdit
+	cacheNote  string // non-empty: the preview failed; the sweep still runs at apply time
+}
+
+// wrapPlanRow is one catalog tool the run will wrap, with its
+// kind-specific consequence rendered as a └ evidence line under the
+// bullet — "would wrap clisso" hides four different behaviors, and the
+// consent screen has to say which one this is.
+type wrapPlanRow struct {
+	tool   string
+	detail string
+}
+
+func (e *planExtras) empty() bool {
+	return e == nil || (len(e.wraps) == 0 && len(e.guardItems) == 0 && len(e.cacheEdits) == 0 && e.cacheNote == "")
+}
+
+// counts returns the extra items and categories for the plan subtotal.
+func (e *planExtras) counts() (items, categories int) {
+	if e == nil {
+		return 0, 0
+	}
+	for _, group := range []int{len(e.wraps), len(e.guardItems), len(e.cacheEdits)} {
+		if group > 0 {
+			categories++
+			items += group
+		}
+	}
+	return items, categories
+}
+
 // printMigratePlan renders the "what jit will rewrite" plan.
 //
 // It takes *discovered rather than the seventeen positional []string it used
@@ -52,7 +94,7 @@ import (
 // showing the user one category's files under another category's heading, on
 // the screen whose whole job is to obtain informed consent before rewriting
 // them. Named fields make the same mistake a compile error.
-func printMigratePlan(w io.Writer, home string, d *discovered) {
+func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtras) {
 	fmt.Fprintln(w, "jit migrate, plan")
 	fmt.Fprintln(w, "Each modified file is backed up before it's rewritten.")
 	fmt.Fprintln(w)
@@ -258,6 +300,8 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 		}
 	}
 
+	printPlanExtras(w, home, extras)
+
 	categories, total := 0, 0
 	for _, items := range [][]string{d.envFiles, d.tfvarsFiles, d.k8sManifests, d.shellConfigs, d.historyFiles, d.mcpConfigs, d.awsProfiles, d.k8sUsers, d.terraformHosts, d.dockerRegistries, d.gitHosts, d.gcpADCFiles, d.sopsAgeFiles, d.npmrcFiles, d.netrcFiles, d.pypircFiles, d.looseSecretFiles} {
 		if len(items) > 0 {
@@ -265,8 +309,57 @@ func printMigratePlan(w io.Writer, home string, d *discovered) {
 		}
 		total += len(items)
 	}
+	extraItems, extraCategories := extras.counts()
+	total += extraItems
+	categories += extraCategories
 	fmt.Fprintln(w, strings.Repeat(glyphRule, 44))
 	fmt.Fprintf(w, "  %s planned across %s\n", countWord(total, "change", "changes"), countWord(categories, "category", "categories"))
+}
+
+// printPlanExtras renders the wrap/guard/cache-sweep categories in the
+// same [Name] count + outcome + bullets shape the file categories use,
+// so one [y/N] reads one uniform plan. Wrap bullets carry a └ detail
+// line because each catalog kind does something materially different.
+func printPlanExtras(w io.Writer, home string, e *planExtras) {
+	if e.empty() {
+		return
+	}
+	if len(e.wraps) > 0 {
+		// Not the shared category renderer: each bullet carries a └ detail
+		// line (the kind-specific consequence), which the shared shape's
+		// inline "(note)" would jam into an unreadable parenthetical.
+		fmt.Fprintf(w, "[%s] %d\n", pluralWord(len(e.wraps), "CLI wrap", "CLI wraps"), len(e.wraps))
+		fmt.Fprintf(w, "  "+glyphAction+" each tool keeps working through a jit shim; reversible: jit wrap undo <tool>\n")
+		for _, row := range e.wraps {
+			fmt.Fprintf(w, "  "+glyphBullet+" %s\n", row.tool)
+			if row.detail != "" {
+				fmt.Fprint(w, "    "+glyphBranch+" ")
+				wrapBody(w, 6, "      ", row.detail)
+			}
+		}
+		fmt.Fprintln(w)
+	}
+	if len(e.guardItems) > 0 {
+		printMigratePlanCategoryAnnotated(w,
+			"shell history guard "+glyphAction+" a zsh hook keeps credential-carrying commands out of your history file, while leaving them usable in that session; reversible: jit guard history --remove",
+			e.guardItems, nil)
+	}
+	if len(e.cacheEdits) > 0 {
+		items := make([]string, 0, len(e.cacheEdits))
+		annotations := make(map[string]string, len(e.cacheEdits))
+		for _, edit := range e.cacheEdits {
+			item := displayPath(home, edit.Path)
+			items = append(items, item)
+			annotations[item] = countWord(edit.Occurrences, "copy", "copies")
+		}
+		printMigratePlanCategoryAnnotated(w,
+			pluralWord(len(e.cacheEdits), "AI agent cache file", "AI agent cache files")+" "+glyphAction+" copies of the values above are redacted in place (backed up encrypted first)",
+			items,
+			func(item string) string { return annotations[item] })
+	}
+	if e.cacheNote != "" {
+		_, _ = cWarn.Fprintf(w, "  AI agent caches could not be previewed (%s); the sweep still runs after the file migrations.\n\n", e.cacheNote)
+	}
 }
 
 // splitMCPByScope separates Claude Desktop's always-checked fixed path

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -57,6 +57,11 @@ type planExtras struct {
 	guardItems []string // non-empty offers the guard; each item is one bullet
 	cacheEdits []migrate.AgentCacheEdit
 	cacheNote  string // non-empty: the preview failed; the sweep still runs at apply time
+	// scanDriven flips the group headers from "you named" to "flagged by
+	// the scan": bare `jit migrate` names nothing — the scan did, and a
+	// header claiming otherwise misstates why the file is in the plan.
+	// A rendering mode, not content: excluded from empty()/counts().
+	scanDriven bool
 }
 
 // wrapPlanRow is one catalog tool the run will wrap, with its
@@ -131,7 +136,11 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		for _, p := range d.envFiles {
 			envOriginal[displayPath(home, p)] = p
 		}
-		_, _ = cBold.Fprintf(w, "Project files you named\n\n")
+		scopedHeader := "Project files you named"
+		if extras != nil && extras.scanDriven {
+			scopedHeader = "Project files flagged by the scan"
+		}
+		_, _ = cBold.Fprintf(w, "%s\n\n", scopedHeader)
 		printMigratePlanCategoryAnnotated(w,
 			pluralWord(len(d.envFiles), ".env file", ".env files")+" "+glyphAction+" EVERY variable moves to the vault (ordinary config too, so the file still works); the file keeps working as a live, auto-updating mount",
 			shorten(d.envFiles),
@@ -203,8 +212,13 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		// These appear only because the caller named a machine-wide file (or
 		// its exact path) explicitly — a migrate run never reaches them on its
 		// own, so the header states plainly that the caller asked for them.
-		_, _ = fmt.Fprintln(w, "Machine-wide config files you named")
-		fmt.Fprintln(w)
+		fixedHeader := "Machine-wide config files you named"
+		if extras != nil && extras.scanDriven {
+			fixedHeader = "Machine-wide config files flagged by the scan"
+		}
+		// Bold like the scoped group's header: the two are the same rank,
+		// and hierarchy comes from bold alone (design/output-style.md).
+		_, _ = cBold.Fprintf(w, "%s\n\n", fixedHeader)
 		printMigratePlanCategory(w,
 			pluralWord(len(d.shellConfigs), "shell config", "shell configs")+" "+glyphAction+" secrets move to the vault; loaded back automatically when your shell starts",
 			shorten(d.shellConfigs))

--- a/internal/cli/migrateremove.go
+++ b/internal/cli/migrateremove.go
@@ -140,6 +140,14 @@ type projectRemovalPlan struct {
 }
 
 func runMigrateRemove(cmd *cobra.Command, args []string) error {
+	// --dry-run is a persistent flag on the migrate group, so it PARSES
+	// here — but remove has no preview implementation, and a "preview"
+	// flag silently ignored on the command that writes plaintext back and
+	// deletes vault secrets is the worst place to ignore one. Fail loud
+	// until remove grows a real plan (design/dry-run-refactor.md D6).
+	if migrateDryRun {
+		return fmt.Errorf("jit migrate remove: --dry-run isn't supported here yet; the per-project [y/N] plan is the preview (decline it to change nothing)")
+	}
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("jit migrate remove: %w", err)

--- a/internal/cli/migrateremove_test.go
+++ b/internal/cli/migrateremove_test.go
@@ -25,6 +25,7 @@ import (
 func execMigrateRemove(t *testing.T, input string, args ...string) (output string, err error) {
 	t.Helper()
 	migrateRemoveYes = false
+	migrateDryRun = false // persistent on the migrate group; a prior test's --dry-run must not leak into a remove run
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/audit"
+	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
 )
 
@@ -26,6 +27,41 @@ var (
 	scanFull       bool
 	scanFailOn     string
 )
+
+// newAuditConfig builds the audit Config every CLI scan surface shares
+// (scan, bare migrate's protect plan, first-run), with the cross-package
+// hooks wired. audit cannot import migrate (migrate imports audit), so
+// the classifier arrives as a hook — the vault.KeyWrapper pattern; see
+// audit.Config.K8sMigratable.
+func newAuditConfig() (audit.Config, error) {
+	cfg, err := audit.NewConfig(agent.Version())
+	if err != nil {
+		return cfg, err
+	}
+	cfg.K8sMigratable = k8sMigratableForScan
+	return cfg, nil
+}
+
+// k8sMigratableForScan answers the hook with migrate's own classifier, so
+// scan and migrate can never disagree about a manifest. Read-only and
+// prompt-free, as the hook's contract requires.
+func k8sMigratableForScan(path string) (reason string, ok bool) {
+	plan, reason, err := migrate.ClassifyK8sSecretManifest(path)
+	switch {
+	case err != nil:
+		// Unreadable where audit could read it moments ago (racing edit,
+		// permissions): don't promise a migrate that will error.
+		return err.Error(), false
+	case plan != nil:
+		return "", true
+	case reason != "":
+		return reason, false
+	default:
+		// Recognized but with nothing migrate can move (fully
+		// SOPS-encrypted, an empty scaffold).
+		return "no plaintext Secret values migrate can move", false
+	}
+}
 
 // riskRank orders the aggregate RISK LEVEL vocabulary so --fail-on can ask
 // "at or above". Kept local to the flag: it is a CLI comparison, not a
@@ -163,7 +199,7 @@ var scanCmd = &cobra.Command{
 			}
 		}
 
-		cfg, err := audit.NewConfig(agent.Version())
+		cfg, err := newAuditConfig()
 		if err != nil {
 			return fmt.Errorf("jit scan: %w", err)
 		}

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -383,3 +383,40 @@ func TestScanFailOnRejectsBadThreshold(t *testing.T) {
 		}
 	}
 }
+
+// TestScanRefusedK8sManifestNotPromisedToMigrate: the wired
+// K8sMigratable hook (design/dry-run-refactor.md D5) makes scan tell the
+// truth about a Secret manifest migrate will refuse — a real dogfood run
+// had scan promise Secret.yaml under "jit will protect these" (+3%),
+// then migrate skip it as complex. The refused manifest must carry
+// migrate's reason and no `jit migrate <path>` recommendation.
+func TestScanRefusedK8sManifestNotPromisedToMigrate(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	dir := filepath.Join(home, "code", "k8s")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// data: mixed with stringData: in one document — migrate's classifier
+	// refuses this shape (k8ssecret.go), so scan must not promise it.
+	manifest := filepath.Join(dir, "Secret.yaml")
+	if err := os.WriteFile(manifest, []byte(`apiVersion: v1
+kind: Secret
+metadata:
+  name: my-secret
+data:
+  password: aHVudGVyMg==
+stringData:
+  token: vlt09zXcVbNm2qWe4rTy6uIo8p42
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out := runScan(t, manifest)
+	if !strings.Contains(out, "can't rewrite provably right") {
+		t.Errorf("expected migrate's refusal reason in the report, got:\n%s", out)
+	}
+	if strings.Contains(out, "jit migrate "+manifest) || strings.Contains(out, "jit migrate ~/code/k8s/Secret.yaml") {
+		t.Errorf("scan must not recommend migrating a manifest migrate refuses, got:\n%s", out)
+	}
+}

--- a/internal/cli/undo.go
+++ b/internal/cli/undo.go
@@ -141,9 +141,9 @@ func runMigrateUndo(cmd *cobra.Command, args []string) error {
 	}
 
 	if migrateDryRun {
-		// Same leading banner discipline as jit migrate (GAPS.md #32): the
+		// Same frame discipline as jit migrate (GAPS.md #32): the
 		// preview-vs-real signal comes BEFORE the plan, not only after it.
-		_, _ = cPathBold.Fprintln(out, "[DRY RUN] Preview, this run changes nothing; the plan below is what a real run would do.")
+		printDryRunBanner(out)
 	}
 
 	registryPath := mount.RegistryPath(root)
@@ -173,9 +173,7 @@ func runMigrateUndo(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(out, "Vault secrets and profile manifests are left in place, this reverses files, never the vault.")
 
 	if migrateDryRun {
-		fmt.Fprintln(out)
-		_, _ = cPathBold.Fprint(out, "[DRY RUN]")
-		fmt.Fprintln(out, " No files were changed.")
+		printDryRunTrailer(out, migrateApplyCommand("jit migrate undo", args), false)
 		return nil
 	}
 

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -67,6 +67,21 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 			tool, strings.Join(wrap.CatalogTools(), ", "), tool)
 	}
 	out := cmd.OutOrStdout()
+	// --dry-run: the same frame and plan row migrate's plan uses
+	// (design/dry-run-refactor.md D6), so one dry-run vocabulary covers
+	// the whole CLI. Rendered before any probe that could fail — a
+	// preview of a tool that isn't installed yet is still a valid answer
+	// to "what would this do".
+	if wrapDryRun {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("jit wrap: %w", err)
+		}
+		printDryRunBanner(out)
+		printPlanExtras(out, home, &planExtras{wraps: []wrapPlanRow{{tool: tool, detail: wrapPlanDetail(home, tool)}}})
+		printDryRunTrailer(out, "jit wrap "+tool, false)
+		return nil
+	}
 	// One vault for the whole wrap, not one per step: openVault builds a
 	// fresh keychainwrap.Wrapper whose master-key cache is per instance,
 	// so each extra open is another Touch ID prompt when the agent
@@ -302,6 +317,11 @@ func wrapSecretAlreadyVaulted(path string) bool {
 var wrapAddEnv []string
 var wrapAddGrant string
 
+// wrapDryRun serves both `jit wrap <tool> --dry-run` and `jit wrap undo
+// <tool> --dry-run` — one flag var, two registrations, matching how the
+// migrate group shares migrateDryRun across its subcommands.
+var wrapDryRun bool
+
 // wrapAddUsage is the one-line shape of a wrap, quoted wherever a user lands
 // without it: `jit wrap list` with nothing wrapped, an empty `wrap undo`
 // completion, the tool-name position that has no flag yet. Same role
@@ -464,6 +484,29 @@ var wrapUndoCmd = &cobra.Command{
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return fmt.Errorf("jit wrap undo: %w", err)
+		}
+		if wrapDryRun {
+			prev, err := wrap.PreviewUndo(home, tool)
+			if err != nil {
+				return fmt.Errorf("jit wrap undo: %w", err)
+			}
+			out := cmd.OutOrStdout()
+			printDryRunBanner(out)
+			fmt.Fprintf(out, "Unwrap %s:\n", tool)
+			fmt.Fprintf(out, "  "+glyphBullet+" shim removed: %s\n", displayPath(home, prev.ShimPath))
+			if prev.ProfilePath != "" {
+				fmt.Fprintf(out, "  "+glyphBullet+" profile removed: %s\n", displayPath(home, prev.ProfilePath))
+			}
+			if len(prev.VaultPaths) > 0 {
+				fmt.Fprint(out, "  ")
+				wrapBody(out, 2, "    ", hlCmds(glyphBullet+" vault secrets kept: "+strings.Join(prev.VaultPaths, ", ")+" (`jit vault rm <path>` removes one for good)"))
+			}
+			if prev.LastTool {
+				fmt.Fprint(out, "  ")
+				wrapBody(out, 2, "    ", glyphBullet+" last wrapped tool: the shim PATH line comes out of "+displayPath(home, wrap.RcFile(home, os.Getenv("SHELL"))))
+			}
+			printDryRunTrailer(out, "jit wrap undo "+tool, false)
+			return nil
 		}
 		res, err := wrap.Undo(home, tool)
 		if err != nil {
@@ -631,6 +674,8 @@ func init() {
 	// --env's value is VAR=<vault-path>: two halves the shell cannot guess,
 	// and it was offering filenames for both.
 	_ = wrapAddCmd.RegisterFlagCompletionFunc("env", completeWrapEnvAssignment)
+	wrapCmd.Flags().BoolVar(&wrapDryRun, "dry-run", false, "preview what wrapping would do without changing anything")
+	wrapUndoCmd.Flags().BoolVar(&wrapDryRun, "dry-run", false, "preview what unwrapping would do without changing anything")
 	wrapCmd.AddCommand(wrapAddCmd, wrapListCmd, wrapUndoCmd)
 	rootCmd.AddCommand(wrapCmd)
 }

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -78,7 +79,11 @@ func runCatalogWrap(cmd *cobra.Command, tool string) error {
 			return fmt.Errorf("jit wrap: %w", err)
 		}
 		printDryRunBanner(out)
-		printPlanExtras(out, home, &planExtras{wraps: []wrapPlanRow{{tool: tool, detail: wrapPlanDetail(home, tool)}}})
+		// printPlanExtras ends with its category-separator blank line and
+		// the trailer opens with one; trim to a single blank between them.
+		var plan bytes.Buffer
+		printPlanExtras(&plan, home, &planExtras{wraps: []wrapPlanRow{{tool: tool, detail: wrapPlanDetail(home, tool)}}})
+		fmt.Fprint(out, strings.TrimRight(plan.String(), "\n")+"\n")
 		printDryRunTrailer(out, "jit wrap "+tool, false)
 		return nil
 	}

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -20,6 +20,7 @@ func execWrap(t *testing.T, args ...string) (stdout string, err error) {
 	// previous test would leak into a call that passes none.
 	wrapAddEnv = nil
 	wrapAddGrant = ""
+	wrapDryRun = false
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
 	rootCmd.SetErr(&buf)
@@ -214,5 +215,61 @@ func TestWrapAddGrantRoundTrip(t *testing.T) {
 
 	if _, err := execWrap(t, "undo", "gcloud"); err != nil {
 		t.Fatalf("jit wrap undo: %v", err)
+	}
+}
+
+// TestWrapDryRunPreviewsWithoutChanging: `jit wrap <tool> --dry-run`
+// renders the same frame + [CLI wrap] plan row migrate's plan uses
+// (design/dry-run-refactor.md D6) and touches nothing — no shim dir, no
+// rc edit, no vault.
+func TestWrapDryRunPreviewsWithoutChanging(t *testing.T) {
+	home := withFixtureHome(t)
+
+	out, err := execWrap(t, "gh", "--dry-run")
+	if err != nil {
+		t.Fatalf("jit wrap gh --dry-run: %v", err)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers, got %d:\n%s", got, out)
+	}
+	for _, want := range []string{"[CLI wrap] 1", "gh", "Apply this plan: jit wrap gh"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the preview, got:\n%s", want, out)
+		}
+	}
+	if _, err := os.Stat(wrap.ShimDir(home)); !os.IsNotExist(err) {
+		t.Errorf("dry-run must not create the shim dir (stat err=%v)", err)
+	}
+}
+
+// TestWrapUndoDryRunPreviewsWithoutChanging: the undo preview names the
+// shim (and rc PATH-line removal for the last tool) and leaves the
+// manifest, shim, and rc untouched.
+func TestWrapUndoDryRunPreviewsWithoutChanging(t *testing.T) {
+	home := withFixtureHome(t)
+	putToolOnPath(t, "openai")
+	plantVaultSecret(t, home, "wrap-openai/OPENAI_API_KEY")
+	if _, err := execWrap(t, "openai"); err != nil {
+		t.Fatalf("jit wrap openai: %v", err)
+	}
+	shim := filepath.Join(wrap.ShimDir(home), "openai")
+	if _, err := os.Lstat(shim); err != nil {
+		t.Fatalf("expected the shim installed before the undo preview: %v", err)
+	}
+
+	out, err := execWrap(t, "undo", "openai", "--dry-run")
+	if err != nil {
+		t.Fatalf("jit wrap undo openai --dry-run: %v", err)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers, got %d:\n%s", got, out)
+	}
+	for _, want := range []string{"Unwrap openai:", "shim removed:", "last wrapped tool", "Apply this plan: jit wrap undo openai"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the undo preview, got:\n%s", want, out)
+		}
+	}
+	if _, err := os.Lstat(shim); err != nil {
+		t.Errorf("dry-run must leave the shim in place: %v", err)
 	}
 }

--- a/internal/guard/guard.go
+++ b/internal/guard/guard.go
@@ -316,6 +316,25 @@ func Remove(home string) (changed, rcEdited bool, err error) {
 	return true, true, nil
 }
 
+// RcCarriesJitLine reports whether the rc file holds the exact
+// comment/source pair Install writes — the read-only half of Remove's
+// rc-edit decision, so `jit guard history --dry-run` can say whether a
+// real --remove would edit the rc or leave a hand-written source line
+// alone.
+func RcCarriesJitLine(home string) bool {
+	data, err := os.ReadFile(zshrcPath(home)) // #nosec G304 -- fixed path under the user's own home
+	if err != nil {
+		return false
+	}
+	for _, l := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(l)
+		if trimmed == rcComment || trimmed == rcLine {
+			return true
+		}
+	}
+	return false
+}
+
 // Installed reports whether the guard is fully in place: the hook file
 // exists and the rc file actually sources it.
 func Installed(home string) bool {

--- a/internal/migrate/agentcache.go
+++ b/internal/migrate/agentcache.go
@@ -170,6 +170,51 @@ func PreviewAgentCaches(home string, secrets []AgentCacheSecret) (AgentCacheClea
 	return sweepAgentCaches(nil, home, secrets, false)
 }
 
+// PlanNeedles collects the plaintext values a migrate run of the named
+// files WOULD vault, so the plan can preview the agent-cache sweep before
+// anything reaches the vault (design/dry-run-refactor.md D4). Read-only
+// and best-effort by contract: an unreadable or unparseable file
+// contributes nothing, because the plan must never fail (or prompt) over
+// a preview. Only the categories with a read-only value parser feed it
+// (.env files, loose secret files) — the apply-time sweep still hunts
+// every vaulted value via Vault.OnSet, which stays the authoritative
+// needle set; the plan's cache category discloses the sweep, it does not
+// bound it.
+func PlanNeedles(envFiles, looseFiles []string) []AgentCacheSecret {
+	var out []AgentCacheSecret
+	seen := map[string]bool{}
+	add := func(value, name string) {
+		if value == "" || seen[value] {
+			return
+		}
+		seen[value] = true
+		out = append(out, AgentCacheSecret{Value: value, Var: name})
+	}
+	for _, path := range envFiles {
+		values, names, _, err := parseEnvFile(path)
+		if err != nil {
+			continue
+		}
+		for _, name := range names {
+			add(values[name], name)
+		}
+	}
+	for _, path := range looseFiles {
+		tokens, _, err := ClassifyLooseSecretFile(path)
+		if err != nil {
+			continue
+		}
+		for _, tok := range tokens {
+			name := tok.AssignedName
+			if name == "" {
+				name = filepath.Base(path)
+			}
+			add(tok.Value, name)
+		}
+	}
+	return out
+}
+
 // CleanAgentCaches removes verbatim copies of the given credentials from every
 // AI agent cache under home, replacing each with a marker naming the vault
 // variable that now holds the value.

--- a/internal/wrap/undo.go
+++ b/internal/wrap/undo.go
@@ -6,6 +6,7 @@ package wrap
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 
 	"github.com/jitpass/jit/internal/profile"
@@ -18,6 +19,46 @@ type UndoResult struct {
 	ProfilePath    string
 	VaultPaths     []string // paths the removed profile referenced, the user's to keep or `jit vault rm`
 	Remaining      int      // wrap-managed tools left after this undo
+}
+
+// UndoPreview reports what Undo WOULD remove, for `jit wrap undo
+// --dry-run`. Read-only by contract.
+type UndoPreview struct {
+	ShimPath    string
+	ProfilePath string   // "" for grant/capture/run-grant wraps, which have no profile to remove
+	VaultPaths  []string // kept either way; listed so the preview matches the real run's output
+	LastTool    bool     // true: the real run also removes the shim PATH line from the rc
+}
+
+// PreviewUndo resolves what Undo(home, tool) would do, touching nothing.
+// It shares Undo's manifest/profile reads rather than re-deriving them,
+// so the preview and the real run can't disagree about the same tool.
+func PreviewUndo(home, tool string) (UndoPreview, error) {
+	manifest, err := LoadManifest(home)
+	if err != nil {
+		return UndoPreview{}, err
+	}
+	entry, ok := manifest.Tools[tool]
+	if !ok {
+		return UndoPreview{}, fmt.Errorf("%s isn't wrap-managed, `jit wrap list` shows what is", tool)
+	}
+	prev := UndoPreview{
+		ShimPath: filepath.Join(ShimDir(home), tool),
+		LastTool: len(manifest.Tools) == 1,
+	}
+	if !entry.IsGrant() && !entry.IsCapture() && !entry.IsRunGrant() {
+		prev.ProfilePath, err = profile.Path(home, entry.Profile)
+		if err != nil {
+			return prev, err
+		}
+		if p, loadErr := profile.LoadFile(prev.ProfilePath); loadErr == nil {
+			for _, vaultPath := range p {
+				prev.VaultPaths = append(prev.VaultPaths, vaultPath)
+			}
+			sort.Strings(prev.VaultPaths)
+		}
+	}
+	return prev, nil
 }
 
 // Undo unwraps a tool: shim symlink gone, wrap-<tool> profile manifest


### PR DESCRIPTION
Implements `design/dry-run-refactor.md` (first commit), born from a live dogfood run of bare `jit migrate --dry-run` whose preview printed three `[DRY RUN]` banners plus a stray lowercase `[dry-run]` echo after the trailer, hid the clisso wrap from the plan and the subtotal, and followed a scan that promised a Secret manifest migrate then refused.

## One frame (D1/D2)
- Every dry-run prints exactly two `[DRY RUN]` markers: a banner as its first line, a trailer as its last, owned by the command runner. The wraps-only run that used to print no frame at all is covered by construction; the lowercase spelling is gone everywhere (`undo`, `caches` included).
- The trailer stops restating the banner and carries what the banner cannot: `Apply this plan: <your invocation minus --dry-run>` (`--yes` deliberately dropped so a preview never propagates a consent skip) plus the `jit scan` scope pointer.
- `jit migrate remove --dry-run` parsed (persistent flag) and was **silently ignored** on the command that restores plaintext and deletes vault secrets — now fails loud.

## A complete plan (D3/D4)
- Wraps, the history guard, and the post-migrate agent-cache sweep render as counted plan categories inside `printMigratePlan`, for `--dry-run` and the real `[y/N]` alike — the plan row is the consent line, and the subtotal counts everything the run will do.
- Wrap rows carry a kind-specific `└` detail from the catalog (shim / capture / native / run-grant), including the `~/.zshrc` PATH-line edit disclosure.
- `migrate.PlanNeedles` reads the values of exactly the post-`--only` file set and feeds `PreviewAgentCaches`, so cache files the sweep will rewrite appear in the plan with copy counts. Best-effort: a failed preview degrades to a note, never a failed or prompting plan.

## scan keeps its promises (D5)
- `audit.Config.K8sMigratable` (the `vault.KeyWrapper` pattern — audit cannot import migrate) lets `annotateRemedies` ask migrate's own classifier about each parsed Secret manifest. Refused ones flip to `RemedyManual` with the refusal reason as evidence, leaving the "jit will protect these" percent promise honest. Wired at all three scan surfaces via `newAuditConfig`.

## dry-run everywhere + routing (D6/D7)
- `jit wrap <tool>`, `jit wrap undo <tool>`, and `jit guard history` gain `--dry-run`, reusing the same frame and renderers (`wrap.PreviewUndo`, `guard.RcCarriesJitLine` added as read-only halves of the real operations).
- Naming a file a wrappable CLI owns (catalog token Sources, clisso's config) routes to `jit wrap <tool>` instead of the loose-secret mixed-content hint.

## Style sweep (D8) + docs
- Skip-note paths middle-truncate; hints wrap with hanging indents; the 1Password notice wraps to terminal width; bare-run group headers say "flagged by the scan" (bare migrate names nothing — the scan did); spacing normalized.
- Migrate guide + quickstart samples refreshed to the real output; `docs-gen` run for the three new flags.

## Invariants preserved
GAPS #26 plan parity (dry-run and the real confirm share one rendering — parity test still passes untouched in mechanics), #17 decline-never-costs-Touch-ID, #32 banner-before-plan, plan-never-prompts (the `op` PATH probe stays a probe), scan strictly read-only.

## Testing
10 new tests (two-marker frame contract, cache-sweep preview, extras plan rows, wrap/undo/guard previews, k8s remedy flip incl. end-to-end through the wired hook, wrap-owned routing, remove fail-loud). Full `go test -race ./...`, gofmt, vet, staticcheck, `go mod verify` clean; every surface also verified by eye in a sandboxed fixture home reproducing the original dogfood scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rdv1NyJCs2h5vy33x9FqUi