### PR TITLE
Round 2 QA fixes: the durable-trail rate limit must not key on caller text

### DIFF
--- a/internal/agent/server_test.go
+++ b/internal/agent/server_test.go
@@ -1558,22 +1558,30 @@ func TestRecordServeErrorRateLimitsIdenticalFailures(t *testing.T) {
 		t.Fatalf("100 identical failures inside the gap wrote %d events, want 1", len(events))
 	}
 
+	// A distinct CAUSE under the same op does NOT get its own line: the
+	// cause quotes caller-chosen bytes, so keying on it let a prober mint a
+	// durable line per request (see
+	// TestServeErrorRateLimitIgnoresCallerText). Only a distinct op does.
 	s.recordServeError("decode", "malformed json", nil)
+	if len(events) != 1 {
+		t.Fatalf("a distinct cause under the same op must fold, got %d events", len(events))
+	}
+	s.recordServeError("reject", "rejected peer: uid mismatch", nil)
 	if len(events) != 2 {
-		t.Fatalf("a DISTINCT cause must record immediately, got %d events", len(events))
+		t.Fatalf("a DISTINCT op must record immediately, got %d events", len(events))
 	}
 
-	// Age the first pair past the gap: the next identical failure records
-	// and carries the fold (1 recorded + 99 suppressed = 100 occurrences).
+	// Age the op past the gap: the next failure records and carries the fold
+	// (1 recorded + 100 suppressed = 101 occurrences).
 	s.serveErrMu.Lock()
-	s.serveErrSeen["decode\x00request too large"].last = time.Now().Add(-2 * serveErrorMinGap)
+	s.serveErrSeen["decode"].last = time.Now().Add(-2 * serveErrorMinGap)
 	s.serveErrMu.Unlock()
 	s.recordServeError("decode", "request too large", nil)
 	if len(events) != 3 {
 		t.Fatalf("after the gap the failure must record again, got %d events", len(events))
 	}
-	if events[2].Count != 100 {
-		t.Errorf("the recorded event must carry the fold: Count = %d, want 100", events[2].Count)
+	if events[2].Count != 101 {
+		t.Errorf("the recorded event must carry the fold: Count = %d, want 101", events[2].Count)
 	}
 }
 
@@ -1958,5 +1966,45 @@ func TestThrottledDisclosedAttemptRecordsNothing(t *testing.T) {
 		if e.Kind == KindUnlock {
 			t.Fatalf("the in-memory ring carries a fabricated unlock: %+v", e)
 		}
+	}
+}
+
+// TestServeErrorRateLimitIgnoresCallerText is the regression test for a
+// bypass the pre-release bug hunt found: the limit keyed on op+cause, and
+// cause embeds the decoder's error text, which quotes bytes the CALLER
+// chose. Varying one digit per request minted a fresh key and a fresh
+// durable line — measured at ~1200 lines/sec, enough to evict the real
+// unlock/denial/grant history out of agent-history.jsonl within seconds,
+// which is precisely the eviction the limit exists to prevent. A
+// caller-influenced value can never be part of a rate-limit key.
+func TestServeErrorRateLimitIgnoresCallerText(t *testing.T) {
+	s := NewServer(filepath.Join(t.TempDir(), "x.sock"), nil, time.Minute)
+	var events []SessionEvent
+	s.OnServeError = func(e SessionEvent) { events = append(events, e) }
+
+	// Every cause distinct, exactly as a prober varying its payload gets.
+	for i := 0; i < 200; i++ {
+		s.recordServeError("decode", fmt.Sprintf("bad request: invalid character %d looking for beginning of value", i), nil)
+	}
+	if len(events) != 1 {
+		t.Fatalf("200 caller-varied causes wrote %d durable events, want 1: the flood key is caller-controllable", len(events))
+	}
+
+	// A different OP is a different fact and still records immediately.
+	s.recordServeError("reject", "rejected peer: uid mismatch", nil)
+	if len(events) != 2 {
+		t.Fatalf("a distinct op must record immediately, got %d events", len(events))
+	}
+
+	// After the gap, the op records again and carries the whole fold.
+	s.serveErrMu.Lock()
+	s.serveErrSeen["decode"].last = time.Now().Add(-2 * serveErrorMinGap)
+	s.serveErrMu.Unlock()
+	s.recordServeError("decode", "bad request: whatever", nil)
+	if len(events) != 3 {
+		t.Fatalf("after the gap the op must record again, got %d events", len(events))
+	}
+	if events[2].Count != 200 {
+		t.Errorf("the recorded event must carry the suppressed fold: Count = %d, want 200", events[2].Count)
 	}
 }

