### PR TITLE
Service reliability phase 4: broker hardening

### DIFF
--- a/design/service-reliability.md
+++ b/design/service-reliability.md
@@ -1,9 +1,10 @@
 # Service reliability: demand-spawned lifecycle, honest health, a broker that keeps its promises
 
-**Status: phases 1-3 implemented, 2026-08-17 (phases 1-2 on branch
-service-reliability, PR #72; phase 3 stacked on it as
-service-log-hygiene, PR #73; both wording previews approved by eye the
-same day). Phases 4-5 are specified but not yet built. Drafted from a
+**Status: phases 1-4 implemented, 2026-08-17 (phases 1-2 on branch
+service-reliability, PR #72; phase 3 stacked as service-log-hygiene,
+PR #73; phase 4 stacked as service-broker-hardening, PR #74; both
+wording previews approved by eye the same day). Phase 5 (the
+mechanical file split) is specified but not yet built. Drafted from a
 full review of the service surface (three parallel code reviews over
 `internal/agent`, `internal/cli/agent*.go` and the log/history/status
 surfaces, 43 findings) plus a verified production incident.**
@@ -216,11 +217,16 @@ the payload).
 
 ## Phase 4: broker hardening
 
-**D12. Socket version skew fails closed.** The Client sends BOTH
-`Disclose` and `DiscloseReason` (belt and suspenders for old
-services), and requests carrying security-relevant fields gain a
-`min_protocol` integer the server compares against its own; a server
-too old to know a field refuses rather than silently dropping it.
+**D12. Socket version skew fails closed.** Three layers, because one
+is not enough: an `agent.Protocol` constant stamped on every response;
+`Request.MinProtocol`, which a server compares against its own and
+refuses when it is too old to serve the request as asked; and — the
+layer that actually covers today's old agents, which would ignore
+`MinProtocol` too — a CLIENT-side check of the agent's reported
+protocol before a disclosed grant is sent at all, refusing to ask
+rather than asking something that cannot enforce the answer.
+`DiscloseReason` is also set as a last-resort trigger for an agent
+from the window when that was the flag's spelling.
 Today a new CLI's `jit run --with` against an old service performs a
 machine-wide reveal with NO disclosed challenge: the exact attack
 `Request.Disclose`'s doc names, and the fail-open sibling of the
@@ -237,10 +243,14 @@ over. Refusals stay recorded (KindDenied), the cooldown-clearing
 unlock semantics stay.
 
 **D14. Audit truth fixes.**
-- Lazy session expiry records its KindLock: `collectIfDoneLocked`
-  stashes the cause, `lockIfGen` writes the event when it finds a
-  lazily-collected session. Today a busy agent can show
-  unlock → unlock with no lock between.
+- Lazy session expiry records its KindLock. Implemented one step
+  earlier than specified: `collectIfDoneLocked` records the event
+  itself (ring and `lastLock` under `mu`, the durable hand-off parked
+  for `notifyPendingLock` to drain outside it) rather than leaving it
+  for `lockIfGen`. Deferring to the timer would still have lost the
+  event in the commonest continuation, where the same request goes
+  straight on to a fresh unlock and no timer ever runs for the session
+  that ended.
 - `grant_use` collapse keys on `c.rawCommand()`, not the redacted
   command (`server.go:754-757`): redaction can map two callers onto
   one string, the misattribution `recordUse` already fixed once.
@@ -248,10 +258,24 @@ unlock semantics stay.
   `RootAlive: true` in its echo.
 
 **D15. Small broker fixes riding along.** Grant expiry timers are
-cancelled on revoke/re-extend (today they accumulate for up to 7
-days); the sleep-path handler moves durable-log writes off the
-kernel's power-change wait (the MEK wipe stays synchronous); `Serve`'s
-ctx-watcher goroutine is joined on accept failure.
+cancelled on revoke/re-extend (they accumulated for up to 7 days);
+`Serve`'s ctx-watcher goroutine ends with Serve rather than parking on
+`ctx.Done()` past an accept failure.
+
+**Rejected on implementation: moving the sleep-path durable write off
+the kernel's power-change wait.** The reviewed finding is real (a
+wedged disk could stall sleep toward the ~30s ceiling) but every
+candidate fix is worse than the bug. The lock's tail is ordered: MEK
+wipe, then `OnLock` → `mountManager.stop`, which is what clears each
+mount's resolved real content. Making the tail asynchronous to get the
+log write off the critical path also defers that clearing, opening a
+window where mounts still hold real values while the machine is going
+to sleep — trading a rare, recoverable stall for a credential-exposure
+window. Buffering only the history append would decouple the write
+from every lock and unlock, but it changes the durability of the one
+trail `jit audit` reads. Neither is worth it for a low-severity
+latency issue; the synchronous ordering is load-bearing. Revisit only
+with evidence of a real stall.
 
 ## Phase 5: mechanical split (last, pure movement)
 

--- a/internal/agent/caller_test.go
+++ b/internal/agent/caller_test.go
@@ -247,3 +247,29 @@ func TestRecordUseKeepsCallersSeparateWhenRedactionCollides(t *testing.T) {
 		}
 	}
 }
