### PR TITLE
Service reliability phases 1-2: demand spawns and honest health

### DIFF
--- a/design/service-reliability.md
+++ b/design/service-reliability.md
@@ -1,0 +1,312 @@
+# Service reliability: demand-spawned lifecycle, honest health, a broker that keeps its promises
+
+**Status: proposed, 2026-08-17. Drafted from a full review of the
+service surface (three parallel code reviews over `internal/agent`,
+`internal/cli/agent*.go` and the log/history/status surfaces, 43
+findings) plus a verified production incident. Nothing here is
+implemented yet.**
+
+## The incident that forced this
+
+2026-08-17, real hardware, after `brew upgrade` moved the cask from
+0.96.0 to 0.97.0: the running agent detected the binary swap and
+self-retired as designed (`internal/cli/agent.go:280`), and launchd
+never respawned it. The broker was dead for 71 minutes. `jit service
+restart`, the documented fix, ran bootout+bootstrap, reported success
+(exit 0, audit `success: true`), and fixed nothing.
+
+Controlled experiments on the same machine established the mechanism:
+
+| What jit relies on | launchd state | Result |
+|---|---|---|
+| `bootstrap` + RunAtLoad (`jit service restart`) | `runs = 0`, `pended nondemand spawn = speculative` | never spawned (30s+, twice) |
+| clean exit + KeepAlive (self-retire hand-off) | `pended nondemand spawn = inefficient`, last exit 0 | never respawned (60s) |
+| `launchctl kickstart` (an explicit demand) | `runs = 1` | immediate, 3 of 3 |
+
+launchd may defer every non-demand spawn indefinitely. `kickstart` is
+the only verb that creates a demand, and jit stopped using it on
+2026-07-20: `1e5d43e` added kickstart-with-bootstrap-fallback, and
+`660ce2c` (same day, a review-findings batch) replaced it with
+unconditional bootout+bootstrap. Since then `jit service restart`
+against a HEALTHY service is worse than a no-op on a deferral-prone
+launchd: it boots the working agent out, re-registers the job, and the
+respawn may never come. The plist declares no `Sockets` key, so there
+is no demand-launch path at all; a pended non-demand spawn is the only
+way the service ever starts.
+
+The four self-retire respawns before the incident took 2s, 3s, 14s and
+2m9s: the same deferral, eventually honored. "It worked before" was
+survivorship.
+
+## Guarantees this plan makes
+
+1. **Every spawn jit asks for is a demand.** No code path registers a
+   job and hopes RunAtLoad or KeepAlive fires. Bootstrap is followed by
+   kickstart; self-retire IS a kickstart.
+2. **No surface reports a state it has not verified.** "Restarted"
+   means the socket answered AND the build matches; a timeout is a
+   non-zero exit and an audit failure; health advice distinguishes what
+   launchd actually reports.
+3. **The service log carries signal.** A permanently failing mount
+   logs its failure once per transition, not once per unlock; the
+   rendered view collapses and colors what the raw log cannot.
+4. **Version skew fails closed on the socket, as it already does in
+   the vault.** A security field an old peer would silently drop is a
+   refusal, not a silent downgrade.
+
+## Phase 1: lifecycle correctness (the incident fix)
+
+**D1. `reloadAgentService` kickstarts after a successful bootstrap.**
+`launchctlRun("kickstart", agentServiceTarget())`, best-effort: its
+error is ignored the way bootout's is, because in the healthy case
+RunAtLoad may already have spawned the process and kickstart then
+reports it running. Never `-k` here (it would kill the just-spawned
+process). The exit-113 "Could not find service" that motivated
+dropping kickstart in `660ce2c` cannot recur: the job was registered
+by the bootstrap one line earlier. Living inside `reloadAgentService`
+covers every caller (restart, ttl, consent, first-use install) by
+construction.
+
+**D2. Self-retire becomes a demand.** `watchOwnBinary`'s restart
+callback runs `launchctl kickstart -k` on the agent's own label
+instead of exiting and trusting KeepAlive. `-k` is correct here: the
+service is running (so it is bootstrapped; no exit-113) and the point
+is to replace it. launchd kills this process and spawns the new
+binary, re-reading the plist, so an upgraded `--ttl`/`--consent`
+takes effect. If the kickstart call itself errors, fall back to
+today's clean exit (KeepAlive remains the backstop). The quiescent
+and ppid==1 gates are unchanged.
+
+**D3. Success means the right build answered.** `waitForAgentSocket`
+is replaced by `waitForAgentBuild(root, build, timeout)`: poll
+OpStatus until `st.Build == agent.BuildID()`, not until a bare dial
+succeeds. This closes the lie where restart declares victory on the
+OLD process still draining its shutdown, and status contradicts it
+seconds later. The timeout becomes a package var so tests do not burn
+real 5s waits (the 4-CPU VM flakes on exactly that).
+
+**D4. Timeouts are failures.** Every branch that today prints "still
+starting up" and returns nil instead returns an error (non-zero exit,
+audit records failure): restart's three branches
+(`agent.go:788,820,837`), `jit service ttl` (`:373`). `jit service
+consent on|off` stops discarding the `running` result (`:486-493`);
+it is a Touch ID gated security toggle that currently prints "The
+service restarted" unconditionally. `jit upgrade`'s
+`restartServiceOntoCurrentBinary` (upgrade.go:524-558) gets the same
+verified wait; the upgrade path is the exact trigger of the incident.
+`migratesummary.go:278` stays soft (best-effort context, the migrate
+already succeeded) but adopts the shared phrasing. All new/changed
+strings go through a preview script before implementation (list in
+Phase 2).
+
+**D5. Foreground `jit service run` refuses to steal a live socket.**
+Before `server.Listen()` unlinks the socket, a `Reachable()` probe:
+if an agent answers, refuse with "an agent is already running; `jit
+service restart` restarts it". Both reviews found this independently:
+today a foreground run silently splits the world (launchd agent keeps
+the session and every FIFO writer, new clients dial the foreground
+one), and on exit it deletes the socket out from under the launchd
+agent's listener, leaving a healthy process every command calls
+crashed, unrecoverable except by manual restart. The same probe
+serializes the double-serve-on-same-FIFO hazard.
+
+**D6. The plist reader unescapes.** `plistProgramPath` returns the
+XML-escaped string today, so for any install path containing `&`,
+`agentPlistNeedsRepoint` is permanently true and `agentPlistOrphaned`
+stats a nonexistent escaped path, making `ensureAgentInstalled` treat
+a healthy install as orphaned and bounce it. Add `xmlUnescape`
+mirroring `xmlEscaper`; test the round-trip on a metacharacter path.
+
+**D7. Small lifecycle fixes riding along.**
+- Restart's missing-plist branch uses the `running` result it already
+  has instead of waiting a second 5s (`agent.go:785-793`).
+- Restart's read-then-stat TOCTOU collapses to one `ReadFile`
+  branching on `IsNotExist` (`:770-795`).
+- `watchOwnBinary` fingerprints `selfpath.Stable(exePath)`, not raw
+  `os.Executable()`, so a versioned-Caskroom exec path cannot make
+  the watcher blind to an upgrade (vanished file reads as "no change
+  yet" forever).
+- `reloadAgentService` retries the bootout+bootstrap PAIR, not
+  bootstrap alone: a genuinely failed bootout makes every bootstrap
+  return "already bootstrapped", classified transient, spinning 3s
+  with no chance of converging.
+- `jit service ttl` (no args) clamps its display to the 8h ceiling
+  the service enforces, with a parenthetical when the plist says more.
+- `installAgentService` writes the plist via temp+rename (launchd or
+  a concurrent reader can see a torn `os.WriteFile` today).
+
+**Deferred, recorded here so it is not re-litigated blind:**
+- `Sockets` launchd activation (a client connection as the demand) is
+  the strongest fix but inverts socket ownership: launchd would
+  create and hold `agent.sock`, touching permissions, peercred
+  ordering, stale-socket cleanup and the foreground mode. Revisit
+  only if kickstart proves insufficient in the field.
+- An flock serializing concurrent first-use installs: self-healing
+  today, bounded churn, not worth the lock until observed hurting.
+
+## Phase 2: honest health vocabulary
+
+**D8. Health surfaces consult launchd.** A `launchdJobState()` helper
+behind the existing `launchctlRun` seam runs `launchctl print
+gui/$UID/com.jitpass.agent` and extracts three facts: job loaded
+(exit status of the print), `runs`, `last exit code`. Parsing is
+confined to this one function, documented as best-effort (empty
+state on any parse surprise), and never gates anything: it phrases
+advice. With it:
+- `jit service status` and `jit status` distinguish "loaded, never
+  spawned (runs = 0): run `jit service restart`" from "loaded, last
+  exit N" from "not loaded: launchd dropped the job". Today
+  `Installed` means only "plist file exists" and one message covers
+  every state, including a mid-restart claim that was false in the
+  incident.
+- `installedNotRunningAdvice` stays the single source; doctor stops
+  hand-duplicating it (`doctorsections.go:558`), and a test pins
+  every surface to the shared string (today: zero tests reference
+  it; the drift its comment warns about already happened once).
+- `jit lock` against a dead service says the truth: no service, no
+  session, already locked. Today it sends the user on a restart
+  errand to lock a session that does not exist (`agent.go:889-897`).
+- `jit service status` handles a sick-but-answering socket the way
+  `jit status` does (unreachable row + advice) instead of a raw
+  command error; `notRunningHint` likewise (`:1550-1558` vs
+  `status.go:422-437`).
+
+Every string above changes user-visible output and goes through one
+preview script (real `$COLUMNS` plus 50/60, ANSI kept, proposed
+output only) before any code edit. The full inventory: restart's
+success/timeout lines, ttl's two lines, consent's two lines,
+`installedNotRunningAdvice` (three surfaces), upgrade's service
+lines, migratesummary's trailer, status/doctor's new launchd-state
+rows, `jit lock`'s no-service line.
+
+## Phase 3: log and history hygiene
+
+**D9. Resolve failures log on transition, not on cadence.** The
+"skipping mount" prints (`mountmanager.go:376,387,525,531,540`) gain
+the suppression their two neighbors already have: log when the error
+CHANGES (appears, changes text, clears), with the existing
+`errLogLast`/`errSuppressed` counter shape. `sm.lastResolveErr`
+already stores the state; this is one comparison. The incident's
+envelope-v4 storm (identical line every unlock for hours) recurs on
+every future envelope bump until this lands.
+
+**D10. `jit service log` renders failure as failure.**
+- `agentlogview.go`'s `mountRe` learns the `skipping mount` shape so
+  those lines fold like other mount rows.
+- Glyph classification stops keying green on "not matching any red
+  substring": resolve failures ("skipping mount", "envelope
+  version", "no such file") render amber at least. Substring
+  classification stays (the raw log is unstructured), but the list
+  is corrected and a test drives the incident's exact lines.
+- `--follow` cuts chunks at the last complete line (audit's
+  `readAppended` shape) instead of tearing lines, and keeps the day
+  header state across chunks.
+- `noteServeError`'s `(+N similar …)` suffix folds like the reads
+  suffix does.
+
+**D11. History stays bounded while the service runs.** `hist.trim()`
+runs periodically (the `rotateAgentLogPeriodically` cadence), not
+only at startup; `OnServeError` durable writes get a per-source rate
+limit (the ring already defends against this flood, the file does
+not); `serveKey`'s pid component stops letting a re-exec-per-read
+reader defeat the hour collapse (key on stable identity, keep pid in
+the payload).
+
+## Phase 4: broker hardening
+
+**D12. Socket version skew fails closed.** The Client sends BOTH
+`Disclose` and `DiscloseReason` (belt and suspenders for old
+services), and requests carrying security-relevant fields gain a
+`min_protocol` integer the server compares against its own; a server
+too old to know a field refuses rather than silently dropping it.
+Today a new CLI's `jit run --with` against an old service performs a
+machine-wide reveal with NO disclosed challenge: the exact attack
+`Request.Disclose`'s doc names, and the fail-open sibling of the
+envelope-v4 incident (which failed closed, correctly, loudly). A
+wire-compat test pins what the Client sends.
+
+**D13. Prompt storms get the consent engine's backoff.** `OpTrust`,
+`grant_create`, `grant_extend` and disclosed reveals reuse
+`consent.Throttled`'s escalating backoff. The consent path gained it
+because "a caller in a loop could simply outlast the user"; that
+rationale applies verbatim to the op with the widest scope in the
+product (OpTrust: whole-tree consent bypass) and was not carried
+over. Refusals stay recorded (KindDenied), the cooldown-clearing
+unlock semantics stay.
+
+**D14. Audit truth fixes.**
+- Lazy session expiry records its KindLock: `collectIfDoneLocked`
+  stashes the cause, `lockIfGen` writes the event when it finds a
+  lazily-collected session. Today a busy agent can show
+  unlock → unlock with no lock between.
+- `grant_use` collapse keys on `c.rawCommand()`, not the redacted
+  command (`server.go:754-757`): redaction can map two callers onto
+  one string, the misattribution `recordUse` already fixed once.
+- `extendGrant` re-verifies root liveness and stops hard-coding
+  `RootAlive: true` in its echo.
+
+**D15. Small broker fixes riding along.** Grant expiry timers are
+cancelled on revoke/re-extend (today they accumulate for up to 7
+days); the sleep-path handler moves durable-log writes off the
+kernel's power-change wait (the MEK wipe stays synchronous); `Serve`'s
+ctx-watcher goroutine is joined on accept failure.
+
+## Phase 5: mechanical split (last, pure movement)
+
+After the fixes land (small diffs on the familiar layout), split the
+two oversized files. No API changes, SPDX headers and build tags on
+every new file, tests move alongside.
+
+`internal/cli/agent.go` (1825 lines) → six files:
+
+| File | Contents |
+|---|---|
+| `servicerun.go` | `agentRunCmd`, compat aliases, log rotation, `lockedWriter`, TTL validation |
+| `servicelaunchd.go` | `launchctlRun` seam, reload/kickstart, install, ensure, plist template + read/unescape, wait helpers |
+| `servicecmds.go` | `serviceCmd`, ttl/consent/restart, `unlockCmd`, `lockCmd`, init wiring |
+| `servicestatus.go` | status command + result struct + renderers |
+| `servicelog.go` | `agentLogCmd`, tail/follow |
+| `agentclient.go` | `agentClient`, `notRunningHint`, `installedNotRunningAdvice`, prompt waits |
+
+`internal/agent/server.go` (1760 lines) → `fetcher.go`,
+`transport.go` (Listen/Serve/handleConn), `session.go` (the entire
+mu/challengeMu discipline in one file), `events.go` (history,
+recordUse family), with `server.go` keeping the struct, hooks and
+dispatch. The struct's three locking regimes are currently
+reconstructed by scanning 1760 lines; the split makes each regime's
+home explicit.
+
+## Test plan
+
+Through the existing `launchctlRun` fake plus the new wait seam:
+- All three restart branches, including bootstrap-succeeds-spawn-
+  pended (assert kickstart issued, assert non-zero exit on timeout).
+- `installAgentService` round-trip (write → `configuredAgentTTL` /
+  `configuredAgentConsent`), metacharacter path, bootout-then-
+  bootstrap-fails disagreement.
+- `ensureAgentInstalled`: fresh, orphan-repair, reachable-orphan,
+  error-not-swallowed-after-bootout.
+- Self-retire: kickstart -k issued under launchd parent, fallback
+  exit on launchctl error.
+- `bootstrapRaceError` all three arms; pair-retry convergence.
+New unit surfaces: `waitForAgentBuild` against a fake status server;
+`launchdJobState` against canned `launchctl print` output; single-
+source test for `installedNotRunningAdvice`; agentlogview incident-
+line corpus (glyph + fold); follow-mode torn-line and day-header;
+history rate-limit and mid-run trim; wire-compat pin for
+Disclose/DiscloseReason/min_protocol; lazy-expiry KindLock; grant_use
+raw-key collision; extend-dead-root.
+
+## Sequencing
+
+Each phase is a PR; 1 and 2 ship together if the wording preview
+passes in one round (2's strings are 1's error paths). 3, 4, 5
+follow independently. Branch off `main`; the working tree's
+`dryrun-frame` work is untouched.
+
+## Sources
+
+Incident + launchd experiments: session of 2026-08-17 on the
+production Mac (launchd-state table above). Code review: three
+parallel reviews, 2026-08-17, findings folded into the decisions
+above; regression history verified in git (`1e5d43e`, `660ce2c`).

--- a/design/service-reliability.md
+++ b/design/service-reliability.md
@@ -1,10 +1,11 @@
 # Service reliability: demand-spawned lifecycle, honest health, a broker that keeps its promises
 
-**Status: proposed, 2026-08-17. Drafted from a full review of the
-service surface (three parallel code reviews over `internal/agent`,
-`internal/cli/agent*.go` and the log/history/status surfaces, 43
-findings) plus a verified production incident. Nothing here is
-implemented yet.**
+**Status: phases 1-2 implemented, 2026-08-17 (branch
+service-reliability; wording preview approved by eye the same day).
+Phases 3-5 are specified but not yet built. Drafted from a full review
+of the service surface (three parallel code reviews over
+`internal/agent`, `internal/cli/agent*.go` and the log/history/status
+surfaces, 43 findings) plus a verified production incident.**
 
 ## The incident that forced this
 

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -368,6 +368,14 @@ type Server struct {
 	events []SessionEvent
 
 	listener net.Listener
+	// socketInfo identifies the socket file THIS server bound, so Close can
+	// tell its own socket from one a later agent has since claimed at the
+	// same path. Without it, a foreground run (or an instance dying in a
+	// reload's teardown window) unlinked the LIVE agent's socket on exit:
+	// that agent kept its session and every FIFO writer, but held an
+	// unlinked inode nothing could dial, so every command reported a healthy
+	// process as crashed until a manual restart booted it out.
+	socketInfo os.FileInfo
 }
 
 // defaultDenialCooldown pauses automatic re-prompts after a declined
@@ -427,6 +435,9 @@ func (s *Server) Listen() error {
 		_ = l.Close()
 		return fmt.Errorf("chmod %s: %w", s.socketPath, err)
 	}
+	if fi, err := os.Lstat(s.socketPath); err == nil {
+		s.socketInfo = fi
+	}
 	s.listener = l
 	return nil
 }
@@ -482,13 +493,19 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 }
 
-// Close shuts down the listener and removes the socket file.
+// Close shuts down the listener and removes the socket file — but only if
+// the path still holds the socket this server bound. A later agent may have
+// claimed the path (Listen replaces stale sockets); removing ITS live socket
+// on our way out is how a briefly-run second agent used to strand the real
+// one behind an unlinked inode.
 func (s *Server) Close() error {
 	var err error
 	if s.listener != nil {
 		err = s.listener.Close()
 	}
-	_ = os.Remove(s.socketPath)
+	if fi, statErr := os.Lstat(s.socketPath); statErr == nil && s.socketInfo != nil && os.SameFile(fi, s.socketInfo) {
+		_ = os.Remove(s.socketPath)
+	}
 	return err
 }
 

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -16,6 +16,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -299,7 +300,7 @@ var agentRunCmd = &cobra.Command{
 			// warning saying why: the exact trap this watcher exists to end.
 			if exePath, exeErr := agentBinaryPath(); exeErr == nil {
 				go watchOwnBinary(runCtx, exePath, agentBinaryCheckInterval, server.Quiescent, func() {
-					fmt.Fprintf(stdout, "jit service: the jit binary on disk changed (this process is build %s), exiting while the session is locked so launchd restarts the service on the current build\n", agent.BuildID())
+					fmt.Fprintf(stdout, "jit service: the jit binary on disk changed (this process is build %s), demanding a launchd restart onto the current build while the session is locked\n", agent.BuildID())
 					// The restart is DEMANDED, not hoped for. A clean exit
 					// trusting KeepAlive was how the 2026-08-17 incident
 					// happened: launchd pended the respawn ("pended nondemand
@@ -399,10 +400,13 @@ var serviceTTLCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("jit service ttl: %w", err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "Session TTL set to %s. The background service restarted, so the next vault use prompts Touch ID once.\n", d)
 		if !running {
-			fmt.Fprintln(cmd.OutOrStdout(), hlCmds("It's still starting up in the background; give `jit service status` a few seconds."))
+			// The TTL itself IS saved — say so before failing on the
+			// restart half, so the error can't read as "nothing happened".
+			fmt.Fprintf(cmd.OutOrStdout(), "Session TTL set to %s.\n", d)
+			return fmt.Errorf("jit service ttl: the TTL is written, but %s; retry `jit service restart`", restartedServiceClause())
 		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Session TTL set to %s. The background service restarted, so the next vault use prompts Touch ID once.\n", d)
 		return nil
 	},
 }
@@ -514,8 +518,21 @@ var serviceConsentCmd = &cobra.Command{
 		if !ok {
 			ttl = agentInstallDefaultTTL
 		}
-		if _, _, err := installAgentService(ttl, on); err != nil {
+		_, running, err := installAgentService(ttl, on)
+		if err != nil {
 			return fmt.Errorf("jit service consent: %w", err)
+		}
+		state := "OFF"
+		if on {
+			state = "ON"
+		}
+		if !running {
+			// The setting IS saved (a Touch ID gated one, when turning off) —
+			// but "The service restarted" was printed unconditionally here,
+			// exit 0, for a service that may never have come back. Say what
+			// happened and fail on the restart half.
+			fmt.Fprintf(cmd.OutOrStdout(), "Per-process credential consent is now %s.\n", state)
+			return fmt.Errorf("jit service consent: the setting is written, but %s; retry `jit service restart`", restartedServiceClause())
 		}
 		if on {
 			fmt.Fprintln(cmd.OutOrStdout(), "Per-process credential consent is now ON. The service restarted; the next credential use prompts Touch ID.")
@@ -828,8 +845,7 @@ var agentRestartCmd = &cobra.Command{
 			if _, running, ierr := installAgentService(agentInstallDefaultTTL, true); ierr != nil {
 				return fmt.Errorf("jit service restart: %w", ierr)
 			} else if !running {
-				fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Started the background service; it's still coming up, give `jit service status` a few seconds."))
-				return nil
+				return fmt.Errorf("jit service restart: %w", agentStartFailure())
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Started the background service. The next vault use will prompt Touch ID.")
 			return nil
@@ -857,8 +873,7 @@ var agentRestartCmd = &cobra.Command{
 			if _, running, ierr := installAgentService(ttl, configuredAgentConsent()); ierr != nil {
 				return fmt.Errorf("jit service restart: %w", ierr)
 			} else if !running {
-				fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Restart requested, the service is still starting up in the background; give `jit service status` a few seconds."))
-				return nil
+				return fmt.Errorf("jit service restart: %w", agentStartFailure())
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Restarted, the service is now running the current binary. The next vault use will prompt Touch ID.")
 			return nil
@@ -874,8 +889,7 @@ var agentRestartCmd = &cobra.Command{
 		// process is actually answering, or status contradicts us moments
 		// later.
 		if !waitForAgentBuild(root, agentStartWait) {
-			fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Restart requested, the service is still starting up in the background; give `jit service status` a few seconds."))
-			return nil
+			return fmt.Errorf("jit service restart: %w", agentStartFailure())
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Restarted, the service is now running the current binary. The next vault use will prompt Touch ID.")
 		return nil
@@ -932,6 +946,15 @@ var lockCmd = &cobra.Command{
 			return fmt.Errorf("jit lock: %w", err)
 		}
 		if err := c.Lock(); err != nil {
+			// A not-running service holds no session: the state `lock` wants
+			// is already true. Telling the user "may have crashed... try
+			// restart" here sent them on a repair errand to lock a session
+			// that didn't exist (observed doing exactly that in the
+			// 2026-08-17 incident, where the restart couldn't work either).
+			if errors.Is(err, agent.ErrNotRunning) {
+				fmt.Fprintln(cmd.OutOrStdout(), "Already locked: the service isn't running, so no session exists.")
+				return nil
+			}
 			return fmt.Errorf("jit lock: %w", notRunningHint(err))
 		}
 		fmt.Fprintln(cmd.OutOrStdout(), "Locked.")
@@ -1009,7 +1032,7 @@ var agentStatusCmd = &cobra.Command{
 				// situation from one that was never set up — launchd was
 				// supposed to keep this one alive, so "run install" is the
 				// wrong advice and hides that something actually failed.
-				fmt.Fprintln(cmd.OutOrStdout(), installedNotRunningAdvice("jit's background service is"))
+				fmt.Fprintln(cmd.OutOrStdout(), installedNotRunningAdvice("jit's background service"))
 				return nil
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), hlCmds("jit's background service is not running. Run `jit service restart` to start it (or just use jit and it starts on its own)."))
@@ -1575,16 +1598,136 @@ func announceTouchIDWait() {
 // answer, but the thing a human can DO about that differs: an installed
 // agent that isn't answering wants a restart (and its log), one that was
 // never installed wants installing.
-// installedNotRunningAdvice is the SINGLE source of the "installed but not
-// running" guidance, shared by `jit status`, `jit service status`, and the
-// notRunningHint agent subcommands print on a dial failure — so the wording
-// can't drift across the three. It did drift once: a change to what restart
-// recovers updated only `jit service status`, leaving `jit status` (the first
-// place a user sees this) and notRunningHint on stale advice. subject is the
-// caller's sentence opener ("Service:", "jit's background service is", "the service is") so each
-// surface keeps its own voice while the actionable half stays identical.
+// launchdJobState is the slice of `launchctl print` the health surfaces
+// phrase advice from: whether the job is loaded, how many times launchd has
+// run it, and how the last run ended. Parsing launchctl's undocumented,
+// localizable output is deliberately confined to queryLaunchdJobState, is
+// best-effort (any surprise degrades to the unknown state), and NEVER gates
+// behaviour — the restart comment's warning about launchctl text as a
+// decision input still stands. It only turns "installed but not running"
+// into the right sentence: the 2026-08-17 incident's job sat loaded with
+// runs = 0 ("pended nondemand spawn") while every surface said "may have
+// crashed or be mid-restart", both halves of which were false.
+type launchdJobState struct {
+	loaded      bool
+	runs        int
+	lastExit    int
+	hasLastExit bool
+}
+
+// queryLaunchdJobState asks launchd about the service's job record. known is
+// false when the state could not be read at all; "could not find service" is
+// a KNOWN answer (the job is definitively not loaded), not a read failure.
+func queryLaunchdJobState() (st launchdJobState, known bool) {
+	out, err := launchctlRun("print", agentServiceTarget())
+	if err != nil {
+		if bytes.Contains(bytes.ToLower(out), []byte("could not find service")) {
+			return launchdJobState{}, true
+		}
+		return launchdJobState{}, false
+	}
+	st.loaded = true
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if v, ok := strings.CutPrefix(line, "runs = "); ok {
+			if n, aerr := strconv.Atoi(strings.TrimSpace(v)); aerr == nil {
+				st.runs = n
+			}
+		} else if v, ok := strings.CutPrefix(line, "last exit code = "); ok {
+			// "(never exited)" and other non-numeric values simply leave
+			// hasLastExit false — exactly the never-spawned shape.
+			if n, aerr := strconv.Atoi(strings.TrimSpace(v)); aerr == nil {
+				st.lastExit, st.hasLastExit = n, true
+			}
+		}
+	}
+	return st, true
+}
+
+// installedNotRunningParts is the SINGLE source of the "installed but not
+// running" guidance, shared by `jit status`, `jit service status`, doctor,
+// migrate's trailer and the notRunningHint agent subcommands print on a dial
+// failure — so the wording can't drift across the surfaces. It did drift
+// once: a change to what restart recovers updated only `jit service status`,
+// leaving `jit status` (the first place a user sees this) and notRunningHint
+// on stale advice. The state half and the action half return separately
+// because doctor renders them as Detail and Action; flat surfaces join them
+// (installedNotRunningAdvice). subject is the caller's noun phrase ("the
+// service", "jit's background service") so each surface keeps its own voice
+// while the sentences stay identical.
+func installedNotRunningParts(subject string) (detail, action string) {
+	st, known := queryLaunchdJobState()
+	switch {
+	case known && st.loaded && st.runs == 0:
+		return subject + " is installed and launchd accepted it, but never started it.",
+			"`jit service restart` demands a start directly; `jit service log` shows recent output."
+	case known && st.loaded && st.hasLastExit:
+		return fmt.Sprintf("%s stopped (last exit code %d) and launchd has not brought it back.", subject, st.lastExit),
+			"`jit service restart` restarts it; `jit service log` shows recent output."
+	case known && !st.loaded:
+		return subject + " is installed but launchd has dropped it.",
+			"`jit service restart` re-registers and starts it; `jit service log` shows recent output."
+	default:
+		return subject + " is installed but not running.",
+			"`jit service restart` restarts it; `jit service log` shows recent output."
+	}
+}
+
 func installedNotRunningAdvice(subject string) string {
-	return subject + " installed but not running, it may have crashed or be mid-restart. Try `jit service restart` (it reloads the service, recovering even one launchd has dropped, and recreates the login item if it was removed). `jit service log` shows recent output."
+	detail, action := installedNotRunningParts(subject)
+	return detail + " " + action
+}
+
+// statusServiceRow is the dashboard-width version of
+// installedNotRunningParts: one clause for `jit status`'s service row, with
+// the action rendered separately as the row's → line.
+func statusServiceRow() string {
+	st, known := queryLaunchdJobState()
+	switch {
+	case known && st.loaded && st.runs == 0:
+		return "installed, but launchd never started it (runs 0)"
+	case known && st.loaded && st.hasLastExit:
+		return fmt.Sprintf("stopped (last exit code %d), launchd has not brought it back", st.lastExit)
+	case known && !st.loaded:
+		return "installed, but launchd has dropped it"
+	default:
+		return "installed but not running"
+	}
+}
+
+// agentStartFailure is the error restart returns when the just-reloaded
+// service never answered: what launchd says happened, and what to do. This
+// replaced "still starting up in the background" + exit 0, which audited
+// success: true for a permanently dead service — the incident's second
+// half. A timeout here is a failure, in the exit code and the audit record.
+func agentStartFailure() error {
+	st, known := queryLaunchdJobState()
+	switch {
+	case known && st.loaded && st.runs == 0:
+		return fmt.Errorf("reloaded, but the service never started (launchd: loaded, runs 0 after %s); retry, and `jit service log` shows recent output", agentStartWait)
+	case known && st.loaded && st.hasLastExit:
+		return fmt.Errorf("the service started but exited (last exit code %d) and has not come back; `jit service log` shows its output", st.lastExit)
+	case known && !st.loaded:
+		return errors.New("launchd no longer shows the service after the reload; `jit service log` shows recent output")
+	default:
+		return fmt.Errorf("the service did not answer within %s; `jit service status` may catch it late, `jit service log` shows output", agentStartWait)
+	}
+}
+
+// restartedServiceClause is ttl/consent's version of agentStartFailure: their
+// setting IS saved, so the sentence blames only the restart half.
+func restartedServiceClause() string {
+	st, known := queryLaunchdJobState()
+	switch {
+	case known && st.loaded && st.runs == 0:
+		return "the restarted service never started (launchd: loaded, runs 0)"
+	case known && st.loaded && st.hasLastExit:
+		return fmt.Sprintf("the restarted service exited (last exit code %d)", st.lastExit)
+	case known && !st.loaded:
+		return "launchd no longer shows the service"
+	default:
+		return "the restarted service has not answered yet"
+	}
 }
 
 func notRunningHint(err error) error {
@@ -1592,7 +1735,7 @@ func notRunningHint(err error) error {
 		return err
 	}
 	if agentInstalled() {
-		return errors.New(installedNotRunningAdvice("the service is"))
+		return errors.New(installedNotRunningAdvice("the service"))
 	}
 	return errors.New("the background service isn't running; run `jit service restart` to start it")
 }

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -99,6 +99,19 @@ var agentRunCmd = &cobra.Command{
 			return fmt.Errorf("jit service run: %w", err)
 		}
 
+		// A foreground run must not steal the socket from a live agent:
+		// Listen unconditionally replaces the socket file, so a second agent
+		// silently splits the world — the first keeps the session and every
+		// FIFO mount's writer while new clients dial this one, and this one's
+		// exit then removes the socket out from under the first's listener,
+		// leaving a healthy process every command reports as crashed. Only
+		// the foreground case checks: under launchd (ppid 1) the reload's
+		// bootout guarantees the singleton, and a mid-teardown predecessor
+		// still answering the socket would turn this probe into a crash loop.
+		if os.Getppid() != 1 && agent.NewClient(agent.SocketPath(root)).Reachable() {
+			return fmt.Errorf("jit service run: an agent is already running and answering on %s; `jit service restart` restarts it", agent.SocketPath(root))
+		}
+
 		// launchd creates the StandardOutPath/StandardErrorPath log 0644;
 		// tighten it to 0600 on every start (covering both a fresh log and
 		// one an older build already left world-readable). It records reader
@@ -278,9 +291,27 @@ var agentRunCmd = &cobra.Command{
 		// file out from under a concurrently-installed agent's O_APPEND fd
 		// is exactly the cross-process interference to avoid.
 		if os.Getppid() == 1 {
-			if exePath, exeErr := os.Executable(); exeErr == nil {
+			// Watch the STABLE path (the same one the plist names), not the raw
+			// os.Executable(): a versioned Caskroom exec path is deleted whole
+			// by `brew upgrade`, and a vanished file deliberately reads as "no
+			// change yet" forever — a watcher pointed there would never fire,
+			// leaving the old build running with only the status mismatch
+			// warning saying why: the exact trap this watcher exists to end.
+			if exePath, exeErr := agentBinaryPath(); exeErr == nil {
 				go watchOwnBinary(runCtx, exePath, agentBinaryCheckInterval, server.Quiescent, func() {
 					fmt.Fprintf(stdout, "jit service: the jit binary on disk changed (this process is build %s), exiting while the session is locked so launchd restarts the service on the current build\n", agent.BuildID())
+					// The restart is DEMANDED, not hoped for. A clean exit
+					// trusting KeepAlive was how the 2026-08-17 incident
+					// happened: launchd pended the respawn ("pended nondemand
+					// spawn = inefficient") and the broker stayed dead for 71
+					// minutes. kickstart -k has launchd kill this process and
+					// spawn the new binary, re-reading the plist on the way (so
+					// an upgraded --ttl/--consent takes effect); it cannot hit
+					// the exit-113 dead end because a running service is by
+					// definition bootstrapped. If launchctl itself errors,
+					// endRun's clean exit still happens and KeepAlive remains
+					// the (unreliable) backstop it always was.
+					_, _ = launchctlRun("kickstart", "-k", agentServiceTarget())
 					endRun()
 				})
 			}
@@ -588,7 +619,13 @@ func plistProgramPath(data []byte) (string, bool) {
 	if len(values) == 0 {
 		return "", false
 	}
-	return values[0], true
+	// Unescape what install escaped: a path containing `&` (common in real
+	// directory names, as the install-side comment notes) round-trips through
+	// the plist as `&amp;`, and returning the escaped form made every
+	// comparison and stat against it wrong — agentPlistNeedsRepoint
+	// permanently true, and agentPlistOrphaned calling a healthy install
+	// orphaned because it stat'ed a path that doesn't exist.
+	return xmlUnescape(values[0]), true
 }
 
 // agentPlistNeedsRepoint reports whether the installed plist runs a different
@@ -650,7 +687,13 @@ func installAgentService(ttl time.Duration, consent bool) (plistPath string, run
 	if err := os.MkdirAll(filepath.Dir(plistPath), 0o700); err != nil {
 		return plistPath, false, err
 	}
-	if err := os.WriteFile(plistPath, []byte(plist), 0o600); err != nil {
+	// Temp+rename, not a plain WriteFile: launchd or a concurrent session's
+	// configuredAgentTTL() read can catch a half-written plist otherwise.
+	tmp := plistPath + ".tmp"
+	if err := os.WriteFile(tmp, []byte(plist), 0o600); err != nil {
+		return plistPath, false, err
+	}
+	if err := os.Rename(tmp, plistPath); err != nil {
 		return plistPath, false, err
 	}
 
@@ -667,8 +710,8 @@ func installAgentService(ttl time.Duration, consent bool) (plistPath string, run
 	// bound its socket — a real, observed confusion where `jit service status`
 	// typed right after a successful install said "not running" for the ~2s
 	// launchd took to actually start it. Wait briefly so "installed" also
-	// means "answering."
-	running = waitForAgentSocket(root, 5*time.Second)
+	// means "answering, on this build."
+	running = waitForAgentBuild(root, agentStartWait)
 	return plistPath, running, nil
 }
 
@@ -771,28 +814,25 @@ var agentRestartCmd = &cobra.Command{
 		if readErr != nil && !os.IsNotExist(readErr) {
 			return fmt.Errorf("jit service restart: %w", readErr)
 		}
-		if _, statErr := os.Stat(plistPath); os.IsNotExist(statErr) {
+		if os.IsNotExist(readErr) {
 			// No login item yet (never started, or uninstalled). Rather than
 			// dead-end, create it: restart is the single "get the service
 			// running" command, and the service is meant to always be present.
 			// Default TTL and default (on) consent, since a missing plist has no
 			// configured value to preserve — `jit service ttl <d>` and
-			// `jit service consent off` change them afterward.
-			root, rerr := vaultRootDir()
-			if rerr != nil {
-				return fmt.Errorf("jit service restart: %w", rerr)
-			}
-			if _, _, ierr := installAgentService(agentInstallDefaultTTL, true); ierr != nil {
+			// `jit service consent off` change them afterward. Branching on the
+			// ReadFile error alone (no separate Stat) keeps this race-free
+			// against a concurrent session's install, and installAgentService
+			// already waited for the socket — its result is the answer, a
+			// second wait would only double the worst-case silence.
+			if _, running, ierr := installAgentService(agentInstallDefaultTTL, true); ierr != nil {
 				return fmt.Errorf("jit service restart: %w", ierr)
-			}
-			if !waitForAgentSocket(root, 5*time.Second) {
+			} else if !running {
 				fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Started the background service; it's still coming up, give `jit service status` a few seconds."))
 				return nil
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), "Started the background service. The next vault use will prompt Touch ID.")
 			return nil
-		} else if statErr != nil {
-			return fmt.Errorf("jit service restart: %w", statErr)
 		}
 		// bootout + bootstrap (reloadAgentService) restarts a running agent
 		// AND recovers one launchd has dropped (the plist on disk with no live
@@ -833,7 +873,7 @@ var agentRestartCmd = &cobra.Command{
 		// Same wait as install, same reason: "Restarted" must mean the new
 		// process is actually answering, or status contradicts us moments
 		// later.
-		if !waitForAgentSocket(root, 5*time.Second) {
+		if !waitForAgentBuild(root, agentStartWait) {
 			fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Restart requested, the service is still starting up in the background; give `jit service status` a few seconds."))
 			return nil
 		}
@@ -1571,6 +1611,24 @@ var xmlEscaper = strings.NewReplacer(
 	"'", "&apos;",
 )
 
+// xmlUnescape reverses xmlEscape for values read back OUT of a plist.
+// plistStringValues deliberately does not unescape (its literal matches,
+// "--ttl" and durations, carry no entities); a PATH read through
+// plistProgramPath must be unescaped before it is compared or stat'ed.
+// `&amp;` is listed first so an escaped-escape (`&amp;lt;`) resolves the
+// way the escaper produced it.
+func xmlUnescape(s string) string {
+	return xmlUnescaper.Replace(s)
+}
+
+var xmlUnescaper = strings.NewReplacer(
+	"&amp;", "&",
+	"&lt;", "<",
+	"&gt;", ">",
+	"&quot;", `"`,
+	"&apos;", "'",
+)
+
 // agentLogMaxBytes caps agent.log. 5MB is months of ordinary lines and
 // still small enough to open casually; the previous generation is kept in
 // agent.log.1, so a rotation never costs the recent past.