--- a/internal/agent/transport.go
+++ b/internal/agent/transport.go
@@ -229,16 +229,25 @@ func (s *Server) recordServeError(op, cause string, c *caller) {
 	if s.OnServeError == nil {
 		return
 	}
-	key := op + "\x00" + cause
+	// Keyed on the OP ALONE, never on the cause. The cause embeds the
+	// decoder's own error text, which quotes bytes the caller chose — so a
+	// prober that varies one digit ("min_protocol":1<N>0) mints a fresh key
+	// per request and every request earns its own durable line. Measured at
+	// ~1200 lines/sec, which evicts the real unlock/denial/grant history from
+	// agent-history.jsonl (trim keeps the newest half) in seconds: exactly
+	// the eviction this limit exists to prevent, walked straight through the
+	// middle of it. A caller-influenced value can never be part of a
+	// rate-limit key.
+	//
+	// The cost is real and accepted: several genuinely different decode
+	// failures inside one gap now fold into one event carrying the FIRST
+	// cause and the total Count. An investigator loses the variety, which is
+	// the lesser loss — the raw prose still lands in agent.log, and an
+	// unbounded durable trail loses everything.
+	key := op
 	now := time.Now()
 	s.serveErrMu.Lock()
 	if s.serveErrSeen == nil {
-		s.serveErrSeen = map[string]*serveErrNote{}
-	}
-	if len(s.serveErrSeen) > 64 {
-		// A prober minting DISTINCT causes must not grow this map for the
-		// process's weeks-long life; resetting forfeits some suppression
-		// counts, never events.
 		s.serveErrSeen = map[string]*serveErrNote{}
 	}
 	n := s.serveErrSeen[key]

--- a/internal/cli/guard.go
+++ b/internal/cli/guard.go
@@ -211,8 +211,8 @@ func guardCheckStdin(r io.Reader) ([]string, error) {
 	// whole read with "token too long" on a single line past its buffer, and
 	// the hook treats any failure as "clean" — so pasting a 3 MB command that
 	// happened to carry a credential got it recorded, with a raw Go error on
-	// stderr. Truncating at the bound instead still checks the first megabyte,
-	// which is where a credential in a pasted blob will be.
+	// stderr. Truncating at the bound instead still checks everything up to
+	// the cap above, which is where a credential in a pasted blob will be.
 	data, err := io.ReadAll(io.LimitReader(r, maxCheckInput))
 	if err != nil {
 		return nil, err

--- a/internal/cli/servicelaunchd.go
+++ b/internal/cli/servicelaunchd.go
@@ -518,8 +518,12 @@ var agentStartWait = 5 * time.Second
 //
 //   - sameBuildAsThisProcess: the ordinary case. The CLI doing the restart IS
 //     the binary the service will run, so build equality is exactly the
-//     postcondition, and it rules out the old process still answering while
-//     it drains its shutdown.
+//     postcondition. Note what it does NOT prove: on a same-build restart the
+//     outgoing process answers with the same build, so a Status() served by a
+//     booted-out-but-not-yet-dead listener satisfies this. The guarantee that
+//     a replacement actually starts comes from the kickstart demand (D1), not
+//     from this wait; the wait's job is to keep the success line from printing
+//     before SOMETHING answers.
 //   - movedOffBuild: `jit upgrade`. The CLI doing the restart is the OLD
 //     binary — the new one was just written to disk and is what the service
 //     will exec — so equality can NEVER hold, and demanding it made every

--- a/internal/cli/servicestatus.go
+++ b/internal/cli/servicestatus.go
@@ -69,6 +69,14 @@ type agentStatusResult struct {
 	// release-scale counterpart. Empty when the service isn't running or
 	// predates the field.
 	Version string `json:"version,omitempty"`
+	// Protocol is the running service's socket-protocol revision
+	// (agent.Protocol). It decides real behaviour — a service below
+	// protocolDisclosedGate cannot enforce the disclosed-credential prompt,
+	// so the client refuses to ask it for a machine-wide grant — and this is
+	// the only machine-readable surface that reports it. Zero when the
+	// service isn't running or predates the field, which is itself the
+	// "too old to trust with that" answer.
+	Protocol int `json:"protocol,omitempty"`
 }
 
 var agentStatusCmd = &cobra.Command{
@@ -116,7 +124,7 @@ var agentStatusCmd = &cobra.Command{
 		}
 
 		if agentStatusFormat == "json" {
-			result := agentStatusResult{Running: true, Installed: agentInstalled(), Unlocked: st.Unlocked, Mounts: st.Mounts, LastUnlock: st.LastUnlock, LastLock: st.LastLock, PendingUnlock: st.PendingUnlock, Build: st.Build, Version: st.Version}
+			result := agentStatusResult{Running: true, Installed: agentInstalled(), Unlocked: st.Unlocked, Mounts: st.Mounts, LastUnlock: st.LastUnlock, LastLock: st.LastLock, PendingUnlock: st.PendingUnlock, Build: st.Build, Version: st.Version, Protocol: st.Protocol}
 			if st.Unlocked {
 				result.LocksInSeconds = int64(st.Remaining.Round(time.Second).Seconds())
 			}


### PR DESCRIPTION
Second pre-release QA round (adversarial + integrations). One finding was in **this release's own code** and is fixed here; three pre-existing ones are filed as #77, #78, #79 rather than fixed mid-release.

## The fix that matters

Phase 3's socket-error rate limit keyed on `op + cause` — and `cause` embeds the JSON decoder's error text, which quotes bytes the **caller** chose. Varying one digit (`"min_protocol":1<N>0`) minted a fresh key and a fresh durable line per request: **measured at ~1200 lines/sec**, enough to evict every real unlock, denial, approval and grant out of `agent-history.jsonl` within seconds — precisely the eviction the limit exists to prevent.

Not a regression (before phase 3 there was no limit at all), but an incomplete fix presented as complete. Now keyed on the **op alone**. Accepted cost, recorded in the code: several distinct decode failures inside one gap fold into one event carrying the first cause and the total Count. The raw prose still lands in `agent.log`; an unbounded durable trail loses everything.

Tests: the old one asserted the *vulnerable* semantics (distinct cause records immediately) and now asserts the correct ones; a new one fires 200 caller-varied causes and requires exactly one durable event.

## Also

- `jit service status --format json` now reports `protocol`. It decides real behaviour (a service below the disclosed gate is refused a machine-wide grant) and was readable from no machine-readable surface.
- `sameBuildAsThisProcess`'s comment claimed it rules out the draining old process. It doesn't — on a same-build restart the outgoing process answers with the same build. The kickstart demand is the guarantee; the comment now says so.
- guard's input-cap comment said "first megabyte" while the cap is 4 MiB.

## Verification

Full `-race` suite, vet, gofmt, staticcheck: clean. Vault verified back at baseline after both QA passes (16 secrets / 7 groups / 103 backups / 2 registered mounts, TTL 5m, consent ON).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ejayf5Jz2yNwudQrUGLWnq