### PR TITLE
Fix the jit upgrade false-failure and five pre-release QA findings

### DIFF
--- a/internal/cli/agentlogview.go
+++ b/internal/cli/agentlogview.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/fatih/color"
@@ -130,7 +131,15 @@ func collapseAgentLog(lines []string, home string) []logEntry {
 		}
 		e := logEntry{date: m[1], clock: m[2][:5], count: 1, detail: m[3]}
 		if r := readsRe.FindStringSubmatch(e.detail); r != nil {
-			e.detail = readsRe.ReplaceAllString(e.detail, "") + " ×" + r[1]
+			// The raw suffix counts what was SUPPRESSED ("+3 since the last
+			// logged one"), so the total occurrences are one more — the
+			// logged one plus the three. ×N means "N times" everywhere else
+			// in jit, so rendering the suppressed count verbatim understated
+			// every row by one (and "×1" claimed a single occurrence for a
+			// line that actually happened twice).
+			if n, err := strconv.Atoi(r[1]); err == nil {
+				e.detail = readsRe.ReplaceAllString(e.detail, "") + " ×" + strconv.Itoa(n+1)
+			}
 		}
 		if mm := mountRe.FindStringSubmatch(e.detail); mm != nil {
 			e.subject, e.detail = mm[1], mm[2]

--- a/internal/cli/agentlogview_test.go
+++ b/internal/cli/agentlogview_test.go
@@ -44,12 +44,16 @@ func TestAgentLogDoesNotCollapseAcrossTimes(t *testing.T) {
 }
 
 func TestAgentLogCollapsesTheReadsNoteIntoACount(t *testing.T) {
+	// The raw suffix counts what was SUPPRESSED since the last logged read,
+	// so 205 suppressed + the logged one = 206 occurrences. ×N means "N
+	// times" everywhere else in jit, so the row must say ×206 — rendering
+	// the suppressed count verbatim understated every row by one.
 	in := "2026-07-28 11:49:30 jit service: mount /Users/x/w/.env: reader pid=6067 (Code) (+205 reads since the last logged one)\n"
 	var buf bytes.Buffer
 	writeAgentLog(&buf, []byte(in), "/Users/x")
 	out := buf.String()
-	if !strings.Contains(out, "×205") {
-		t.Errorf("expected the reads note as ×205, got:\n%s", out)
+	if !strings.Contains(out, "×206") {
+		t.Errorf("expected the reads note as ×206 (205 suppressed + 1 logged), got:\n%s", out)
 	}
 	if strings.Contains(out, "since the last logged one") {
 		t.Errorf("expected the prose form gone, got:\n%s", out)
@@ -183,8 +187,8 @@ func TestAgentLogFoldsSimilarSuffix(t *testing.T) {
 	var buf bytes.Buffer
 	writeAgentLog(&buf, []byte(in), "/Users/x")
 	out := buf.String()
-	if !strings.Contains(out, "×3") {
-		t.Errorf("the similar-suffix must fold to ×3, got:\n%s", out)
+	if !strings.Contains(out, "×4") {
+		t.Errorf("the similar-suffix must fold to ×4 (3 suppressed + 1 logged), got:\n%s", out)
 	}
 	if strings.Contains(out, "since the last logged one") {
 		t.Errorf("the prose suffix must not survive the fold, got:\n%s", out)

--- a/internal/cli/migratesummary.go
+++ b/internal/cli/migratesummary.go
@@ -259,7 +259,7 @@ func reportAgentStatus(w io.Writer, root string, producedMount bool) {
 		// Installed but not answering — crashed or mid-restart. Don't reinstall
 		// on top of it; point at restart, the same guidance every other surface
 		// gives for this state (installedNotRunningAdvice).
-		bold("%s", installedNotRunningAdvice("jit's background service"))
+		bold("%s", hlCmds(installedNotRunningAdvice("jit's background service")))
 	default:
 		// Never installed. Set it up silently now — this used to be the single
 		// next step every migrate run ended by telling the user to run

--- a/internal/cli/servicelaunchd.go
+++ b/internal/cli/servicelaunchd.go
@@ -195,6 +195,13 @@ func agentPlistNeedsRepoint(data []byte) bool {
 // sets itself up on first use, and the plist is a low-privilege, fully
 // reversible user LaunchAgent.
 func installAgentService(ttl time.Duration, consent bool) (plistPath string, running bool, err error) {
+	return installAgentServiceReady(ttl, consent, sameBuildAsThisProcess)
+}
+
+// installAgentServiceReady is installAgentService with the "it's up" test
+// injected, for the one caller whose new build is not its own: `jit upgrade`
+// (see restartServiceOntoCurrentBinary). Everything else wants the default.
+func installAgentServiceReady(ttl time.Duration, consent bool, ready agentReady) (plistPath string, running bool, err error) {
 	exePath, err := agentBinaryPath()
 	if err != nil {
 		return "", false, err
@@ -249,7 +256,7 @@ func installAgentService(ttl time.Duration, consent bool) (plistPath string, run
 	// typed right after a successful install said "not running" for the ~2s
 	// launchd took to actually start it. Wait briefly so "installed" also
 	// means "answering, on this build."
-	running = waitForAgentBuild(root, agentStartWait)
+	running = waitForAgentReady(root, agentStartWait, ready)
 	return plistPath, running, nil
 }
 
@@ -504,24 +511,61 @@ func bootstrapRaceError(launchctlOutput []byte) bool {
 // tests don't spend real wall-clock on the give-up path.
 var agentStartWait = 5 * time.Second
 
+// agentReady decides when a just-(re)started service counts as up. Two
+// implementations exist because the caller's relationship to the new build
+// differs, and getting that backwards makes the success message lie in one
+// direction or the other:
+//
+//   - sameBuildAsThisProcess: the ordinary case. The CLI doing the restart IS
+//     the binary the service will run, so build equality is exactly the
+//     postcondition, and it rules out the old process still answering while
+//     it drains its shutdown.
+//   - movedOffBuild: `jit upgrade`. The CLI doing the restart is the OLD
+//     binary — the new one was just written to disk and is what the service
+//     will exec — so equality can NEVER hold, and demanding it made every
+//     successful upgrade wait out the full timeout and then report a failure
+//     over a perfectly healthy service. What upgrade can honestly verify is
+//     that the service came back and is no longer the build it was.
+type agentReady func(st agent.Status) bool
+
+func sameBuildAsThisProcess(st agent.Status) bool { return st.Build == agent.BuildID() }
+
+func movedOffBuild(previous string) agentReady {
+	return func(st agent.Status) bool {
+		// Nothing was running before (or its build was unreadable): any agent
+		// answering now is the one this restart produced.
+		return previous == "" || st.Build != previous
+	}
+}
+
 // waitForAgentBuild polls until an agent running THIS build answers the
-// socket, or gives up. install/restart use it so their success message never
-// races launchd's actual spawn — and "the service is now running the current
-// binary" is a statement about the answering process's own BuildID, not
-// about a bare dial succeeding. The distinction is real: during a reload the
-// OLD process can still be draining its shutdown and answering the socket,
-// and a wait that only dialed would declare success on it (every path here
-// has just written or verified a plist pointing at this binary, so build
-// equality is the correct postcondition).
+// socket, or gives up.
 func waitForAgentBuild(root string, timeout time.Duration) bool {
+	return waitForAgentReady(root, timeout, sameBuildAsThisProcess)
+}
+
+// waitForAgentReady polls until an answering agent satisfies ready, so a
+// success message never races launchd's actual spawn.
+func waitForAgentReady(root string, timeout time.Duration, ready agentReady) bool {
 	client := agent.NewClient(agent.SocketPath(root))
 	for deadline := time.Now().Add(timeout); time.Now().Before(deadline); {
-		if st, err := client.Status(); err == nil && st.Build == agent.BuildID() {
+		if st, err := client.Status(); err == nil && ready(st) {
 			return true
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 	return false
+}
+
+// runningAgentBuild reports the build of whatever agent is answering now, ""
+// when none is. `jit upgrade` captures it BEFORE restarting so it can verify
+// the service actually moved off it.
+func runningAgentBuild(root string) string {
+	st, err := agent.NewClient(agent.SocketPath(root)).Status()
+	if err != nil {
+		return ""
+	}
+	return st.Build
 }
 
 const agentPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>

--- a/internal/cli/servicerun.go
+++ b/internal/cli/servicerun.go
@@ -77,7 +77,10 @@ var agentRunCmd = &cobra.Command{
 		// bootout guarantees the singleton, and a mid-teardown predecessor
 		// still answering the socket would turn this probe into a crash loop.
 		if os.Getppid() != 1 && agent.NewClient(agent.SocketPath(root)).Reachable() {
-			return fmt.Errorf("jit service run: an agent is already running and answering on %s; `jit service restart` restarts it", agent.SocketPath(root))
+			// "the background service", not "an agent": this is the only
+			// surface a user would meet the word, and every other one
+			// (help, status, doctor) says service.
+			return fmt.Errorf("jit service run: the background service is already running and answering on %s; use `jit service restart` to restart it", agent.SocketPath(root))
 		}
 
 		// launchd creates the StandardOutPath/StandardErrorPath log 0644;
@@ -348,7 +351,11 @@ func validateAgentTTLSetting(ttl time.Duration) error {
 		return err
 	}
 	if ttl > agent.DefaultMaxSessionAge {
-		return fmt.Errorf("--ttl must not exceed %s, got %s (a session ends at that hard ceiling no matter how actively it is used, so a longer idle timeout could never be reached)", agent.DefaultMaxSessionAge, ttl)
+		// No "--ttl" in the message: the human who reaches this typed a
+		// POSITIONAL argument to `jit service ttl`, and --ttl is a flag only
+		// `jit service run` takes. Naming it sent people looking for a flag
+		// they never used.
+		return fmt.Errorf("the session TTL must not exceed %s, got %s (a session ends at that hard ceiling no matter how actively it is used, so a longer idle timeout could never be reached)", agent.DefaultMaxSessionAge, ttl)
 	}
 	return nil
 }

--- a/internal/cli/servicestatus.go
+++ b/internal/cli/servicestatus.go
@@ -94,14 +94,18 @@ var agentStatusCmd = &cobra.Command{
 		if errors.Is(err, agent.ErrNotRunning) {
 			installed := agentInstalled()
 			if agentStatusFormat == "json" {
-				return writeJSON(cmd.OutOrStdout(), agentStatusResult{Installed: installed})
+				// Mounts is [] rather than null, as its own doc comment
+				// promises: "never omitted outright, so a script parsing
+				// this doesn't need to special-case field-missing vs empty
+				// list". A nil slice marshals to null and broke that.
+				return writeJSON(cmd.OutOrStdout(), agentStatusResult{Installed: installed, Mounts: []agent.MountRevealStatus{}})
 			}
 			if installed {
 				// An installed agent that isn't answering is a different
 				// situation from one that was never set up — launchd was
 				// supposed to keep this one alive, so "run install" is the
 				// wrong advice and hides that something actually failed.
-				fmt.Fprintln(cmd.OutOrStdout(), installedNotRunningAdvice("jit's background service"))
+				fmt.Fprintln(cmd.OutOrStdout(), hlCmds(installedNotRunningAdvice("jit's background service")))
 				return nil
 			}
 			fmt.Fprintln(cmd.OutOrStdout(), hlCmds("jit's background service is not running. Run `jit service restart` to start it (or just use jit and it starts on its own)."))

--- a/internal/cli/upgrade.go
+++ b/internal/cli/upgrade.go
@@ -526,21 +526,38 @@ func sudoCommand(args ...string) *exec.Cmd {
 // Reloading then re-execs the old file and leaves the user upgraded in every
 // way except the service that holds their key — while this function's whole
 // contract is that it "points the service at the binary now on disk."
-// It returns whether the service came back on this build within the start
-// wait: the upgrade path is the exact trigger of the 2026-08-17 incident
-// (binary swapped, launchd never respawned), and "now on v<latest>" printed
-// off a discarded result was one of the surfaces that reported success over
-// a dead broker.
+// It returns whether the service came back within the start wait: the
+// upgrade path is the exact trigger of the 2026-08-17 incident (binary
+// swapped, launchd never respawned), and "now on v<latest>" printed off a
+// discarded result was one of the surfaces that reported success over a dead
+// broker.
+//
+// "Came back" here means MOVED OFF the build that was running, not "matches
+// this process's build" — the postcondition every other restart caller uses.
+// This is the one caller for which those differ: the process running this
+// code is the OLD binary (the new one is what was just written to disk and
+// what the service will exec), so build equality can never hold, and
+// demanding it made every successful upgrade wait out the full timeout and
+// then report failure over a healthy service.
 func restartServiceOntoCurrentBinary() (running bool, err error) {
 	plistPath, err := agentPlistPath()
 	if err != nil {
 		return false, err
 	}
+	root, err := vaultRootDir()
+	if err != nil {
+		return false, err
+	}
+	// Captured BEFORE anything restarts: the build we need the service to
+	// stop being. Empty when nothing is answering, which makes any later
+	// answer proof enough.
+	ready := movedOffBuild(runningAgentBuild(root))
+
 	if _, statErr := os.Stat(plistPath); errors.Is(statErr, os.ErrNotExist) {
 		// No plist to preserve a setting from, so install with the defaults
 		// (default TTL, consent on). An existing plist takes a branch below,
 		// which keeps whatever TTL and consent state it already has baked in.
-		_, running, ierr := installAgentService(agentInstallDefaultTTL, true)
+		_, running, ierr := installAgentServiceReady(agentInstallDefaultTTL, true, ready)
 		return running, ierr
 	} else if statErr != nil {
 		return false, statErr
@@ -554,17 +571,13 @@ func restartServiceOntoCurrentBinary() (running bool, err error) {
 		if d, ok := configuredAgentTTL(); ok {
 			ttl = d
 		}
-		_, running, ierr := installAgentService(ttl, configuredAgentConsent())
+		_, running, ierr := installAgentServiceReady(ttl, configuredAgentConsent(), ready)
 		return running, ierr
 	}
 	if out, err := reloadAgentService(plistPath); err != nil {
 		return false, fmt.Errorf("%w (%s)", err, strings.TrimSpace(string(out)))
 	}
-	root, err := vaultRootDir()
-	if err != nil {
-		return false, err
-	}
-	return waitForAgentBuild(root, agentStartWait), nil
+	return waitForAgentReady(root, agentStartWait, ready), nil
 }
 
 func dirWritable(dir string) bool {


### PR DESCRIPTION
## What

Pre-release QA on the service-reliability stack (#72–#75) found **one release blocker** and five smaller defects, all in code that stack introduced. This fixes them.

Found by: a 241-check mechanical sweep (passed clean) plus three QA reviewers — code-diff, UX, and docs.

## The blocker: `jit upgrade` would report failure on every *successful* upgrade

`restartServiceOntoCurrentBinary` ended in `waitForAgentBuild`, which requires the answering service's build to equal `agent.BuildID()`. But during an upgrade **the process running that check is the old binary**, while the service restarts onto the new one — so equality can never hold. Every successful upgrade would burn the full 5s wait, then print:

```
Restarting service ... reinstalled for vX.Y.Z, but it has not come back yet
  Run `jit service restart`.
```

over a service that is in fact healthy on the new build. That inverts this release's own point, on the exact path D4 named as the incident's trigger: unverified *success* became reported *failure*. Tarball/curl installs only (brew copies refuse `jit upgrade`), which is why no test caught it — upgrade is the one cross-build caller.

**Fix:** separate the postcondition from the mechanism. `waitForAgentReady` takes an `agentReady` predicate; the default `sameBuildAsThisProcess` is right for every same-build caller, and upgrade uses `movedOffBuild(prev)` — captured *before* restarting — because "came back and is no longer the build it was" is what upgrade can honestly verify. `installAgentServiceReady` threads the same predicate so upgrade's install branches don't wait twice.

## Five more

| Finding | Fix |
|---|---|
| The installed-but-not-running advice printed **literal backticks, no cyan** on `jit service status` and migrate's trailer (the sibling branch ten lines away had `hlCmds`) | route both through `hlCmds` |
| The `×N` log fold **understated every count by one** — the raw suffix counts what was *suppressed*, so "+1 reads" is two occurrences and the row said `×1` | render suppressed+1; tests updated to the corrected semantics |
| `jit service run`'s refusal said "an agent"; every other surface says "service" | reworded, and de-stuttered the restart hint |
| `jit service ttl 9h` blamed `--ttl` — a flag only `jit service run` takes | name the setting, not a flag the user never typed |
| `--format json` emitted `"mounts": null`, contradicting the field's own doc comment | emit `[]` |

## Deliberately not changed

`jit doctor` renders a dropped service amber while `jit status` renders it red. `kindService` is advisory **by design** so `jit doctor` never exits non-zero over a stopped service; making them agree would break that contract.

## Verification

Full `-race` suite, vet, gofmt, staticcheck, docs-gen: clean. All six fixes verified live on the VM against a running service (refusal wording, TTL error, JSON shape, log counts, styled advice). Vault returned to baseline (16 secrets / 7 groups, TTL 5m, consent ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejayf5Jz2yNwudQrUGLWnq