+
+// The grant-serve path has the identical collapse window and the identical
+// hazard, and it keyed on the REDACTED command — so two tools under one grant
+// whose argvs redact to the same string merged into one aggregate stamped
+// with the first one's pid. A grant covers a whole process tree, so two tools
+// sharing a window is the ordinary case there, not an exotic one. This is
+// TestRecordUseKeepsCallersSeparateWhenRedactionCollides for grant_use.
+func TestGrantUseKeepsCallersSeparateWhenRedactionCollides(t *testing.T) {
+	s := &Server{useWindow: time.Hour}
+	c1 := callerFor([]string{"some-tool", "--token=sk_FAKEfixtureAAAA1111BBBB2222"})
+	c2 := callerFor([]string{"some-tool", "--token=sk_FAKEfixtureCCCC3333DDDD4444"})
+	if c1.command() != c2.command() {
+		t.Fatalf("test premise broken: redacted commands differ: %q vs %q", c1.command(), c2.command())
+	}
+
+	// Exactly what the OpUnwrap grant hit records.
+	s.recordAggregated(KindUse, OpGrantUse, c1.rawCommand(), c1, "a")
+	s.recordAggregated(KindUse, OpGrantUse, c2.rawCommand(), c2, "b")
+
+	s.mu.Lock()
+	flushed := s.flushUsesLocked(true, time.Now())
+	s.mu.Unlock()
+	if len(flushed) != 2 {
+		t.Fatalf("flushed %d grant_use aggregate(s), want 2: distinct callers must not merge just because their redacted argvs match (got %+v)", len(flushed), flushed)
+	}
+}

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -315,10 +315,44 @@ func (c *Client) RunForPID(mounts []RunMount, pid int32) error {
 // machine-wide credential must not be phrased by the process asking for it —
 // and "the process asking" is only ever `jit run` when nothing malicious is
 // on the machine.
+// Version skew is handled BEFORE the request goes out, and the belt is
+// deliberately worn with braces:
+//
+//   - MinProtocol makes an agent that knows the field refuse rather than
+//     under-enforce.
+//   - The status pre-check catches the case MinProtocol structurally cannot
+//     — an agent so old it ignores MinProtocol too. Such an agent also
+//     ignores Disclose, so it would perform this machine-wide reveal with no
+//     prompt at all. Refusing to ask is the only fail-closed answer
+//     available from this side of the socket.
+//   - DiscloseReason is set as a last-resort trigger for an agent from the
+//     window where that was the flag's spelling. It is honored there as a
+//     TRIGGER only, and the text is jit's own, not a caller's — the
+//     prompt-spoofing hazard that retired the field is about caller-supplied
+//     wording reaching a human, and there is no caller here but jit run.
 func (c *Client) GrantGlobalForPID(mounts []RunMount, pid int32) error {
-	_, err := c.call(Request{Op: OpRevealPID, RunMounts: mounts, TargetPID: pid, Disclose: true})
+	st, err := c.Status()
+	if err != nil {
+		return err
+	}
+	if st.Protocol < protocolDisclosedGate {
+		return fmt.Errorf("the running background service is too old to enforce the disclosed-credential prompt this grant requires (it speaks protocol %d, this needs %d), and granting a machine-wide credential without that prompt is exactly what the check prevents; run `jit service restart` to move it onto the current binary", st.Protocol, protocolDisclosedGate)
+	}
+	_, err = c.call(Request{
+		Op:             OpRevealPID,
+		RunMounts:      mounts,
+		TargetPID:      pid,
+		Disclose:       true,
+		DiscloseReason: legacyDiscloseTrigger,
+		MinProtocol:    protocolDisclosedGate,
+	})
 	return err
 }
+
+// legacyDiscloseTrigger is the DiscloseReason text sent purely so a
+// pre-Disclose agent still takes its gate. Phrased as what is happening
+// rather than as reassurance, since such an agent renders it verbatim.
+const legacyDiscloseTrigger = "grant a machine-wide credential to this run"
 
 // GrantCreate asks the agent to create a process grant: after one disclosed
 // challenge (agent-worded, like every prompt), pid's process tree may unwrap
@@ -438,6 +472,11 @@ type Status struct {
 	// cannot, which is whether that binary still exists. Empty when the
 	// agent predates the field.
 	ExecutablePath string
+	// Protocol is the agent's socket-protocol revision (agent.Protocol),
+	// zero from any agent predating the field. Callers whose safety depends
+	// on the agent enforcing something check this BEFORE asking — see
+	// GrantGlobalForPID.
+	Protocol int
 }
 
 // History asks for every unlock and lock the agent knows of, newest first
@@ -478,6 +517,7 @@ func (c *Client) Status() (Status, error) {
 		Build:          resp.Build,
 		Version:        resp.Version,
 		ExecutablePath: resp.ExecutablePath,
+		Protocol:       resp.Protocol,
 	}, nil
 }
 

--- a/internal/agent/consent_test.go
+++ b/internal/agent/consent_test.go
@@ -62,6 +62,10 @@ func startConsentServer(t *testing.T, denyConsent *atomic.Bool) (*Server, string
 	}
 	s := NewServer(shortSocketPath(t), newFetcher, time.Minute)
 	s.Consent = consent.New(time.Minute)
+	// Several of these tests flip a decline to an approval and retry
+	// immediately, which the disclosed-prompt backoff would (correctly)
+	// pause. That backoff has its own tests; here it would only buy sleep.
+	s.discloseBackoff = nil
 
 	var launcher atomic.Pointer[string]
 	aws := "/usr/local/bin/aws"

