### PR TITLE
Service reliability phase 3: log signal and bounded trails

### DIFF
--- a/design/service-reliability.md
+++ b/design/service-reliability.md
@@ -1,9 +1,10 @@
 # Service reliability: demand-spawned lifecycle, honest health, a broker that keeps its promises
 
-**Status: phases 1-2 implemented, 2026-08-17 (branch
-service-reliability; wording preview approved by eye the same day).
-Phases 3-5 are specified but not yet built. Drafted from a full review
-of the service surface (three parallel code reviews over
+**Status: phases 1-3 implemented, 2026-08-17 (phases 1-2 on branch
+service-reliability, PR #72; phase 3 stacked on it as
+service-log-hygiene, PR #73; both wording previews approved by eye the
+same day). Phases 4-5 are specified but not yet built. Drafted from a
+full review of the service surface (three parallel code reviews over
 `internal/agent`, `internal/cli/agent*.go` and the log/history/status
 surfaces, 43 findings) plus a verified production incident.**
 

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -367,6 +367,13 @@ type Server struct {
 	// structurally cannot, since each new unlock overwrites the last.
 	events []SessionEvent
 
+	// serveErrSeen rate-limits identical socket-boundary failures into the
+	// durable trail (see recordServeError). Its own mutex: these fire on
+	// connection-handling goroutines before any session state is involved,
+	// and must not contend with mu.
+	serveErrMu   sync.Mutex
+	serveErrSeen map[string]*serveErrNote
+
 	listener net.Listener
 	// socketInfo identifies the socket file THIS server bound, so Close can
 	// tell its own socket from one a later agent has since claimed at the
@@ -1449,17 +1456,65 @@ func unlockEvent(op string, c *caller) *SessionEvent {
 	return e
 }
 
+// serveErrNote is one (op, cause) pair's rate-limit state.
+type serveErrNote struct {
+	last       time.Time
+	suppressed int
+}
+
+// serveErrorMinGap spaces identical socket-boundary failures in the durable
+// trail. One minute keeps a sustained flood at a bounded one line per
+// minute per distinct failure — visible, timestamped, countable — instead
+// of one line per connection.
+const serveErrorMinGap = time.Minute
+
 // recordServeError hands a socket-boundary failure to OnServeError as a
 // KindError event: op names which failure ("reject", "decode", "accept"),
 // cause carries the detail, and c (when the kernel still named the peer)
 // stamps the same By/ByPID/LaunchedBy provenance an unlock would carry — for a
 // rejected peer that provenance is the whole point of recording it. No-op when
 // no sink is wired (a test server, or the KeyWrapper embedding with no socket).
+//
+// Identical (op, cause) pairs are rate-limited: a misbehaving peer can hit
+// the same failure at connection rate for weeks, and each event used to
+// become its own durable line — recordRejectedClass defends the in-memory
+// ring against exactly that caller-minted eviction, but the FILE had no
+// equivalent, so a flood could push real unlock/denial history out by byte
+// pressure. Repeats within serveErrorMinGap fold into the next recorded
+// event's Count (total occurrences), the same ×N motif mount serves carry.
 func (s *Server) recordServeError(op, cause string, c *caller) {
 	if s.OnServeError == nil {
 		return
 	}
-	e := SessionEvent{UnixTime: time.Now().Unix(), Kind: KindError, Op: op, Cause: cause}
+	key := op + "\x00" + cause
+	now := time.Now()
+	s.serveErrMu.Lock()
+	if s.serveErrSeen == nil {
+		s.serveErrSeen = map[string]*serveErrNote{}
+	}
+	if len(s.serveErrSeen) > 64 {
+		// A prober minting DISTINCT causes must not grow this map for the
+		// process's weeks-long life; resetting forfeits some suppression
+		// counts, never events.
+		s.serveErrSeen = map[string]*serveErrNote{}
+	}
+	n := s.serveErrSeen[key]
+	if n != nil && now.Sub(n.last) < serveErrorMinGap {
+		n.suppressed++
+		s.serveErrMu.Unlock()
+		return
+	}
+	var suppressed int
+	if n != nil {
+		suppressed = n.suppressed
+	}
+	s.serveErrSeen[key] = &serveErrNote{last: now}
+	s.serveErrMu.Unlock()
+
+	e := SessionEvent{UnixTime: now.Unix(), Kind: KindError, Op: op, Cause: cause}
+	if suppressed > 0 {
+		e.Count = int64(suppressed) + 1
+	}
 	if c != nil {
 		e.By = c.command()
 		e.ByPID = c.pid

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1536,3 +1536,41 @@ func TestApprovedDisclosedChallengeIsRecorded(t *testing.T) {
 	}
 	t.Error("approved event never reached OnSessionEvent, so it never reaches the durable trail jit audit reads")
 }
+
+// TestRecordServeErrorRateLimitsIdenticalFailures pins the durable-trail
+// flood defense: recordRejectedClass protects the in-memory ring from
+// caller-minted eviction, but every socket-boundary failure used to become
+// its own durable line — a peer looping on the same malformed request could
+// push real unlock/denial history out of agent-history.jsonl by byte
+// pressure. Identical (op, cause) pairs inside serveErrorMinGap fold into
+// the next recorded event's Count; distinct causes still record immediately.
+func TestRecordServeErrorRateLimitsIdenticalFailures(t *testing.T) {
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), nil, time.Minute)
+	var events []SessionEvent
+	s.OnServeError = func(e SessionEvent) { events = append(events, e) }
+
+	for i := 0; i < 100; i++ {
+		s.recordServeError("decode", "request too large", nil)
+	}
+	if len(events) != 1 {
+		t.Fatalf("100 identical failures inside the gap wrote %d events, want 1", len(events))
+	}
+
+	s.recordServeError("decode", "malformed json", nil)
+	if len(events) != 2 {
+		t.Fatalf("a DISTINCT cause must record immediately, got %d events", len(events))
+	}
+
+	// Age the first pair past the gap: the next identical failure records
+	// and carries the fold (1 recorded + 99 suppressed = 100 occurrences).
+	s.serveErrMu.Lock()
+	s.serveErrSeen["decode\x00request too large"].last = time.Now().Add(-2 * serveErrorMinGap)
+	s.serveErrMu.Unlock()
+	s.recordServeError("decode", "request too large", nil)
+	if len(events) != 3 {
+		t.Fatalf("after the gap the failure must record again, got %d events", len(events))
+	}
+	if events[2].Count != 100 {
+		t.Errorf("the recorded event must carry the fold: Count = %d, want 100", events[2].Count)
+	}
+}

--- a/internal/cli/agent.go
+++ b/internal/cli/agent.go
@@ -317,6 +317,7 @@ var agentRunCmd = &cobra.Command{
 				})
 			}
 			go rotateAgentLogPeriodically(runCtx, logPath, &logMu, stderr)