@@ -1694,21 +1752,45 @@ var launchctlRun = func(args ...string) ([]byte, error) {
 // (EIO, launchctl exit 5) — observed on real hardware. The previous install
 // code happened to dodge it by writing the plist between bootout and
 // bootstrap, which gave launchd that beat; doing the two back-to-back exposed
-// it. So retry the bootstrap through the teardown window rather than
-// surfacing a transient race as a hard failure. A non-transient error (bad
-// plist, permissions) is returned on the first try.
+// it. So retry through the teardown window rather than surfacing a transient
+// race as a hard failure — and retry the bootout+bootstrap PAIR, not
+// bootstrap alone: a bootout that genuinely failed leaves every bootstrap
+// answering "already bootstrapped", which bootstrapRaceError classifies as
+// transient, and without a fresh bootout the loop could never converge. A
+// non-transient error (bad plist, permissions) is returned on the first try.
+//
+// A successful bootstrap is followed by a best-effort kickstart, because
+// bootstrap only REGISTERS the job — it does not guarantee a spawn. launchd
+// can defer a RunAtLoad spawn indefinitely: observed 2026-08-17 on real
+// hardware as `pended nondemand spawn = speculative`, runs = 0, twice, 30s+
+// each — and the same machine's KeepAlive equally never respawned a cleanly
+// exited agent, leaving the broker dead for 71 minutes while restart
+// reported success. kickstart is the one launchctl verb that creates an
+// explicit demand; in those experiments it spawned the job instantly, 3 of
+// 3. Its error is ignored the way bootout's is: in the healthy case
+// RunAtLoad has already spawned the process and kickstart merely reports it
+// running. The exit-113 "Could not find service" that got kickstart dropped
+// in 660ce2c cannot recur here — the job was registered one line earlier,
+// and this kickstart never uses -k, so it cannot kill a just-spawned
+// process either.
 func reloadAgentService(plistPath string) ([]byte, error) {
-	_, _ = launchctlRun("bootout", agentServiceTarget())
 	var out []byte
 	var err error
 	for attempt := 0; attempt < 15; attempt++ {
+		if attempt > 0 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		_, _ = launchctlRun("bootout", agentServiceTarget())
 		out, err = launchctlRun("bootstrap", agentDomainTarget(), plistPath)
 		if err == nil || !bootstrapRaceError(out) {
-			return out, err
+			break
 		}
-		time.Sleep(200 * time.Millisecond)
 	}
-	return out, err
+	if err != nil {
+		return out, err
+	}
+	_, _ = launchctlRun("kickstart", agentServiceTarget())
+	return out, nil
 }
 
 // bootstrapRaceError reports whether a failed bootstrap is the transient
@@ -1722,13 +1804,24 @@ func bootstrapRaceError(launchctlOutput []byte) bool {
 		bytes.Contains(l, []byte("service already bootstrapped"))
 }
 
-// waitForAgentSocket polls until an agent answers the socket, or gives up.
-// install/restart use it so their success message never races launchd's
-// actual spawn of the process.
-func waitForAgentSocket(root string, timeout time.Duration) bool {
+// agentStartWait is how long install/restart wait for the just-(re)loaded
+// service to answer before declaring the start unconfirmed. A package var so
+// tests don't spend real wall-clock on the give-up path.
+var agentStartWait = 5 * time.Second
+
+// waitForAgentBuild polls until an agent running THIS build answers the
+// socket, or gives up. install/restart use it so their success message never
+// races launchd's actual spawn — and "the service is now running the current
+// binary" is a statement about the answering process's own BuildID, not
+// about a bare dial succeeding. The distinction is real: during a reload the
+// OLD process can still be draining its shutdown and answering the socket,
+// and a wait that only dialed would declare success on it (every path here
+// has just written or verified a plist pointing at this binary, so build
+// equality is the correct postcondition).
+func waitForAgentBuild(root string, timeout time.Duration) bool {
 	client := agent.NewClient(agent.SocketPath(root))
 	for deadline := time.Now().Add(timeout); time.Now().Before(deadline); {
-		if client.Reachable() {
+		if st, err := client.Status(); err == nil && st.Build == agent.BuildID() {
 			return true
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/internal/cli/agent_status_test.go
+++ b/internal/cli/agent_status_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -276,5 +277,140 @@ func TestWaitForAgentBuild(t *testing.T) {
 	// and all (status never challenges).
 	if !waitForAgentBuild(root, 2*time.Second) {
 		t.Fatal("an agent on this build answers; the wait must succeed")
+	}
+}
+
+// fakeLaunchdPrint pins launchctlRun to a canned `launchctl print` answer
+// (all other verbs succeed silently), so the advice-variant tests are
+// deterministic regardless of the machine's real launchd state.
+func fakeLaunchdPrint(t *testing.T, out string, err error) {
+	t.Helper()
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		if args[0] == "print" {
+			return []byte(out), err
+		}
+		return nil, nil
+	}
+}
+
+// TestQueryLaunchdJobState pins the (deliberately confined) parse of
+// launchctl print: the three states the health surfaces phrase advice from,
+// and the read-failure case that must degrade to unknown rather than guess.
+func TestQueryLaunchdJobState(t *testing.T) {
+	t.Run("pended spawn: loaded, runs 0, never exited", func(t *testing.T) {
+		fakeLaunchdPrint(t, "com.jitpass.agent = {\n\truns = 0\n\tlast exit code = (never exited)\n}", nil)
+		st, known := queryLaunchdJobState()
+		if !known || !st.loaded || st.runs != 0 || st.hasLastExit {
+			t.Errorf("got %+v known=%v, want loaded runs=0 no-last-exit (the incident's exact state)", st, known)
+		}
+	})
+	t.Run("ran and exited", func(t *testing.T) {
+		fakeLaunchdPrint(t, "\truns = 3\n\tlast exit code = 78\n", nil)
+		st, known := queryLaunchdJobState()
+		if !known || !st.loaded || st.runs != 3 || !st.hasLastExit || st.lastExit != 78 {
+			t.Errorf("got %+v known=%v, want loaded runs=3 lastExit=78", st, known)
+		}
+	})
+	t.Run("job not loaded is a KNOWN answer", func(t *testing.T) {
+		fakeLaunchdPrint(t, `Could not find service "com.jitpass.agent" in domain for user gui: 501`, errors.New("exit status 113"))
+		st, known := queryLaunchdJobState()
+		if !known || st.loaded {
+			t.Errorf("got %+v known=%v, want known and not loaded", st, known)
+		}
+	})
+	t.Run("any other failure is unknown, never a guess", func(t *testing.T) {
+		fakeLaunchdPrint(t, "Bad request.", errors.New("exit status 5"))
+		if _, known := queryLaunchdJobState(); known {
+			t.Error("an unreadable state must report known=false")
+		}
+	})
+}
+
+// TestInstalledNotRunningPartsVariants pins each launchd state to its
+// sentence — the vocabulary that replaced one "may have crashed or be
+// mid-restart" for every state, which the 2026-08-17 incident showed being
+// wrong on both halves (nothing crashed, nothing was mid-restart, and the
+// advised restart couldn't work).
+func TestInstalledNotRunningPartsVariants(t *testing.T) {
+	cases := []struct {
+		name, print string
+		printErr    error
+		wantDetail  string
+	}{
+		{"never started", "runs = 0\nlast exit code = (never exited)", nil,
+			"the service is installed and launchd accepted it, but never started it."},
+		{"stopped", "runs = 2\nlast exit code = 1", nil,
+			"the service stopped (last exit code 1) and launchd has not brought it back."},
+		{"dropped", `Could not find service "x"`, errors.New("exit status 113"),
+			"the service is installed but launchd has dropped it."},
+		{"unknown", "Bad request.", errors.New("exit status 5"),
+			"the service is installed but not running."},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeLaunchdPrint(t, tc.print, tc.printErr)
+			detail, action := installedNotRunningParts("the service")
+			if detail != tc.wantDetail {
+				t.Errorf("detail = %q, want %q", detail, tc.wantDetail)
+			}
+			if !strings.Contains(action, "`jit service restart`") || !strings.Contains(action, "`jit service log`") {
+				t.Errorf("action must carry the restart and the log command, got %q", action)
+			}
+		})
+	}
+}
+
+// TestRestartTimeoutIsAFailure is the incident's second half as a test: a
+// reload that launchd accepts but never spawns must make `jit service
+// restart` FAIL — non-zero exit, an audit record of failure — not print
+// "still starting up" and exit 0 (which audited success: true over a broker
+// that stayed dead 71 minutes).
+func TestRestartTimeoutIsAFailure(t *testing.T) {
+	shortFixtureHome(t)
+
+	restoreWait := agentStartWait
+	agentStartWait = 50 * time.Millisecond
+	t.Cleanup(func() { agentStartWait = restoreWait })
+
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		if args[0] == "print" {
+			// The incident's state: job registered, spawn pended forever.
+			return []byte("runs = 0\nlast exit code = (never exited)"), nil
+		}
+		return nil, nil // bootout/bootstrap/kickstart all "succeed"
+	}
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"service", "restart"})
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("a restart whose service never came up must fail, got exit 0")
+	}
+	if !strings.Contains(err.Error(), "never started") || !strings.Contains(err.Error(), "runs 0") {
+		t.Errorf("the error must carry launchd's diagnosis, got %q", err)
+	}
+}
+
+// TestLockIsHonestWhenServiceDown: a not-running service holds no session,
+// so `jit lock` reports the already-true state instead of sending the user
+// on a restart errand to lock a session that doesn't exist.
+func TestLockIsHonestWhenServiceDown(t *testing.T) {
+	shortFixtureHome(t)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"lock"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("lock against a dead service must succeed (the state is already true), got %v", err)
+	}
+	if !strings.Contains(buf.String(), "Already locked") {
+		t.Errorf("want the honest already-locked line, got %q", buf.String())
 	}
 }