--- a/internal/agent/grant.go
+++ b/internal/agent/grant.go
@@ -499,12 +499,27 @@ func (s *Server) extendGrant(req Request, c *caller) Response {
 	var name, under string
 	var count int
 	var profiles []string
+	var rootPID int32
+	var rootStart int64
 	if g != nil {
 		name, under, count, profiles = g.name, g.anchorName, len(g.deks), g.profiles
+		rootPID, rootStart = g.rootPID, g.rootStart
 	}
 	s.grantMu.Unlock()
 	if g == nil {
 		return Response{OK: false, Error: fmt.Sprintf("grant_extend: no grant %q (it may have expired — extend cannot resurrect one, create it again)", req.GrantID)}
+	}
+	// The root must still be the process this grant was anchored to, checked
+	// BEFORE prompting. Creation verifies the fork-time stamp on both sides
+	// of its challenge and every serve re-checks it, but extend did neither:
+	// a human could be asked to widen the window of a grant whose root had
+	// already died, approve it, and get an OK whose echoed status hard-coded
+	// RootAlive true. The next prune would end it moments later — so the
+	// prompt bought nothing and the answer described a grant that was
+	// already over.
+	if cur, alive := lineage.ProcessStartTime(rootPID); !alive || cur != rootStart {
+		s.endGrant(req.GrantID, grantEndExited)
+		return Response{OK: false, Error: fmt.Sprintf("grant_extend: grant %q's process has exited, so there is no window left to extend (create a new grant)", req.GrantID)}
 	}
 
 	// grantCreateReason already words the full scope; re-lead it as an
@@ -548,6 +563,14 @@ func (s *Server) endGrantBy(id, cause string, c *caller) {
 		return
 	}
 	delete(s.grants, id)
+	// The expiry timer has nothing left to check; stopping it here (rather
+	// than leaving it to fire and find the grant gone) is what keeps timers
+	// from outliving the grants they time. Already under grantMu, so this is
+	// the map operation, not stopGrantExpiry.
+	if t := s.grantTimers[id]; t != nil {
+		t.Stop()
+		delete(s.grantTimers, id)
+	}
 	paths := g.secretPaths()
 	name := g.name
 	g.wipeDEKs()
@@ -609,13 +632,28 @@ func (s *Server) pruneGrants(now time.Time) {
 // deadline re-check is the guard).
 func (s *Server) armGrantExpiry(id string, expires time.Time) {
 	delay := time.Until(expires) + time.Second
-	time.AfterFunc(delay, func() {
+	timer := time.AfterFunc(delay, func() {
 		s.grantMu.Lock()
 		g := s.grants[id]
 		expired := g != nil && time.Now().After(g.expires)
+		delete(s.grantTimers, id)
 		s.grantMu.Unlock()
 		if expired {
 			s.endGrant(id, grantEndExpired)
 		}
 	})
+	// Keep the handle so a re-extend or an end can stop it. Each arming used
+	// to leave its predecessor running — up to a week out, holding the id and
+	// closure — so a grant extended through a working week accumulated a pile
+	// of live timers. Harmless (every one re-checks the deadline before
+	// acting) but unbounded, and the fix is one map.
+	s.grantMu.Lock()
+	if s.grantTimers == nil {
+		s.grantTimers = map[string]*time.Timer{}
+	}
+	if old := s.grantTimers[id]; old != nil {
+		old.Stop()
+	}
+	s.grantTimers[id] = timer
+	s.grantMu.Unlock()
 }

--- a/internal/agent/grant_test.go
+++ b/internal/agent/grant_test.go
@@ -585,3 +585,90 @@ func historyKinds(s *Server) string {
 	}
 	return strings.Join(kinds, ", ")
 }
+
+// TestGrantExtendRefusesADeadRoot: creation verifies the root's fork-time
+// stamp on both sides of its challenge, and every serve re-checks it — extend
+// did neither. A human could be asked to widen the window of a grant whose
+// root had already exited, approve it, and get back a status hard-coding
+// RootAlive true; the next prune would end it moments later. The prompt bought
+// nothing and the answer described a grant that was already over.
+func TestGrantExtendRefusesADeadRoot(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x07}, 32))
+	wireGrantResolver(s, sec)
+
+	// A real short-lived child: its pid is genuine at creation and genuinely
+	// gone afterwards, so this exercises the actual lineage check.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting the grant root: %v", err)
+	}
+	rootPID := int32(cmd.Process.Pid) // #nosec G115 -- a pid from the OS
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(rootPID, "", []string{"jamf"}, "", time.Hour)
+	if err != nil {
+		_ = cmd.Process.Kill()
+		t.Fatalf("GrantCreate: %v", err)
+	}
+
+	_ = cmd.Process.Kill()
+	_, _ = cmd.Process.Wait()
+
+	before := atomic.LoadInt32(&calls)
+	_, err = c.GrantExtend(st.ID, 2*time.Hour)
+	if err == nil {
+		t.Fatal("extending a grant whose root has exited must fail, not report RootAlive true")
+	}
+	if !strings.Contains(err.Error(), "exited") {
+		t.Errorf("the error must say the process is gone, got %q", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != before {
+		t.Errorf("the dead root was checked AFTER prompting (%d -> %d): a Touch ID that can buy nothing must not be asked for", before, got)
+	}
+}
+
+// Every arming used to leave its predecessor running, up to a week out,
+// holding the id and its closure — so a grant extended through a working week
+// accumulated a pile of live timers. Each was harmless (they re-check the
+// deadline before acting) but the pile was unbounded.
+func TestGrantExpiryTimersDoNotAccumulate(t *testing.T) {
+	var calls int32
+	s, socketPath, cleanup := startTestServer(t, time.Minute, &calls)
+	defer cleanup()
+
+	sec := sealGrantSecret(t, "jamf/api-pass", "mcp", bytes.Repeat([]byte{0x07}, 32))
+	wireGrantResolver(s, sec)
+
+	c := NewClient(socketPath)
+	st, err := c.GrantCreate(int32(os.Getpid()), "", []string{"jamf"}, "", time.Hour) // #nosec G115 -- test pid
+	if err != nil {
+		t.Fatalf("GrantCreate: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		if _, err := c.GrantExtend(st.ID, time.Duration(i+2)*time.Hour); err != nil {
+			t.Fatalf("GrantExtend %d: %v", i, err)
+		}
+	}
+
+	s.grantMu.Lock()
+	timers := len(s.grantTimers)
+	s.grantMu.Unlock()
+	if timers != 1 {
+		t.Errorf("one grant extended 10 times holds %d timers, want 1", timers)
+	}
+
+	// Ending the grant leaves none behind.
+	if err := c.GrantRevoke(st.ID); err != nil {
+		t.Fatalf("GrantRevoke: %v", err)
+	}
+	s.grantMu.Lock()
+	timers = len(s.grantTimers)
+	s.grantMu.Unlock()
+	if timers != 0 {
+		t.Errorf("a revoked grant left %d timers armed, want 0", timers)
+	}
+}

--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -3,12 +3,48 @@
 
 package agent
 
+// Protocol is this build's socket-protocol revision. It exists because
+// version skew across the socket degrades by SILENT JSON FIELD DROPPING,
+// and that is fail-open for any field whose presence is what enforces
+// something: an old agent that has never heard of Request.Disclose simply
+// ignores it and performs the reveal with no disclosed challenge at all —
+// exactly the machine-wide silent credential grant that flag exists to
+// prevent. Vault-side skew already fails CLOSED and loudly ("envelope
+// version 4, newer than this jit understands"); the socket had no
+// equivalent.
+//
+// Two mechanisms use it, in opposite directions:
+//
+//   - Request.MinProtocol lets a client REQUIRE enforcement it cannot
+//     verify from the outside: an agent whose own Protocol is lower
+//     refuses the request instead of silently doing less than was asked.
+//     This protects a future client talking to today's agent.
+//   - Response.Protocol (on status) lets a client check BEFORE it sends
+//     anything security-relevant, which is what protects a new client
+//     talking to a genuinely old agent — one that predates MinProtocol
+//     and would ignore that too. An absent field reads as 0.
+//
+// Bump this when adding a field whose absence would weaken a gate, and
+// name the new value in the client check that requires it.
+const Protocol = 1
+
+// protocolDisclosedGate is the Protocol at which the agent is known to
+// honor Request.Disclose. Below it, a disclosed grant cannot be proven to
+// have prompted anyone, so the client refuses to ask.
+const protocolDisclosedGate = 1
+
 // Request is one RPC sent to a running agent over its Unix socket, one
 // JSON object per connection (dial, send exactly one Request, read exactly
 // one Response, close — no multiplexing needed for this CLI-tool traffic
 // pattern).
 type Request struct {
-	Op string `json:"op"` // "wrap" | "unwrap" | "unlock" | "lock" | "status" | "refresh" | "reveal_pid" | "stop_mount" | "history"
+	// MinProtocol is the lowest agent Protocol that can serve this request
+	// AS ASKED. Set it whenever dropping one of this request's fields would
+	// silently weaken a gate rather than merely losing a nicety; an agent
+	// below it fails the request closed. Zero (absent) means any agent will
+	// do, which is the truth for ordinary wrap/unwrap/status traffic.
+	MinProtocol int    `json:"min_protocol,omitempty"`
+	Op          string `json:"op"` // "wrap" | "unwrap" | "unlock" | "lock" | "status" | "refresh" | "reveal_pid" | "stop_mount" | "history"
 	// Data is the DEK (for "wrap") or the wrapped DEK (for "unwrap").
 	// encoding/json base64-encodes a []byte field automatically.
 	Data []byte `json:"data,omitempty"`
@@ -258,6 +294,12 @@ const OpGrantUse = "grant_use"
 type Response struct {
 	OK    bool   `json:"ok"`
 	Error string `json:"error,omitempty"`
+	// Protocol is the answering agent's own socket-protocol revision (see
+	// Protocol). Set on every response, so a client can check what the
+	// running agent enforces before it sends a request whose safety depends
+	// on that enforcement. Zero from any agent predating the field, which is
+	// precisely the "too old to trust with this" signal.
+	Protocol int `json:"protocol,omitempty"`
 	// Data is the wrapped/unwrapped result for "wrap"/"unwrap".
 	Data []byte `json:"data,omitempty"`
 	// Unlocked and ExpiresInSeconds answer "status" (and are also set on

--- a/internal/agent/server.go
+++ b/internal/agent/server.go
@@ -238,6 +238,10 @@ type Server struct {
 	// never survives the agent process.
 	grantMu sync.Mutex
 	grants  map[string]*processGrant
+	// grantTimers holds each live grant's expiry timer so re-arming or ending
+	// one can stop its predecessor instead of leaving it to run out (see
+	// armGrantExpiry). Guarded by grantMu, alongside grants itself.
+	grantTimers map[string]*time.Timer
 
 	// OnResolveGrant, if set, resolves grant_create's profile NAMES to the
 	// concrete secrets they cover — vault path, wrapped DEK bytes, AAD-bound
@@ -324,7 +328,12 @@ type Server struct {
 	// the anchor maxSessionAge measures from. Unlike expiry it is never
 	// pushed forward by use; that is the whole point of it.
 	sessionStart time.Time
-	lockTimer    *time.Timer
+	// pendingLockNotify is a lock event that has been recorded in the ring
+	// (and in lastLock) but not yet handed to OnSessionEvent, because it was
+	// created under mu and that callback must never run there. Set only by
+	// collectIfDoneLocked; drained by notifyPendingLock. Guarded by mu.
+	pendingLockNotify *SessionEvent
+	lockTimer         *time.Timer
 	// lastDenied is when a challenge most recently failed — what the
 	// denial cooldown above measures from — and lastDeniedCause is why, so
 	// the cooldown refusal can repeat the ORIGINAL failure instead of
@@ -374,6 +383,18 @@ type Server struct {
 	serveErrMu   sync.Mutex
 	serveErrSeen map[string]*serveErrNote
 
+	// discloseRefusals is the prompt-storm backoff for disclosed challenges
+	// (see discloseBackoffLocked). Guarded by challengeMu, not mu: every
+	// read and write happens inside discloseChallengeOp, which holds
+	// challengeMu across the whole prompt, so the state a waiter reads is
+	// always the one the challenge it queued behind just wrote.
+	discloseRefusals map[string]discloseRefusal
+	// discloseBackoff is the escalation schedule, a field for the same
+	// reason denialCooldown is one: a test that wants to exercise the
+	// decline-then-approve sequence should not have to sleep out a real
+	// pause. Empty disables the backoff entirely.
+	discloseBackoff []time.Duration
+
 	listener net.Listener
 	// socketInfo identifies the socket file THIS server bound, so Close can
 	// tell its own socket from one a later agent has since claimed at the
@@ -417,9 +438,12 @@ func NewServer(socketPath string, newFetcher func() MEKFetcher, ttl time.Duratio
 		maxSessionAge:  DefaultMaxSessionAge,
 		readTimeout:    10 * time.Second,
 		denialCooldown: defaultDenialCooldown,
-		useWindow:      defaultUseWindow,
-		trustRoots:     map[int32]int64{},
-		identify:       callerFromConn,
+		// The disclosed-prompt backoff (discloseBackoffLocked) starts from
+		// the shipped schedule; tests override the field.
+		discloseBackoff: discloseBackoffSchedule,
+		useWindow:       defaultUseWindow,
+		trustRoots:      map[int32]int64{},
+		identify:        callerFromConn,
 	}
 }
 
@@ -483,9 +507,19 @@ func tightenSocketDir(dir string) {
 // Serve accepts connections until ctx is cancelled or the listener fails.
 // Call Listen first.
 func (s *Server) Serve(ctx context.Context) error {
+	// The watcher ends when Serve does, not only when ctx is cancelled: a
+	// listener that fails for its own reason returns below, and a watcher
+	// still parked on ctx.Done() would outlive the Serve call that started
+	// it. The daemon's deferred cancel covers that today; a library embedding
+	// this Server need not have one.
+	served := make(chan struct{})
+	defer close(served)
 	go func() {
-		<-ctx.Done()
-		_ = s.listener.Close()
+		select {
+		case <-ctx.Done():
+			_ = s.listener.Close()
+		case <-served:
+		}
 	}()
 	for {
 		conn, err := s.listener.Accept()
@@ -578,6 +612,10 @@ func (s *Server) handleConn(conn net.Conn) {
 	// the response write.
 	_ = conn.SetDeadline(time.Time{})
 	resp := s.handle(req, c)
+	// Stamped on EVERY response, not just status: it is how a client learns
+	// what this agent is able to enforce, and a client that has to make a
+	// second round trip to find out would be tempted to skip the check.
+	resp.Protocol = Protocol
 	_ = conn.SetWriteDeadline(time.Now().Add(s.readTimeout))
 	_ = json.NewEncoder(conn).Encode(resp)
 }
@@ -594,6 +632,18 @@ func currentExecutablePath() string {
 }
 
 func (s *Server) handle(req Request, c *caller) Response {
+	// A request that names a protocol this build cannot speak is refused
+	// whole, before any dispatch. Unknown OPS already failed closed; unknown
+	// FIELDS did not — JSON drops them silently, so a request whose safety
+	// rests on a field this agent has never heard of would otherwise be
+	// served as though the field had said nothing. Refusing names the fix,
+	// because the fix is always the same: the agent is older than the CLI
+	// asking, and restarting it onto the current binary resolves it.
+	if req.MinProtocol > Protocol {
+		return Response{OK: false, Error: fmt.Sprintf(
+			"%s: this request needs agent protocol %d but the running service speaks %d — it predates a check this request depends on; run `jit service restart` to move it onto the current binary",
+			req.Op, req.MinProtocol, Protocol)}
+	}
 	switch req.Op {
 	case OpStatus:
 		unlocked, remaining := s.status()
@@ -632,8 +682,13 @@ func (s *Server) handle(req Request, c *caller) Response {
 		// alone would have handed every process on the machine a free reset:
 		// refuse, unlock, refuse, unlock — the exact flood this backoff exists
 		// to stop, with an extra syscall per round.
-		if fresh && s.Consent != nil {
-			s.Consent.ClearBackoff()
+		if fresh {
+			if s.Consent != nil {
+				s.Consent.ClearBackoff()
+			}
+			// The disclosed-prompt pauses clear on the same signal and under
+			// the same `fresh` gate, for the identical reason.
+			s.clearDiscloseBackoff()
 		}
 		unlocked, remaining := s.status()
 		return Response{OK: true, Unlocked: unlocked, ExpiresInSeconds: int64(remaining.Seconds())}
@@ -776,7 +831,14 @@ func (s *Server) handle(req Request, c *caller) Response {
 		// minutes-old unlock are different facts in an audit. Any miss falls
 		// through to the ordinary path unchanged.
 		if dek, path, ok := s.grantUnwrap(c, req.Data); ok {
-			s.recordAggregated(KindUse, OpGrantUse, c.command(), c, path)
+			// Collapse on the RAW argv, never the redacted form — the same
+			// requirement recordUse documents at length and has a test for.
+			// Redaction can map two different callers onto one string, and
+			// this path has the identical collapse window, so keying on it
+			// would stamp the first caller's pid onto the second's uses. A
+			// grant covers a whole tree, so two tools under one grant hitting
+			// the same window is the ordinary case here, not an exotic one.
+			s.recordAggregated(KindUse, OpGrantUse, c.rawCommand(), c, path)
 			return Response{OK: true, Data: dek}
 		}
 		// Nothing has verified req.Class yet. It is AEAD-bound into the wrap,
@@ -974,6 +1036,14 @@ func (s *Server) discloseChallengeOp(reason, op string, c *caller) (*SessionEven
 	s.challengeMu.Lock()
 	defer s.challengeMu.Unlock()
 
+	// Checked INSIDE challengeMu, the same placement and the same reason as
+	// the denial cooldown on the unlock path: a caller that queued behind
+	// the very challenge just refused must be turned away too, or a loop
+	// gets a second dialog the instant the first is dismissed.
+	if err := s.discloseBackoffLocked(op, c); err != nil {
+		return unlockEvent(op, c), nil, err
+	}
+
 	pending := unlockEvent(op, c)
 	pending.Cause = reason
 	s.mu.Lock()
@@ -1003,10 +1073,128 @@ func (s *Server) discloseChallengeOp(reason, op string, c *caller) (*SessionEven
 	s.recordEvent(*event)
 	s.mu.Unlock()
 
+	s.noteDiscloseOutcomeLocked(op, c, err == nil)
+
 	if err != nil {
 		return event, nil, fmt.Errorf("disclosed grant declined: %w", err)
 	}
 	return event, mek, nil
+}
+
+// discloseRefusal is one key's consecutive-refusal state for the disclosed
+// prompt backoff.
+type discloseRefusal struct {
+	count int
+	until time.Time
+}
+
+// discloseBackoffKey identifies who is being throttled. It is the op plus the
+// caller's LAUNCHER, deliberately not the prompt reason and not the caller's
+// own argv: trustReason renders the caller's command, which the caller
+// chooses, so a loop could otherwise mint a fresh key per iteration and
+// out-wait nothing. The launcher is the same coarse anchor the consent
+// engine's backoff uses, with the same acknowledged cost (a shared
+// interpreter or terminal covers several programs) and the same mitigation —
+// the pauses are seconds, they never become a standing refusal, and an
+// approval clears them.
+func discloseBackoffKey(op string, c *caller) string {
+	launcher := ""
+	if c != nil {
+		launcher = c.launchedBy()
+	}
+	return op + "\x00" + launcher
+}
+
+// maxDiscloseRefusalKeys bounds the map over a weeks-long process. Reached
+// only by a caller churning launchers; resetting forfeits escalation state,
+// never a prompt.
+const maxDiscloseRefusalKeys = 64
+
+// discloseBackoffLocked refuses to prompt while a key is inside its
+// post-refusal pause. Caller must hold challengeMu.
+//
+// Disclosed challenges deliberately do NOT arm the global denial cooldown —
+// a refused grant is a targeted "not this", not "stop trying to unlock" —
+// which left the widest-scope operations in the product (OpTrust, whose one
+// approval waives per-tool consent for a whole tree; grant create and
+// extend; a global-credential reveal) with no throttle whatsoever. Any
+// same-user process could put an unbounded stream of Touch ID dialogs on
+// screen until the human approved one to make it stop. That is the exact
+// asymmetry consent.Throttled was introduced to close, in the words of its
+// own rationale — "a caller in a loop could simply outlast the user" — and
+// it was never carried over to here.
+func (s *Server) discloseBackoffLocked(op string, c *caller) error {
+	r, ok := s.discloseRefusals[discloseBackoffKey(op, c)]
+	if !ok {
+		return nil
+	}
+	if remaining := time.Until(r.until); remaining > 0 {
+		return fmt.Errorf("this authorization was declined %s; not asking again for %s (approve one, or run `jit unlock`, to clear the pause)",
+			plural(r.count, "time"), remaining.Round(time.Second))
+	}
+	return nil
+}
+
+// noteDiscloseOutcomeLocked records an approval (which clears the key) or a
+// refusal (which escalates its pause). Caller must hold challengeMu.
+func (s *Server) noteDiscloseOutcomeLocked(op string, c *caller, approved bool) {
+	key := discloseBackoffKey(op, c)
+	if approved {
+		delete(s.discloseRefusals, key)
+		return
+	}
+	if s.discloseRefusals == nil {
+		s.discloseRefusals = map[string]discloseRefusal{}
+	}
+	if len(s.discloseRefusals) >= maxDiscloseRefusalKeys {
+		if _, known := s.discloseRefusals[key]; !known {
+			s.discloseRefusals = map[string]discloseRefusal{}
+		}
+	}
+	r := s.discloseRefusals[key]
+	r.count++
+	r.until = time.Now().Add(discloseBackoffFor(s.discloseBackoff, r.count))
+	s.discloseRefusals[key] = r
+}
+
+// discloseBackoffSchedule is the pause after the 1st, 2nd, and 3rd-or-later
+// consecutive refusal. Same numbers as the consent engine's, for the same
+// reasons: short enough that an accidental decline followed immediately by a
+// re-run barely registers, topping out at the denial cooldown's 30s, which
+// is long enough that a loop cannot convert patience into approval.
+var discloseBackoffSchedule = []time.Duration{
+	2 * time.Second,
+	8 * time.Second,
+	30 * time.Second,
+}
+
+func discloseBackoffFor(schedule []time.Duration, refusals int) time.Duration {
+	if refusals <= 0 || len(schedule) == 0 {
+		return 0
+	}
+	if refusals > len(schedule) {
+		refusals = len(schedule)
+	}
+	return schedule[refusals-1]
+}
+
+// plural renders a refusal count the way consent.Throttled's message does.
+func plural(n int, unit string) string {
+	if n == 1 {
+		return "once"
+	}
+	return fmt.Sprintf("%d %ss", n, unit)
+}
+
+// clearDiscloseBackoff drops every disclosed-prompt pause. Called by a FRESH
+// unlock, on the same reasoning that clears the consent backoff there: a
+// human who just passed Touch ID is present, and "now" is exactly the signal
+// a refusal withheld. An unlock that prompts nobody clears nothing, or any
+// process could reset its own pause by asking for a session it already has.
+func (s *Server) clearDiscloseBackoff() {
+	s.challengeMu.Lock()
+	defer s.challengeMu.Unlock()
+	s.discloseRefusals = nil
 }
 
 func (s *Server) ensureUnlockedNotify(onFresh func(), op string, c *caller, label string) ([]byte, error) {
@@ -1243,6 +1431,9 @@ func (s *Server) challengeUnlock(op string, c *caller, label string) ([]byte, *S
 // session from the unlock that started it, so continuous use extends a
 // session but can no longer sustain one forever (see collectIfDoneLocked).
 func (s *Server) touchSession() []byte {
+	// Ordered so the durable hand-off for a session this call may have
+	// collected runs after mu is released (defers unwind last-in-first-out).
+	defer s.notifyPendingLock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mek == nil {
@@ -1267,6 +1458,7 @@ func (s *Server) touchSession() []byte {
 // buy the session another full TTL on its way to being rejected, or the check
 // meant to make junk requests cheap would make them useful instead.
 func (s *Server) peekSession() []byte {
+	defer s.notifyPendingLock() // see touchSession: drained outside mu
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mek == nil {
@@ -1289,10 +1481,48 @@ func (s *Server) collectIfDoneLocked(now time.Time) bool {
 	if now.Before(s.expiry) && !aged {
 		return false
 	}
+	// This collection IS the session's lock, so it is recorded as one. It
+	// used to be recorded nowhere: the wipe below nils the MEK silently, and
+	// the still-armed idle timer then found hadSession false and wrote no
+	// KindLock and no lastLock at all — history showed unlock → unlock with
+	// nothing between, which is exactly the "I authorized this twenty
+	// minutes ago, why again?" question a lock cause exists to answer. The
+	// race needs a request to beat the timer goroutine past expiry: a busy
+	// agent, which is the common one. Recording HERE rather than leaving it
+	// to the timer also survives the usual continuation, where the same
+	// request goes straight on to a fresh unlock and no timer ever runs for
+	// the session that ended.
+	//
+	// The ring and lastLock are updated under mu (both require it); the
+	// durable OnSessionEvent hand-off cannot run here, so it is parked for
+	// notifyPendingLock to drain outside the lock.
+	cause := fmt.Sprintf("%s idle timeout", s.ttl)
+	if aged {
+		cause = fmt.Sprintf("%s maximum session age", s.maxSessionAge)
+	}
+	event := &SessionEvent{UnixTime: now.Unix(), Kind: KindLock, Cause: cause}
+	s.lastLock = event
+	s.recordEvent(*event)
+	s.pendingLockNotify = event
+
 	wipe(s.mek)
 	unlockMemory(s.mek)
 	s.mek = nil
 	return true
+}
+
+// notifyPendingLock hands a lazily-collected session's lock event to the
+// durable sink, outside mu. Every caller of collectIfDoneLocked calls it once
+// it has released the lock; it is a no-op when nothing was collected, so
+// calling it unconditionally is correct and cheap.
+func (s *Server) notifyPendingLock() {
+	s.mu.Lock()
+	event := s.pendingLockNotify
+	s.pendingLockNotify = nil
+	s.mu.Unlock()
+	if event != nil && s.OnSessionEvent != nil {
+		s.OnSessionEvent(*event)
+	}
 }
 
 // armLockTimer (re)arms the idle auto-lock a full TTL out. Caller must

--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -19,6 +19,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/jitpass/jit/internal/lineage"
 )
 
 // shortSocketPath returns a socket path under /tmp directly, not
@@ -1572,5 +1574,322 @@ func TestRecordServeErrorRateLimitsIdenticalFailures(t *testing.T) {
 	}
 	if events[2].Count != 100 {
 		t.Errorf("the recorded event must carry the fold: Count = %d, want 100", events[2].Count)
+	}
+}
+
+// TestMinProtocolFailsClosed pins the socket-skew defense. Version skew here
+// degrades by silent JSON field dropping, which is fail-OPEN for any field
+// whose presence is what enforces something: an agent that never heard of
+// Disclose ignores it and performs the reveal with no disclosed challenge.
+// Unknown OPS always failed closed; unknown FIELDS did not. A request naming
+// a protocol above this build's is now refused whole, and the error names the
+// fix (restart the service onto the current binary).
+func TestMinProtocolFailsClosed(t *testing.T) {
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), nil, time.Minute)
+
+	resp := s.handle(Request{Op: OpStatus, MinProtocol: Protocol + 1}, nil)
+	if resp.OK {
+		t.Fatal("a request needing a newer protocol than this build speaks must be refused")
+	}
+	if !strings.Contains(resp.Error, "jit service restart") {
+		t.Errorf("the refusal must name the fix, got %q", resp.Error)
+	}
+
+	// At or below this build's protocol, the request is served normally.
+	if resp := s.handle(Request{Op: OpStatus, MinProtocol: Protocol}, nil); !resp.OK {
+		t.Errorf("a request this build can serve as asked must proceed, got %q", resp.Error)
+	}
+	if resp := s.handle(Request{Op: OpStatus}, nil); !resp.OK {
+		t.Errorf("an ordinary request (no MinProtocol) must proceed, got %q", resp.Error)
+	}
+}
+
+// TestStatusReportsProtocol: the Protocol stamp is what lets a client check
+// what the running agent enforces BEFORE sending a request whose safety
+// depends on that enforcement — the only fail-closed option against an agent
+// so old it would ignore MinProtocol too (see Client.GrantGlobalForPID).
+func TestStatusReportsProtocol(t *testing.T) {
+	_, socketPath, cleanup := startTestServer(t, time.Minute, new(int32))
+	defer cleanup()
+
+	st, err := NewClient(socketPath).Status()
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if st.Protocol != Protocol {
+		t.Errorf("Status.Protocol = %d, want %d", st.Protocol, Protocol)
+	}
+	if st.Protocol < protocolDisclosedGate {
+		t.Errorf("this build must satisfy its own disclosed-gate requirement (%d)", protocolDisclosedGate)
+	}
+}
+
+// TestDisclosedChallengeBacksOffAfterRefusals is the prompt-storm defense.
+// Disclosed challenges deliberately never arm the global denial cooldown (a
+// refused grant is "not this", not "stop trying to unlock"), which left the
+// widest-scope operations in the product with no throttle at all: a caller in
+// a loop could put an unbounded stream of Touch ID dialogs on screen until
+// the human approved one to make it stop. That is the exact asymmetry
+// consent.Throttled exists to close, and it was never carried over here.
+func TestDisclosedChallengeBacksOffAfterRefusals(t *testing.T) {
+	var prompts int32
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), func() MEKFetcher {
+		return fnFetcher{fn: func(string) ([]byte, error) {
+			atomic.AddInt32(&prompts, 1)
+			return nil, errors.New("declined")
+		}}
+	}, time.Minute)
+
+	c := &caller{pid: 4242, self: lineage.Process{PID: 4242, ExecPath: "/bin/loop"},
+		ancestors: []lineage.Process{{PID: 1234, ExecPath: "/bin/zsh"}}}
+
+	// First refusal prompts and arms the pause.
+	if _, _, err := s.discloseChallengeOp("grant something wide", OpTrust, c); err == nil {
+		t.Fatal("a declined challenge must return an error")
+	}
+	if got := atomic.LoadInt32(&prompts); got != 1 {
+		t.Fatalf("first attempt prompted %d times, want 1", got)
+	}
+
+	// A loop retrying immediately gets the pause, NOT another dialog.
+	for i := 0; i < 20; i++ {
+		_, _, err := s.discloseChallengeOp("grant something wide", OpTrust, c)
+		if err == nil {
+			t.Fatal("a paused challenge must not succeed")
+		}
+		if !strings.Contains(err.Error(), "not asking again") {
+			t.Fatalf("attempt %d: want the pause message, got %q", i+2, err)
+		}
+	}
+	if got := atomic.LoadInt32(&prompts); got != 1 {
+		t.Errorf("a 21-iteration loop put %d dialogs on screen, want 1", got)
+	}
+
+	// The key is the op plus the caller's LAUNCHER, not the prompt reason:
+	// trustReason renders the caller's own command, so keying on the reason
+	// would let a loop mint a fresh key per iteration and out-wait nothing.
+	if _, _, err := s.discloseChallengeOp("a completely different reason", OpTrust, c); err == nil ||
+		!strings.Contains(err.Error(), "not asking again") {
+		t.Errorf("varying the reason must not escape the pause, got %v", err)
+	}
+	if got := atomic.LoadInt32(&prompts); got != 1 {
+		t.Errorf("varying the reason produced %d dialogs, want 1", got)
+	}
+}
+
+// An approval clears the pause: the point is to make refusing cheap, never to
+// lock the operation out. A fresh unlock clears it too (clearDiscloseBackoff),
+// on the same "a human at the keyboard is the signal a refusal withheld"
+// reasoning the consent backoff already honors.
+func TestDisclosedBackoffClearedByApprovalAndUnlock(t *testing.T) {
+	var deny atomic.Bool
+	deny.Store(true)
+	key := bytes.Repeat([]byte{0x42}, 32)
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), func() MEKFetcher {
+		return fnFetcher{fn: func(string) ([]byte, error) {
+			if deny.Load() {
+				return nil, errors.New("declined")
+			}
+			k := make([]byte, len(key))
+			copy(k, key)
+			return k, nil
+		}}
+	}, time.Minute)
+	// A pause long enough that only an explicit clear can end it inside the test.
+	s.discloseBackoff = []time.Duration{time.Hour}
+
+	c := &caller{pid: 7, self: lineage.Process{PID: 7, ExecPath: "/bin/tool"}}
+
+	if _, _, err := s.discloseChallengeOp("r", OpGrantCreate, c); err == nil {
+		t.Fatal("precondition: the challenge must be declined")
+	}
+	if err := s.discloseBackoffLocked(OpGrantCreate, c); err == nil {
+		t.Fatal("precondition: the pause must be armed")
+	}
+
+	// clearDiscloseBackoff is what a FRESH unlock calls.
+	s.clearDiscloseBackoff()
+	if err := s.discloseBackoffLocked(OpGrantCreate, c); err != nil {
+		t.Errorf("a fresh unlock must clear the pause, got %v", err)
+	}
+
+	// And an approval clears the key it approved.
+	if _, _, err := s.discloseChallengeOp("r", OpGrantCreate, c); err == nil {
+		t.Fatal("expected the second decline to re-arm")
+	}
+	deny.Store(false)
+	s.clearDiscloseBackoff() // let the approval through
+	if _, mek, err := s.discloseChallengeOp("r", OpGrantCreate, c); err != nil {
+		t.Fatalf("approved challenge: %v", err)
+	} else {
+		wipe(mek)
+	}
+	if err := s.discloseBackoffLocked(OpGrantCreate, c); err != nil {
+		t.Errorf("an approval must leave no pause behind, got %v", err)
+	}
+}
+
+// TestLazyExpiryStillRecordsTheLock: a session collected lazily (a request
+// noticing the expiry before the idle timer's goroutine got there) used to be
+// wiped with no KindLock event and no lastLock at all — history showed
+// unlock → unlock with nothing between, and the re-prompt had no explanation.
+// Recording at collection also survives the usual continuation, where the
+// same request goes straight on to a fresh unlock and no timer ever runs for
+// the session that ended.
+func TestLazyExpiryStillRecordsTheLock(t *testing.T) {
+	var events []SessionEvent
+	var mu sync.Mutex
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), func() MEKFetcher {
+		return &fakeFetcher{key: bytes.Repeat([]byte{0x42}, 32), calls: new(int32)}
+	}, time.Minute)
+	s.OnSessionEvent = func(e SessionEvent) {
+		mu.Lock()
+		events = append(events, e)
+		mu.Unlock()
+	}
+
+	mek, err := s.ensureUnlocked(OpUnlock, nil, "")
+	if err != nil {
+		t.Fatalf("ensureUnlocked: %v", err)
+	}
+	wipe(mek)
+
+	// Expire the session in place and stop the timer, modelling the race the
+	// bug needed: the timer has not run, and a request arrives.
+	s.mu.Lock()
+	s.expiry = time.Now().Add(-time.Second)
+	if s.lockTimer != nil {
+		s.lockTimer.Stop()
+	}
+	s.mu.Unlock()
+
+	if got := s.touchSession(); got != nil {
+		wipe(got)
+		t.Fatal("an expired session must not serve the key")
+	}
+
+	if _, lastLock := s.provenance(); lastLock == nil {
+		t.Error("a lazily-collected session recorded no lastLock: history shows unlock -> unlock with nothing between")
+	} else if !strings.Contains(lastLock.Cause, "idle timeout") {
+		t.Errorf("lock cause = %q, want the idle timeout that actually ended it", lastLock.Cause)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	var locks int
+	for _, e := range events {
+		if e.Kind == KindLock {
+			locks++
+		}
+	}
+	if locks != 1 {
+		t.Errorf("durable trail got %d lock events, want exactly 1", locks)
+	}
+}
+
+// TestDisclosedGrantRefusesAnOldAgent is the fail-closed half that MinProtocol
+// structurally cannot cover: an agent old enough to ignore Disclose also
+// ignores MinProtocol, so it would perform this machine-wide reveal with no
+// prompt at all — the exact silent credential grant the flag exists to
+// prevent. The client checks the agent's reported protocol BEFORE sending
+// anything, and refuses to ask rather than asking something that cannot
+// enforce the answer.
+func TestDisclosedGrantRefusesAnOldAgent(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	var reveals atomic.Int32
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				var req Request
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				if req.Op == OpRevealPID {
+					reveals.Add(1)
+				}
+				// A pre-Protocol agent: no protocol field at all, and it
+				// would happily serve the reveal.
+				_ = json.NewEncoder(conn).Encode(Response{OK: true})
+			}()
+		}
+	}()
+
+	err = NewClient(socketPath).GrantGlobalForPID([]RunMount{{Path: "/x/ADC", Mode: MountModeGrant}}, 4242)
+	if err == nil {
+		t.Fatal("granting a machine-wide credential through an agent that cannot enforce the disclosed prompt must fail")
+	}
+	if !strings.Contains(err.Error(), "jit service restart") {
+		t.Errorf("the refusal must name the fix, got %q", err)
+	}
+	if got := reveals.Load(); got != 0 {
+		t.Errorf("the reveal was sent %d time(s) to an agent that cannot gate it; it must never leave the client", got)
+	}
+}
+
+// The same call against a current agent still works, and carries both the
+// MinProtocol requirement and the legacy trigger — the belt and the braces
+// must not have broken the ordinary path.
+func TestDisclosedGrantSendsRequirementAndLegacyTrigger(t *testing.T) {
+	socketPath := shortSocketPath(t)
+	l, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+
+	got := make(chan Request, 4)
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				var req Request
+				if err := json.NewDecoder(conn).Decode(&req); err != nil {
+					return
+				}
+				got <- req
+				_ = json.NewEncoder(conn).Encode(Response{OK: true, Protocol: Protocol})
+			}()
+		}
+	}()
+
+	if err := NewClient(socketPath).GrantGlobalForPID([]RunMount{{Path: "/x/ADC", Mode: MountModeGrant}}, 4242); err != nil {
+		t.Fatalf("GrantGlobalForPID against a current agent: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case req := <-got:
+			if req.Op != OpRevealPID {
+				continue // the status pre-check
+			}
+			if !req.Disclose {
+				t.Error("the disclosed flag must still be set")
+			}
+			if req.MinProtocol < protocolDisclosedGate {
+				t.Errorf("MinProtocol = %d, want at least %d so a knowing-but-older agent refuses rather than under-enforcing", req.MinProtocol, protocolDisclosedGate)
+			}
+			if req.DiscloseReason == "" {
+				t.Error("the legacy trigger must be set so a pre-Disclose agent still takes its gate")
+			}
+			return
+		case <-deadline:
+			t.Fatal("no reveal_pid request arrived")
+		}
 	}
 }


### PR DESCRIPTION
## What

Phase 4 of `design/service-reliability.md`: broker hardening. Stacked on #73 (which is stacked on #72) — merge in order; this diff is its own commit.

No user-visible output wording changed, so no preview gate here.

## Socket skew fails closed

Version skew across the socket degraded by **silent JSON field dropping**, which is fail-*open* for any field whose presence is what enforces something. Concretely: a new CLI's `jit run --with gcp` against an agent that never heard of `Request.Disclose` performed the reveal with **no disclosed challenge at all** — exactly the machine-wide silent credential grant that flag exists to prevent. Vault-side skew already fails closed and loudly ("envelope version 4, newer than this jit understands"); the socket had no equivalent.

Three layers, because no single one covers every direction:

| Layer | Covers |
|---|---|
| `agent.Protocol`, stamped on every response | tells a client what the running agent can enforce |
| `Request.MinProtocol` | an agent below it refuses the request whole, naming the fix, instead of quietly doing less than asked |
| **Client-side pre-check** before a disclosed grant is sent | an agent old enough to ignore `MinProtocol` too — refuses to *ask* rather than asking something that cannot enforce the answer |

`DiscloseReason` also rides along as a last-resort trigger for an agent from the window when that was the flag's spelling.

## Prompt storms get the consent engine's backoff

Disclosed challenges deliberately never arm the global denial cooldown (a refused grant is "not this", not "stop trying to unlock"), which left the **widest-scope operations in the product** with no throttle whatsoever: `OpTrust` (one approval waives per-tool consent for a whole tree), grant create, grant extend, global-credential reveals. Any same-user process could loop and put an unbounded stream of Touch ID dialogs on screen until the human approved one to make it stop — the exact asymmetry `consent.Throttled` was introduced to close ("a caller in a loop could simply outlast the user"), never carried over.

All four sites share one seam, so the backoff lands there: the same 2s/8s/30s schedule, keyed on the op plus the caller's **launcher** rather than the prompt reason (`trustReason` renders caller-chosen argv, so a reason key would let a loop mint a fresh one per iteration and out-wait nothing), cleared by an approval or a fresh `jit unlock`.

## Audit truth

- **A lazily-collected session now records its lock.** `collectIfDoneLocked` wiped the MEK silently; the still-armed timer then found `hadSession` false and wrote no `KindLock` and no `lastLock` — history showed unlock → unlock with nothing between, so a re-prompt had no explanation. Recorded at collection rather than deferred to the timer, which would still have lost it in the commonest continuation (same request goes straight on to a fresh unlock, no timer ever runs).
- `grant_use` collapses on the raw argv, not the redacted form — redaction can map two callers onto one string, and a grant covers a whole tree, so two tools sharing a window is ordinary there.
- `extendGrant` verifies the root is still alive **before** prompting, instead of asking for a Touch ID that can buy nothing and echoing `RootAlive: true` about a grant the next prune ends.

## Also

Grant expiry timers are cancelled on re-extend and on end (each arming left its predecessor running, up to a week out); `Serve`'s ctx-watcher goroutine ends with `Serve` rather than parking past an accept failure.

**Deliberately not fixed:** the sleep-path durable write. The spec records why — deferring the lock's tail to get the log write off the kernel's power-change wait also defers clearing mounts' resolved real content, trading a rare recoverable stall for a credential-exposure window.

## Tests

`MinProtocol` refusal + pass-through, `Status.Protocol`, a hand-rolled pre-Protocol agent proving the disclosed grant never leaves the client (and that a current agent still gets `Disclose`+`MinProtocol`+legacy trigger), a 21-iteration prompt loop producing exactly 1 dialog (including that varying the reason doesn't escape it), approval/unlock clearing, lazy-expiry lock event, `grant_use` redaction collision, extend-with-dead-root (real short-lived child, asserts no prompt was burned), and timer non-accumulation across 10 extends + revoke. Full `-race` suite, vet, gofmt, staticcheck, gosec: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejayf5Jz2yNwudQrUGLWnq