+			go trimHistoryPeriodically(runCtx, hist, agentLogRotateCheckInterval)
 		}
 
 		fmt.Fprintf(stdout, "jit service listening on %s (session TTL %s, build %s)\n", agent.SocketPath(root), agentTTL, agent.BuildID())
@@ -1123,7 +1124,21 @@ var agentLogCmd = &cobra.Command{
 			out, donePaging = pageableOutput(cmd)
 			defer donePaging()
 		}
-		writeAgentLogTail(out, tailLines(data, agentLogLines))
+		// One renderer for the tail AND every --follow chunk, so the day
+		// header prints on day changes rather than once per polled chunk.
+		home, herr := os.UserHomeDir()
+		if herr != nil {
+			home = ""
+		}
+		renderer := &agentLogRenderer{home: home}
+		render := func(b []byte) {
+			if agentLogRaw {
+				_, _ = out.Write(b)
+				return
+			}
+			renderer.write(out, b)
+		}
+		render(tailLines(data, agentLogLines))
 
 		if !agentLogFollow {
 			return nil
@@ -1159,30 +1174,23 @@ var agentLogCmd = &cobra.Command{
 			}
 			if _, err := f.Seek(offset, io.SeekStart); err == nil {
 				// --follow renders each appended chunk through the same
-				// formatter as the initial tail, so a live stream and a
-				// static read look identical rather than the stream
-				// reverting to raw lines partway down the screen.
+				// formatter (and the same renderer state) as the initial
+				// tail, so a live stream and a static read look identical.
+				// Consume only complete lines: a chunk read mid-write used
+				// to split a line across two polls, and each half rendered
+				// as an unparseable raw fragment. The remainder stays
+				// unconsumed — offset advances only past the last newline —
+				// and comes back whole on the next poll (audit's
+				// readAppended makes the same cut).
 				chunk, _ := io.ReadAll(f)
-				writeAgentLogTail(out, chunk)
-				offset += int64(len(chunk))
+				if i := bytes.LastIndexByte(chunk, '\n'); i >= 0 {
+					render(chunk[:i+1])
+					offset += int64(i + 1)
+				}
 			}
 			_ = f.Close()
 		}
 	},
-}
-
-// writeAgentLogTail prints a slice of the log, formatted for reading unless
-// --raw asked for the bytes as written.
-func writeAgentLogTail(out io.Writer, data []byte) {
-	if agentLogRaw {
-		_, _ = out.Write(data)
-		return
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		home = ""
-	}
-	writeAgentLog(out, data, home)
 }
 
 // tailLines returns the last n lines of data, newline-terminated — the