--- a/internal/cli/agent_status_test.go
+++ b/internal/cli/agent_status_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -95,10 +96,14 @@ func TestAgentStatusFormatRejectsUnknownValue(t *testing.T) {
 // TestReloadAgentServiceBootoutThenBootstrap pins reloadAgentService's
 // recovery contract (the launchctl seam is what makes this testable at all,
 // which the old exec'd path was not): it ALWAYS boots out first, then
-// bootstraps, and it recovers a launchd-dropped service — the bootout
-// failing with "Could not find service" is expected and must not fail the
-// reload, only the bootstrap result decides. Guards against a future edit
-// that drops the bootout, reorders the two, or lets bootout's error abort.
+// bootstraps, then KICKSTARTS — and it recovers a launchd-dropped service:
+// the bootout failing with "Could not find service" is expected and must not
+// fail the reload, only the bootstrap result decides. The kickstart is the
+// incident guard (2026-08-17): bootstrap only registers the job, and launchd
+// can pend the RunAtLoad spawn forever ("pended nondemand spawn", runs=0);
+// kickstart is the explicit demand. Guards against a future edit that drops
+// the bootout, reorders the verbs, lets bootout's error abort — or drops the
+// kickstart again the way 660ce2c did.
 func TestReloadAgentServiceBootoutThenBootstrap(t *testing.T) {
 	var calls [][]string
 	restore := launchctlRun
@@ -110,22 +115,50 @@ func TestReloadAgentServiceBootoutThenBootstrap(t *testing.T) {
 			// The dropped-service case: launchd has no record to boot out.
 			return []byte(`Could not find service "com.jitpass.agent" in domain for user gui: 502`), errors.New("exit status 113")
 		}
-		return nil, nil // bootstrap succeeds
+		return nil, nil // bootstrap and kickstart succeed
 	}
 
 	if out, err := reloadAgentService("/tmp/whatever.plist"); err != nil {
 		t.Fatalf("reload must succeed when only bootout fails (dropped service): err=%v out=%q", err, out)
 	}
-	if len(calls) != 2 || calls[0][0] != "bootout" || calls[1][0] != "bootstrap" {
-		t.Fatalf("want bootout then bootstrap, got %v", calls)
+	if len(calls) != 3 || calls[0][0] != "bootout" || calls[1][0] != "bootstrap" || calls[2][0] != "kickstart" {
+		t.Fatalf("want bootout, bootstrap, kickstart, got %v", calls)
 	}
 	if calls[1][len(calls[1])-1] != "/tmp/whatever.plist" {
 		t.Errorf("bootstrap must be handed the plist path, got %v", calls[1])
 	}
+	// Plain kickstart, never -k: -k would kill the process RunAtLoad may
+	// already have spawned; the demand must only start, not restart.
+	for _, a := range calls[2] {
+		if a == "-k" {
+			t.Errorf("reload's kickstart must not use -k, got %v", calls[2])
+		}
+	}
+	if calls[2][len(calls[2])-1] != agentServiceTarget() {
+		t.Errorf("kickstart must target the service, got %v", calls[2])
+	}
+
+	// A kickstart error must NOT fail the reload: in the healthy case
+	// RunAtLoad already spawned the process and kickstart merely reports it
+	// running.
+	launchctlRun = func(args ...string) ([]byte, error) {
+		if args[0] == "kickstart" {
+			return []byte("already running"), errors.New("exit status 37")
+		}
+		return nil, nil
+	}
+	if _, err := reloadAgentService("/tmp/whatever.plist"); err != nil {
+		t.Fatalf("a kickstart error must be ignored, got %v", err)
+	}
 
 	// And a non-transient bootstrap failure IS surfaced (a race error like EIO
-	// would instead be retried — see TestReloadAgentServiceRetriesThroughBootoutRace).
+	// would instead be retried — see TestReloadAgentServiceRetriesThroughBootoutRace),
+	// with no kickstart after it: there is no registered job to demand.
+	var kickstarts int
 	launchctlRun = func(args ...string) ([]byte, error) {
+		if args[0] == "kickstart" {
+			kickstarts++
+		}
 		if args[0] == "bootstrap" {
 			return []byte("Bootstrap failed: 112: Operation not permitted"), errors.New("exit status 112")
 		}
@@ -133,6 +166,9 @@ func TestReloadAgentServiceBootoutThenBootstrap(t *testing.T) {
 	}
 	if _, err := reloadAgentService("/tmp/whatever.plist"); err == nil {
 		t.Fatal("a bootstrap failure must be returned, got nil")
+	}
+	if kickstarts != 0 {
+		t.Errorf("no kickstart after a failed bootstrap, got %d", kickstarts)
 	}
 }
 
@@ -145,9 +181,13 @@ func TestReloadAgentServiceRetriesThroughBootoutRace(t *testing.T) {
 	restore := launchctlRun
 	t.Cleanup(func() { launchctlRun = restore })
 
-	var bootstraps int
+	var bootstraps, bootouts int
 	launchctlRun = func(args ...string) ([]byte, error) {
 		if args[0] == "bootout" {
+			bootouts++
+			return nil, nil
+		}
+		if args[0] == "kickstart" {
 			return nil, nil
 		}
 		bootstraps++
@@ -161,6 +201,12 @@ func TestReloadAgentServiceRetriesThroughBootoutRace(t *testing.T) {
 	}
 	if bootstraps != 3 {
 		t.Errorf("want 3 bootstrap attempts (2 EIO + 1 success), got %d", bootstraps)
+	}
+	// The PAIR retries, not bootstrap alone: a bootout that genuinely failed
+	// leaves every bootstrap answering "already bootstrapped" (a transient by
+	// the classifier), and only a fresh bootout can ever clear it.
+	if bootouts != 3 {
+		t.Errorf("want the bootout re-run on every retry (3 total), got %d", bootouts)
 	}
 
 	// A non-transient bootstrap error returns immediately, no retry.
@@ -192,5 +238,43 @@ func TestBoundedPromptWaitIsScopedToRun(t *testing.T) {
 	boundedPromptWait = true
 	if !boundedPromptWait {
 		t.Error("jit run must be able to opt in")
+	}
+}
+
+// TestWaitForAgentBuild pins install/restart's success condition: "the
+// service is now running the current binary" is decided by the answering
+// process's own BuildID matching ours, not by a bare dial succeeding. The
+// bare-dial version could declare success on the OLD process still draining
+// its shutdown during a reload. (The wrong-build half is structural: the
+// server answers OpStatus with agent.BuildID(), so a same-process test can
+// only exercise the match and the give-up; the mismatch path is the same
+// comparison.)
+func TestWaitForAgentBuild(t *testing.T) {
+	root, err := os.MkdirTemp("/tmp", "jit-wfb-") // short path: unix sockets cap at ~104 bytes
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+
+	// Nothing listening: the wait gives up. The timeout is the caller's
+	// (agentStartWait in production), so the test pays 300ms, not 5s.
+	if waitForAgentBuild(root, 300*time.Millisecond) {
+		t.Fatal("no agent is listening; the wait must give up")
+	}
+
+	server := agent.NewServer(agent.SocketPath(root), func() agent.MEKFetcher { return &fakeMEKFetcher{key: bytes.Repeat([]byte{1}, 32)} }, time.Minute)
+	if err := server.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = server.Serve(ctx) }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	// This process serves OpStatus with its own BuildID, which is by
+	// definition the caller's too — the wait must succeed, locked session
+	// and all (status never challenges).
+	if !waitForAgentBuild(root, 2*time.Second) {
+		t.Fatal("an agent on this build answers; the wait must succeed")
 	}
 }

--- a/internal/cli/agentplist_test.go
+++ b/internal/cli/agentplist_test.go
@@ -51,14 +51,25 @@ func TestPlistProgramPath(t *testing.T) {
 		}
 	})
 
-	t.Run("a path with XML metacharacters survives", func(t *testing.T) {
+	t.Run("a path with XML metacharacters round-trips to its RAW form", func(t *testing.T) {
 		// Directory names really do contain "&" — installAgentService escapes
-		// on the way in, so the value read back is the escaped form. What
-		// matters here is that the reader returns the ProgramArguments entry
-		// rather than stopping at the first entity.
+		// on the way in, and the reader must UNESCAPE on the way out. Returning
+		// the escaped form made every consumer wrong for such a path:
+		// agentPlistNeedsRepoint compared `R&amp;D` against `R&D` (permanently
+		// true, every restart took the rewrite branch), and agentPlistOrphaned
+		// stat'ed the escaped path (IsNotExist, so ensureAgentInstalled treated
+		// a healthy install as orphaned and bounced it).
 		got, ok := plistProgramPath(plistFor("/Users/x/R&amp;D/jit"))
-		if !ok || got != "/Users/x/R&amp;D/jit" {
-			t.Errorf("got %q ok=%v, want the full escaped path", got, ok)
+		if !ok || got != "/Users/x/R&D/jit" {
+			t.Errorf("got %q ok=%v, want the unescaped path /Users/x/R&D/jit", got, ok)
+		}
+	})
+
+	t.Run("escape then read is the identity for every metacharacter", func(t *testing.T) {
+		raw := `/Users/x/R&D/<odd> "dir"/it's/jit`
+		got, ok := plistProgramPath(plistFor(xmlEscape(raw)))
+		if !ok || got != raw {
+			t.Errorf("got %q ok=%v, want %q (write-side xmlEscape must round-trip through the reader)", got, ok, raw)
 		}
 	})
 

--- a/internal/cli/doctorsections.go
+++ b/internal/cli/doctorsections.go
@@ -553,15 +553,16 @@ func agentFindingsFrom(root string, st statusAgent) []checkFinding {
 			Action: "`jit service restart` to bring it back",
 		})
 	case !st.Running && st.Installed:
+		// installedNotRunningParts is the single source of this state's
+		// wording (it queries launchd for WHICH not-running state this is);
+		// doctor renders its two halves as Detail and Action rather than
+		// re-typing them — the hand-typed copy here is the drift the shared
+		// helper's comment warns about, and it happened once already.
+		detail, action := installedNotRunningParts("the service")
 		out = append(out, checkFinding{
 			Kind:   kindService,
-			Detail: "the service is installed but not running; it may have crashed, or be mid-restart.",
-			// installedNotRunningAdvice packs the restart, what it recovers,
-			// and the log command into one sentence, which is three next
-			// steps on one line. The action line takes at most one (rule:
-			// "a reader given three next steps takes none"); the log command
-			// follows as its own finding-level note rather than riding along.
-			Action: "`jit service restart` reloads it, recovering even one launchd has dropped. `jit service log` shows recent output",
+			Detail: detail,
+			Action: strings.TrimSuffix(action, "."),
 		})
 	case !st.Running:
 		// Not installed and not running is fine on its own — you just haven't

--- a/internal/cli/doctorsections_test.go
+++ b/internal/cli/doctorsections_test.go
@@ -4,6 +4,7 @@
 package cli
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -213,11 +214,28 @@ func TestWrapFindingsReportPassingChecks(t *testing.T) {
 }
 
 // TestAgentFindingsInstalledNotRunning confirms the unreachable case above
-// didn't swallow the ordinary crashed/mid-restart one.
+// didn't swallow the ordinary installed-but-not-running one, and that doctor
+// derives its wording from installedNotRunningParts (which phrases the state
+// from launchd's job record — faked here so the machine running the test
+// can't change the expected variant).
 func TestAgentFindingsInstalledNotRunning(t *testing.T) {
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		return []byte(`Could not find service "com.jitpass.agent" in domain for user gui: 501`), errors.New("exit status 113")
+	}
+
 	findings := agentFindingsFrom(t.TempDir(), statusAgent{Installed: true})
-	if len(findings) != 1 || !strings.Contains(findings[0].Detail, "may have crashed") {
-		t.Errorf("expected the installed-but-not-running advice, got %+v", findings)
+	if len(findings) != 1 || !strings.Contains(findings[0].Detail, "launchd has dropped it") {
+		t.Errorf("expected the launchd-dropped-it advice for a not-loaded job, got %+v", findings)
+	}
+	if !strings.Contains(findings[0].Action, "jit service restart") {
+		t.Errorf("the action must name the restart, got %q", findings[0].Action)
+	}
+
+	wantDetail, _ := installedNotRunningParts("the service")
+	if findings[0].Detail != wantDetail {
+		t.Errorf("doctor's detail must BE installedNotRunningParts's, not a copy: %q vs %q", findings[0].Detail, wantDetail)
 	}
 }
 

--- a/internal/cli/migratesummary.go
+++ b/internal/cli/migratesummary.go
@@ -259,7 +259,7 @@ func reportAgentStatus(w io.Writer, root string, producedMount bool) {
 		// Installed but not answering — crashed or mid-restart. Don't reinstall
 		// on top of it; point at restart, the same guidance every other surface
 		// gives for this state (installedNotRunningAdvice).
-		bold("%s", installedNotRunningAdvice("jit's background service is"))
+		bold("%s", installedNotRunningAdvice("jit's background service"))
 	default:
 		// Never installed. Set it up silently now — this used to be the single
 		// next step every migrate run ended by telling the user to run

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -593,9 +593,12 @@ func printStatusText(w io.Writer, r statusResult) {
 		printStatusAction(w, "`jit service restart` to bring it back")
 	case !r.Agent.Running && r.Agent.Installed:
 		// launchd was supposed to keep this one alive — "run install" is
-		// the wrong advice and hides that something actually failed.
+		// the wrong advice and hides that something actually failed. The row
+		// carries what launchd says happened (statusServiceRow queries it);
+		// the action line is the one command.
 		_, _ = cRisk.Fprint(w, glyphRisk+" ")
-		printStatusGlyphValue(w, "%s", installedNotRunningAdvice("the service is"))
+		printStatusGlyphValue(w, "%s", statusServiceRow())
+		printStatusAction(w, "`jit service restart`")
 	case !r.Agent.Running:
 		_, _ = cRisk.Fprint(w, glyphRisk+" ")
 		fmt.Fprint(w, "not running — run ")

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -237,10 +237,15 @@ func runUpgrade(cmd *cobra.Command, _ []string) error {
 	// if the restart hiccups, so a restart failure is a warning, not an error
 	// that would wrongly imply the binary wasn't swapped.
 	fmt.Fprintf(out, "Restarting service ... ")
-	if err := restartServiceOntoCurrentBinary(); err != nil {
+	running, restartErr := restartServiceOntoCurrentBinary()
+	switch {
+	case restartErr != nil:
 		fmt.Fprintln(out, "could not restart automatically")
-		fmt.Fprint(out, hlCmds(fmt.Sprintf("  Run `jit service restart` to move the service onto %s (%s).\n", latest, err)))
-	} else {
+		fmt.Fprint(out, hlCmds(fmt.Sprintf("  Run `jit service restart` to move the service onto %s (%s).\n", latest, restartErr)))
+	case !running:
+		fmt.Fprintf(out, "reinstalled for %s, but it has not come back yet\n", latest)
+		fmt.Fprint(out, hlCmds("  Run `jit service restart`.\n"))
+	default:
 		fmt.Fprintf(out, "now on %s.\n", latest)
 	}
 
@@ -521,40 +526,45 @@ func sudoCommand(args ...string) *exec.Cmd {
 // Reloading then re-execs the old file and leaves the user upgraded in every
 // way except the service that holds their key — while this function's whole
 // contract is that it "points the service at the binary now on disk."
-func restartServiceOntoCurrentBinary() error {
+// It returns whether the service came back on this build within the start
+// wait: the upgrade path is the exact trigger of the 2026-08-17 incident
+// (binary swapped, launchd never respawned), and "now on v<latest>" printed
+// off a discarded result was one of the surfaces that reported success over
+// a dead broker.
+func restartServiceOntoCurrentBinary() (running bool, err error) {
 	plistPath, err := agentPlistPath()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if _, statErr := os.Stat(plistPath); errors.Is(statErr, os.ErrNotExist) {
 		// No plist to preserve a setting from, so install with the defaults
 		// (default TTL, consent on). An existing plist takes a branch below,
 		// which keeps whatever TTL and consent state it already has baked in.
-		if _, _, ierr := installAgentService(agentInstallDefaultTTL, true); ierr != nil {
-			return ierr
-		}
-		return nil
+		_, running, ierr := installAgentService(agentInstallDefaultTTL, true)
+		return running, ierr
 	} else if statErr != nil {
-		return statErr
+		return false, statErr
 	}
 	plistData, err := os.ReadFile(plistPath) // #nosec G304 -- jit's own launchd plist under the user's LaunchAgents dir
 	if err != nil {
-		return err
+		return false, err
 	}
 	if agentPlistNeedsRepoint(plistData) {
 		ttl := agentInstallDefaultTTL
 		if d, ok := configuredAgentTTL(); ok {
 			ttl = d
 		}
-		if _, _, ierr := installAgentService(ttl, configuredAgentConsent()); ierr != nil {
-			return ierr
-		}
-		return nil
+		_, running, ierr := installAgentService(ttl, configuredAgentConsent())
+		return running, ierr
 	}
 	if out, err := reloadAgentService(plistPath); err != nil {
-		return fmt.Errorf("%w (%s)", err, strings.TrimSpace(string(out)))
+		return false, fmt.Errorf("%w (%s)", err, strings.TrimSpace(string(out)))
 	}
-	return nil
+	root, err := vaultRootDir()
+	if err != nil {
+		return false, err
+	}
+	return waitForAgentBuild(root, agentStartWait), nil
 }
 
 func dirWritable(dir string) bool {


### PR DESCRIPTION
## What

Phases 1-2 of `design/service-reliability.md` (committed here as the spec): the launchd lifecycle stops trusting non-demand spawns, and every health surface stops reporting states it hasn't verified.

Driven by a verified production incident (2026-08-17): after a brew upgrade, launchd pended both the RunAtLoad spawn and the KeepAlive respawn indefinitely (`pended nondemand spawn`, runs = 0), the broker was dead for 71 minutes, and `jit service restart` reported success over it. `launchctl kickstart` started it instantly, 3 of 3 — the verb jit dropped in 660ce2c.

## Every spawn is a demand

- `reloadAgentService` kickstarts (plain, never `-k`, best-effort) after a successful bootstrap — restart/ttl/consent/install all inherit it. The retry loop re-runs the bootout+bootstrap pair, since a failed bootout makes every bootstrap read "already bootstrapped" forever.
- Self-retire runs `kickstart -k` on its own label instead of exit-and-hope; the watcher fingerprints the stable binary path so a Caskroom-versioned exec path can't blind it.
- `waitForAgentBuild` replaces the bare-dial wait: success means the answering process's BuildID matches ours.
- Foreground `jit service run` refuses to steal a live agent's socket; `Server.Close` only unlinks the socket it bound (`os.SameFile`).
- `plistProgramPath` unescapes what install escaped (an `&` in the install path made repoint permanently true and orphan-detection stat a nonexistent path).

## No unverified success

- `queryLaunchdJobState` reads `launchctl print` (loaded / runs / last exit) behind the existing seam — best-effort, never a gate, it only picks the right sentence.
- restart/ttl/consent timeouts are now errors: non-zero exit, audit failure, launchd's diagnosis in the message. `consent` stops discarding the running result; `jit upgrade` confirms the service came back before printing "now on vX".
- `installedNotRunningParts` single-sources the installed-but-not-running vocabulary across `jit status`, `jit service status`, doctor (which now derives instead of hand-typing), migrate's trailer and dial hints — with the three real launchd states instead of one "may have crashed".
- `jit lock` against a dead service: "Already locked" instead of a repair errand.

## Tests

Kickstart contract (order, no `-k`, none after failed bootstrap, error ignored), pair-retry, `waitForAgentBuild` live-server + give-up, XML round-trip, launchd-state parse per variant, doctor single-sourcing, and `TestRestartTimeoutIsAFailure` driving the incident's exact state (loaded, runs 0) through the real command. Full `-race` suite, vet, staticcheck, gosec, docs-gen drift: clean.

Phases 3-5 (log/history hygiene, broker hardening, mechanical file split) follow as separate PRs per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejayf5Jz2yNwudQrUGLWnq