--- a/internal/cli/agenthistory.go
+++ b/internal/cli/agenthistory.go
@@ -7,12 +7,14 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/auditlog"
@@ -223,5 +225,25 @@ func (h *historyLog) trim() {
 	}
 	if err := os.Rename(tmp, h.path); err != nil {
 		fmt.Fprintf(h.stderr, "jit service: trimming session history: %v\n", err)
+	}
+}
+
+// trimHistoryPeriodically re-checks the history cap while the service runs,
+// on the same cadence (and for the same reason) as rotateAgentLogPeriodically:
+// launchd keeps one process alive for weeks, so a startup-only trim leaves
+// anything that grows the file — the durable trail now also carries KindError
+// socket events — free to run past the cap until the NEXT restart. trim()
+// takes the same mutex as append, so a mid-run trim can't tear a write; the
+// temp+rename is the same one the startup call does.
+func trimHistoryPeriodically(ctx context.Context, h *historyLog, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			h.trim()
+		}
 	}
 }

--- a/internal/cli/agenthistory_test.go
+++ b/internal/cli/agenthistory_test.go
@@ -7,12 +7,15 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jitpass/jit/internal/agent"
 )
@@ -233,4 +236,30 @@ func TestHistoryLogScrubLegacyRemovesPlaintextFromDisk(t *testing.T) {
 	if got := h.load(agent.MaxSessionEvents); len(got) != 3 {
 		t.Errorf("load returned %d events after scrub, want 3", len(got))
 	}
+}
+
+// TestTrimHistoryPeriodically pins the mid-run cap: the 2MB trim used to run
+// only at service start, so anything that grew the file — launchd keeps one
+// process alive for weeks — ran unbounded until the NEXT restart.
+func TestTrimHistoryPeriodically(t *testing.T) {
+	h := newHistoryLog(t.TempDir(), io.Discard)
+	line := []byte(`{"unix_time":1,"kind":"unlock"}` + "\n")
+	big := bytes.Repeat(line, historyMaxBytes/len(line)+64)
+	if err := os.WriteFile(h.path, big, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go trimHistoryPeriodically(ctx, h, 5*time.Millisecond)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if fi, err := os.Stat(h.path); err == nil && fi.Size() <= historyMaxBytes {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	fi, _ := os.Stat(h.path)
+	t.Fatalf("the periodic trim never brought the file under the cap (size %d, cap %d)", fi.Size(), historyMaxBytes)
 }

--- a/internal/cli/agentlogview.go
+++ b/internal/cli/agentlogview.go
@@ -46,13 +46,28 @@ var mountRe = regexp.MustCompile(`^mount ([^:]+): (.*)$`)
 // writeAgentLog renders the log for humans. home is used to shorten paths;
 // pass "" to leave them absolute.
 func writeAgentLog(w io.Writer, data []byte, home string) {
+	(&agentLogRenderer{home: home}).write(w, data)
+}
+
+// agentLogRenderer renders chunks of the log through one continuous state,
+// so --follow's polled chunks read like a single document: the day header
+// prints on day CHANGES only. Each chunk used to go through a fresh
+// stateless pass, so every poll that carried rows re-printed the date
+// header. Folding still happens within a chunk only — a run spanning a poll
+// boundary stays two rows, the same "timeline is never rewritten" trade the
+// collapse already makes at minute boundaries.
+type agentLogRenderer struct {
+	home string
+	day  string
+}
+
+func (r *agentLogRenderer) write(w io.Writer, data []byte) {
 	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
 	if len(lines) == 1 && lines[0] == "" {
 		return
 	}
 
-	day := ""
-	for _, e := range collapseAgentLog(lines, home) {
+	for _, e := range collapseAgentLog(lines, r.home) {
 		if e.raw != "" {
 			// A panic, a stack frame, anything the daemon printed that isn't
 			// one of its own timestamped notes. It goes through byte-exact —
@@ -63,11 +78,11 @@ func writeAgentLog(w io.Writer, data []byte, home string) {
 			fmt.Fprintln(w, e.raw)
 			continue
 		}
-		if e.date != day {
-			if day != "" {
+		if e.date != r.day {
+			if r.day != "" {
 				fmt.Fprintln(w)
 			}
-			day = e.date
+			r.day = e.date
 			_, _ = fmt.Fprintf(w, "  %s\n", e.date)
 		}
 		writeAgentLogEntry(w, e)

--- a/internal/cli/agentlogview.go
+++ b/internal/cli/agentlogview.go
@@ -33,10 +33,12 @@ import (
 // "… jit service <verb>" for lifecycle lines (stopped, listening on …).
 var logLineRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) jit service(?::)? (.*)$`)
 
-// readsRe collapses the log's own rate-limiting note. "(+207 reads since the
-// last logged one)" is 38 columns to say a number the "×207" motif already
-// carries everywhere else in jit.
-var readsRe = regexp.MustCompile(`\s*\(\+(\d+) reads? since the last logged one\)`)
+// readsRe collapses the log's own rate-limiting notes. "(+207 reads since
+// the last logged one)" is 38 columns to say a number the "×207" motif
+// already carries everywhere else in jit; the serve-error suffix ("+3
+// similar since the last logged one") is the same note in different words
+// and folds the same way.
+var readsRe = regexp.MustCompile(`\s*\(\+(\d+) (?:reads?|similar) since the last logged one\)`)
 
 // mountRe pulls the mount path out of a mount note so it can be shortened to
 // its tail. Every one of these lines opens with the same ~50 characters of
@@ -185,7 +187,13 @@ func agentLogGlyph(msg string) (string, *color.Color) {
 	case strings.Contains(l, "decoy"),
 		strings.Contains(l, "not identified"),
 		strings.Contains(l, "missed"),
-		strings.Contains(l, "denied"):
+		strings.Contains(l, "denied"),
+		// A mount the service cannot serve or resolve is degraded, not
+		// narration: "skipped," is the current write shape, "skipping
+		// mount" the one older logs still carry. Both rendered green
+		// through an entire afternoon of the 2026-08-17 incident.
+		strings.Contains(l, "skipped,"),
+		strings.Contains(l, "skipping mount"):
 		return glyphWarn, cWarn
 	default:
 		return glyphOK, cOK

--- a/internal/cli/agentlogview_test.go
+++ b/internal/cli/agentlogview_test.go
@@ -130,3 +130,63 @@ func TestAgentLogRendererKeepsDayStateAcrossChunks(t *testing.T) {
 		t.Errorf("a genuinely new day must print its header once, got %d:\n%s", got, buf.String())
 	}
 }
+
+// TestAgentLogRendersSkipsAsDegraded drives the 2026-08-17 incident's exact
+// line shapes through the renderer: a mount the service cannot serve or
+// resolve must read as degraded (amber), fold like any other mount row, and
+// the recovery line must read as routine (green). The old "skipping mount"
+// shape — still present in logs written before the transition-logging fix —
+// gets the amber glyph too, even though it predates the foldable format.
+func TestAgentLogRendersSkipsAsDegraded(t *testing.T) {
+	in := "2026-08-17 11:38:12 jit service: mount /Users/x/pt2/proj/.env: skipped, reading profile /Users/x/pt2/proj/.jit/profiles/proj-2.yaml: open: no such file or directory\n" +
+		"2026-08-17 12:33:01 jit service: mount /Users/x/e2e/.env: skipped, resolving MATCHED_SECRET: secret has envelope version 4, newer than this jit understands (max 3), upgrade jit to read it\n" +
+		"2026-08-17 12:34:40 jit service: mount /Users/x/e2e/.env: recovered, serving again (14 skipped attempts before this)\n" +
+		"2026-08-17 12:36:02 jit service: skipping mount /Users/x/old/.env: legacy line from an older build\n"
+	var buf bytes.Buffer
+	writeAgentLog(&buf, []byte(in), "/Users/x")
+	out := buf.String()
+
+	// The glyph sits on a row's FIRST line; long reasons wrap onto
+	// continuation lines, so assert against the substring that shares the
+	// glyph's line (the row lead, not the wrapped tail).
+	for glyph, want := range map[string]string{
+		glyphWarn: "skipped, reading profile",
+		glyphOK:   "recovered, serving again",
+	} {
+		found := false
+		for _, line := range strings.Split(out, "\n") {
+			if strings.Contains(line, want) && strings.Contains(line, glyph) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected %q marked with %q, got:\n%s", want, glyph, out)
+		}
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, "skipped, resolving") && !strings.Contains(line, glyphWarn) {
+			t.Errorf("an envelope-version skip must be amber, got: %s", line)
+		}
+		if strings.Contains(line, "skipping mount") && !strings.Contains(line, glyphWarn) {
+			t.Errorf("the pre-fix 'skipping mount' shape must be amber too, got: %s", line)
+		}
+	}
+	if !strings.Contains(out, "…") && !strings.Contains(out, "~/pt2/proj/.env") {
+		t.Errorf("the skip row must go through the mount-row path shortening, got:\n%s", out)
+	}
+}
+
+// TestAgentLogFoldsSimilarSuffix: the serve-error rate-limit suffix is the
+// reads suffix in different words, and folds to the same ×N motif.
+func TestAgentLogFoldsSimilarSuffix(t *testing.T) {
+	in := "2026-08-17 12:36:02 jit service: mount /Users/x/a/.env: writing: broken pipe (still serving) (+3 similar since the last logged one)\n"
+	var buf bytes.Buffer
+	writeAgentLog(&buf, []byte(in), "/Users/x")
+	out := buf.String()
+	if !strings.Contains(out, "×3") {
+		t.Errorf("the similar-suffix must fold to ×3, got:\n%s", out)
+	}
+	if strings.Contains(out, "since the last logged one") {
+		t.Errorf("the prose suffix must not survive the fold, got:\n%s", out)
+	}
+}

--- a/internal/cli/agentlogview_test.go
+++ b/internal/cli/agentlogview_test.go
@@ -112,3 +112,21 @@ func TestAgentLogHandlesEmptyInput(t *testing.T) {
 		t.Errorf("expected no output for an empty log, got %q", buf.String())
 	}
 }
+
+// TestAgentLogRendererKeepsDayStateAcrossChunks pins --follow's chunk fix:
+// every polled chunk renders through ONE renderer, so a chunk continuing the
+// same day must not re-print the date header (a fresh stateless pass per
+// chunk used to print it once per poll that carried rows).
+func TestAgentLogRendererKeepsDayStateAcrossChunks(t *testing.T) {
+	var buf bytes.Buffer
+	r := &agentLogRenderer{home: "/Users/x"}
+	r.write(&buf, []byte("2026-08-17 10:00:00 jit service: stopped.\n"))
+	r.write(&buf, []byte("2026-08-17 10:01:00 jit service: stopped.\n"))
+	if got := strings.Count(buf.String(), "2026-08-17"); got != 1 {
+		t.Errorf("the day header printed %d times across two same-day chunks, want 1:\n%s", got, buf.String())
+	}
+	r.write(&buf, []byte("2026-08-18 09:00:00 jit service: stopped.\n"))
+	if got := strings.Count(buf.String(), "2026-08-18"); got != 1 {
+		t.Errorf("a genuinely new day must print its header once, got %d:\n%s", got, buf.String())
+	}
+}

--- a/internal/cli/mountmanager.go
+++ b/internal/cli/mountmanager.go
@@ -119,6 +119,18 @@ type mountManager struct {
 	mu     sync.Mutex
 	wg     sync.WaitGroup
 	served map[string]*servedMount
+	// skipReason/skipSuppressed make mount-skip logging transitional: a
+	// mount that structurally cannot serve or resolve (deleted profile, an
+	// envelope version newer than this build) is retried on EVERY unlock and
+	// refresh, and each pass used to log the identical line — the 2026-08-17
+	// incident's log was hours of it, every few minutes, drowning the
+	// startup and serve-error lines the log exists to surface. A skip now
+	// logs when its reason CHANGES (appears, changes text, clears); the
+	// steady state stays visible through lastResolveErr on the status
+	// surfaces. Keyed by mount path, guarded by mu; both the ensureServing
+	// skips (mount never entered served) and the resolveReal skips share it.
+	skipReason   map[string]string
+	skipAttempts map[string]int
 	// shuttingDown is set once by shutdown() (under mu) so ensureServing
 	// refuses to start — and wg.Add — a new Serve goroutine after shutdown
 	// snapshotted served and began wg.Wait(). Without it, an in-flight RPC's
@@ -328,6 +340,61 @@ func (sm *servedMount) setResolveErr(err error) {
 	sm.mu.Unlock()
 }
 
+// noteMountSkip records that path was skipped for err and reports whether to
+// log it: only on a transition (the first failure, or the reason changing).
+// Identical repeats are counted, not logged; noteMountRecovered surfaces the
+// count when the mount comes back.
+func (m *mountManager) noteMountSkip(path string, err error) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.skipReason == nil {
+		m.skipReason = map[string]string{}
+		m.skipAttempts = map[string]int{}
+	}
+	m.skipAttempts[path]++
+	cur := err.Error()
+	if m.skipReason[path] == cur {
+		return false
+	}
+	m.skipReason[path] = cur
+	return true
+}
+
+// noteMountRecovered clears path's skip state. attempts is how many times
+// the mount was skipped in total since it started failing (across reason
+// changes); recovered is false when the mount was never failing, which is
+// every ordinary resolve.
+func (m *mountManager) noteMountRecovered(path string) (attempts int, recovered bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.skipReason[path]; !ok {
+		return 0, false
+	}
+	attempts = m.skipAttempts[path]
+	delete(m.skipReason, path)
+	delete(m.skipAttempts, path)
+	return attempts, true
+}
+
+// logMountSkip is every skip site's one exit: transition-gated, and phrased
+// as "mount <path>: skipped, <reason>" so `jit service log` folds and
+// path-shortens it like any other mount row (the old "skipping mount X"
+// shape matched none of the view's machinery and rendered green).
+func (m *mountManager) logMountSkip(path string, err error) {
+	if m.noteMountSkip(path, err) {
+		fmt.Fprintf(m.stderr, "jit service: mount %s: skipped, %v\n", path, err)
+	}
+}
+
+// logMountRecovered is the clear half of the transition: one line saying the
+// mount is back, carrying how many attempts the suppression absorbed.
+func (m *mountManager) logMountRecovered(path string) {
+	if attempts, recovered := m.noteMountRecovered(path); recovered {
+		fmt.Fprintf(m.stdout, "jit service: mount %s: recovered, serving again (%s before this)\n",
+			path, countWord(attempts, "skipped attempt", "skipped attempts"))
+	}
+}
+
 // loadRegistry reads the mount registry, logging (not erroring — this
 // runs from hooks with no caller to return an error to) on failure.
 func (m *mountManager) loadRegistry() ([]mount.Entry, bool) {
@@ -373,7 +440,7 @@ func (m *mountManager) ensureServing(entries []mount.Entry) {
 
 		p, varOrder, err := profile.LoadFileOrdered(entry.ProfilePath)
 		if err != nil {
-			fmt.Fprintf(m.stderr, "jit service: skipping mount %s: %v\n", entry.MountPath, err)
+			m.logMountSkip(entry.MountPath, err)
 			continue
 		}
 		// DecoyValues only ever reads p's KEYS (variable names) — never a
@@ -384,7 +451,7 @@ func (m *mountManager) ensureServing(entries []mount.Entry) {
 		if entry.TemplatePath != "" {
 			tmpl, err := os.ReadFile(entry.TemplatePath) // #nosec G304 -- path comes from jit's own mount registry, not external input
 			if err != nil {
-				fmt.Fprintf(m.stderr, "jit service: skipping mount %s: reading template: %v\n", entry.MountPath, err)
+				m.logMountSkip(entry.MountPath, fmt.Errorf("reading template: %w", err))
 				continue
 			}
 			decoy = mount.FormatTemplate(tmpl, decoyValues)
@@ -426,6 +493,10 @@ func (m *mountManager) ensureServing(entries []mount.Entry) {
 		m.served[entry.MountPath] = sm
 		m.wg.Add(1)
 		m.mu.Unlock()
+		// A mount that had been skipped (deleted profile, unreadable
+		// template) and now serves again closes its skip transition here —
+		// resolveReal closes the resolve-failure kind on its own success.
+		m.logMountRecovered(entry.MountPath)
 
 		onReaderConnected := func(path string, sm *servedMount) func() {
 			return func() { m.noteReaderConnected(path, sm) }
@@ -522,13 +593,13 @@ func (m *mountManager) resolveReal(entries []mount.Entry, v *vault.Vault) {
 
 		p, varOrder, err := profile.LoadFileOrdered(entry.ProfilePath)
 		if err != nil {
-			fmt.Fprintf(m.stderr, "jit service: skipping mount %s: %v\n", entry.MountPath, err)
+			m.logMountSkip(entry.MountPath, err)
 			sm.setResolveErr(err)
 			continue
 		}
 		values, err := inject.Resolve(v, p)
 		if err != nil {
-			fmt.Fprintf(m.stderr, "jit service: skipping mount %s: %v\n", entry.MountPath, err)
+			m.logMountSkip(entry.MountPath, err)
 			sm.setResolveErr(err)
 			continue
 		}
@@ -537,7 +608,7 @@ func (m *mountManager) resolveReal(entries []mount.Entry, v *vault.Vault) {
 		if entry.TemplatePath != "" {
 			tmpl, err := os.ReadFile(entry.TemplatePath) // #nosec G304 -- path comes from jit's own mount registry, not external input
 			if err != nil {
-				fmt.Fprintf(m.stderr, "jit service: skipping mount %s: reading template: %v\n", entry.MountPath, err)
+				m.logMountSkip(entry.MountPath, fmt.Errorf("reading template: %w", err))
 				sm.setResolveErr(err)
 				continue
 			}
@@ -548,6 +619,7 @@ func (m *mountManager) resolveReal(entries []mount.Entry, v *vault.Vault) {
 		if !sm.setRealIfGen(real, gen) {
 			continue // a lock raced this resolve; leave the mount decoy
 		}
+		m.logMountRecovered(entry.MountPath)
 		// Resolution only ARMS the real content in memory; it never opens a
 		// window. A mount serves that real content solely to a run-scoped
 		// grant's own process tree (jit run --live / --with) — there is no

--- a/internal/cli/mountmanager_test.go
+++ b/internal/cli/mountmanager_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -541,5 +542,40 @@ func TestServedMountGenGuardDropsResolveRacedByLock(t *testing.T) {
 	// And a later lock clears it and reports it did.
 	if !sm.invalidateReal() {
 		t.Fatal("invalidateReal should report clearing the real content just installed")
+	}
+}
+
+// TestMountSkipLogsOnTransitionOnly pins the incident's log-storm fix at the
+// source: a mount that fails the same way on every unlock logs ONCE, a
+// changed reason logs once more, and the recovery line carries how many
+// attempts the suppression absorbed. The steady state stays observable
+// through lastResolveErr on the status surfaces, not through repetition.
+func TestMountSkipLogsOnTransitionOnly(t *testing.T) {
+	var errBuf, outBuf bytes.Buffer
+	m := &mountManager{stdout: &outBuf, stderr: &errBuf}
+
+	for i := 0; i < 50; i++ {
+		m.logMountSkip("/tmp/a.env", errors.New("no such file or directory"))
+	}
+	if got := strings.Count(errBuf.String(), "skipped,"); got != 1 {
+		t.Fatalf("50 identical failures logged %d lines, want 1:\n%s", got, errBuf.String())
+	}
+
+	m.logMountSkip("/tmp/a.env", errors.New("envelope version 4, newer than this jit understands"))
+	if got := strings.Count(errBuf.String(), "skipped,"); got != 2 {
+		t.Fatalf("a CHANGED reason must log, got %d lines:\n%s", got, errBuf.String())
+	}
+
+	m.logMountRecovered("/tmp/a.env")
+	if !strings.Contains(outBuf.String(), "recovered, serving again (51 skipped attempts before this)") {
+		t.Errorf("recovery must carry the absorbed attempts (49 suppressed + 2 logged), got:\n%s", outBuf.String())
+	}
+
+	// A mount that was never failing recovers silently — this is every
+	// ordinary resolve, and it must not add a line per unlock.
+	outBuf.Reset()
+	m.logMountRecovered("/tmp/b.env")
+	if outBuf.Len() != 0 {
+		t.Errorf("an ordinary resolve must not log a recovery, got: %s", outBuf.String())
 	}
 }

--- a/internal/cli/mountserveaudit.go
+++ b/internal/cli/mountserveaudit.go
@@ -100,12 +100,16 @@ const maxPendingServes = 64
 
 // serveKey is one aggregate's identity. Deliberately includes the reader and
 // the verdict: collapsing across either would merge facts an investigation
-// needs separated ("who read it" and "what did they get").
+// needs separated ("who read it" and "what did they get"). The reader is its
+// executable path, NOT its pid: a watcher that re-execs per read gets a
+// fresh pid every time, and a pid-keyed aggregate minted one event per read
+// — defeating the hour window the auditor exists to enforce and letting the
+// noisiest reader flood the durable trail. The first read's pid still rides
+// in the event payload (ByPID); the follow-up pids were noise, not facts.
 type serveKey struct {
-	mount     string
-	readerPID int32
-	reader    string
-	decoy     bool
+	mount  string
+	reader string
+	decoy  bool
 }
 
 type serveAggregate struct {
@@ -159,7 +163,7 @@ func (a *serveAuditor) record(now time.Time, mount, reason string, rec serveReco
 	if a == nil || a.emit == nil {
 		return
 	}
-	key := serveKey{mount: mount, readerPID: rec.reader.pid, reader: rec.reader.execPath, decoy: rec.decoy}
+	key := serveKey{mount: mount, reader: rec.reader.execPath, decoy: rec.decoy}
 
 	a.mu.Lock()
 	if a.pending == nil {

--- a/internal/cli/mountserveaudit_test.go
+++ b/internal/cli/mountserveaudit_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -138,25 +139,26 @@ func TestServeAuditMemoizesTheMountLabel(t *testing.T) {
 	a.labelFn = func(string) string { lookups++; return "gcp" }
 	now := time.Unix(1_700_000_000, 0)
 
-	// Distinct readers, so each gets its own aggregate and every one of them
-	// needs the label — but the mount is the same, so the lookup is not.
+	// Distinct readers (by executable, the key's identity), so each gets its
+	// own aggregate and every one of them needs the label — but the mount is
+	// the same, so the lookup is not.
 	for i := 0; i < 20; i++ {
-		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), "/bin/sh"))
+		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), fmt.Sprintf("/bin/sh%d", i)))
 	}
 	if lookups != 1 {
 		t.Errorf("resolved the same mount's label %d times, want 1", lookups)
 	}
 }
 
-// The pending map is keyed partly on pid, so a burst of short-lived readers
-// each claim a key. It needs a ceiling that isn't "however many processes the
-// machine can spawn" — and hitting it must flush, never drop.
+// The pending map is keyed on reader identity, so a burst of distinct
+// readers each claim a key. It needs a ceiling that isn't "however many
+// programs the machine can run" — and hitting it must flush, never drop.
 func TestServeAuditBoundsPendingAggregates(t *testing.T) {
 	a, c := newTestAuditor(time.Hour)
 	now := time.Unix(1_700_000_000, 0)
 
 	for i := 0; i < maxPendingServes*3; i++ {
-		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), "/bin/sh"))
+		a.record(now, "/tmp/m.env", "r", decoyRead(int32(i+1), fmt.Sprintf("/bin/tool%d", i)))
 	}
 
 	a.mu.Lock()
@@ -250,5 +252,35 @@ func TestServeReasonNamesTheCause(t *testing.T) {
 				t.Errorf("serveReason = %q, want it to mention %q", got, tc.wantFragment)
 			}
 		})
+	}
+}
+
+// TestServeAuditFoldsReExecingReader pins the key's identity choice: a
+// watcher that re-execs per read arrives with a fresh pid every time, and a
+// pid-keyed aggregate minted one event per read — defeating the hour window
+// outright (the noisiest possible reader got the least collapsed trail).
+// Same executable, same mount, same verdict = one aggregate, however many
+// pids it burns; the count carries the reads.
+func TestServeAuditFoldsReExecingReader(t *testing.T) {
+	a, c := newTestAuditor(time.Hour)
+	now := time.Unix(1_700_000_000, 0)
+
+	for i := 0; i < 50; i++ {
+		a.record(now, "/tmp/m.env", "r", decoyRead(int32(1000+i), "/usr/bin/watcher"))
+	}
+
+	a.mu.Lock()
+	pending := len(a.pending)
+	a.mu.Unlock()
+	if pending != 1 {
+		t.Fatalf("50 reads by one re-execing program produced %d aggregates, want 1", pending)
+	}
+	if got := len(c.all()); got != 0 {
+		t.Errorf("nothing should have flushed inside the window, got %d events", got)
+	}
+	a.emitAll(a.take(true, now))
+	events := c.all()
+	if len(events) != 1 || events[0].Count != 50 {
+		t.Fatalf("want one event carrying all 50 reads, got %+v", events)
 	}
 }


### PR DESCRIPTION
## What

Phase 3 of `design/service-reliability.md`: the service log carries signal, and the durable trails stay bounded. Stacked on #72 (phases 1-2) — merge that first; this diff is the two commits on top.

During the 2026-08-17 incident, the service log was hours of one identical "skipping mount" line every few minutes, rendered with the green routine-narration glyph, while the durable history had two unbounded growth paths.

## Log signal (preview approved by eye)

- A failing mount logs when its reason **changes** (appears, changes text, clears), not on every unlock — the five skip sites funnel through one transition-gated helper, and recovery logs once with the total attempts absorbed. The steady state stays observable via `lastResolveErr` on the status surfaces.
- The line shape becomes `mount <path>: skipped, <reason>`, so `jit service log` folds and path-shortens it like every other mount row; skips render **amber** (both the new shape and the pre-fix shape old logs still carry).
- The serve-error `(+N similar …)` suffix folds to the same `×N` motif as reads.
- `--follow` keeps one renderer across polls (day header on day *changes*, not per chunk) and consumes only complete lines, so a line racing the writer no longer renders as two raw fragments.

## Bounded trails

- The 2MB history cap is re-checked every 10 minutes while the service runs, not only at startup — launchd keeps one process alive for weeks.
- `recordServeError` rate-limits identical (op, cause) socket-boundary failures to one durable line per minute, repeats folding into the next event's Count — the in-memory ring already had this defense (`recordRejectedClass`); the file did not.
- The serve-audit key drops the reader pid: a re-exec-per-read watcher minted one aggregate per read, defeating the hour window outright. Identity is the executable path; the first read's pid still rides in the payload.

## Tests

Transition-only logging (50 identical failures → 1 line; changed reason → 1 more; recovery carries the count; ordinary resolves stay silent), incident-line corpus through the renderer (amber glyphs, fold, path shortening), ×N suffix fold, renderer day-state across chunks, periodic trim under a shrunk interval, serve-error rate limit (100 identical → 1 event, gap-aged repeat carries Count 100), re-exec reader folds 50 reads → 1 event. Full `-race` suites, vet, staticcheck, gosec: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejayf5Jz2yNwudQrUGLWnq
