### PR TITLE
Fix the three open pre-release QA findings (#77, #78, #79)

### DIFF
--- a/docs/reference/commands/jit_migrate.md
+++ b/docs/reference/commands/jit_migrate.md
@@ -16,8 +16,8 @@ full plan — every file it will rewrite and every CLI it will wrap — and
 asks for confirmation before touching anything. It is exactly the command
 the scan report's "jit will protect these" section points at.
 
-With arguments, nothing is discovered or touched except the targets you
-name. Each target is resolved on its own:
+With arguments, discovery is scoped to the targets you name (plus the
+agent-cache sweep described below). Each target is resolved on its own:
 
   A file       is routed to the right category by what it is. A project file
                (.env, *.tfvars, mcp.json/.mcp.json, .npmrc) has its secrets
@@ -44,6 +44,13 @@ naming a file is itself the decision to convert it. Every run prints the full
 plan and asks for confirmation before touching anything, and every modified
 file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`
 restores a migrated file from that backup.
+
+After vaulting, the run also clears verbatim copies of the newly vaulted
+credentials from AI agent caches under your home directory — files beyond
+the targets you named, each listed in the plan and backed up before it is
+touched. Only values the scanner counts as secrets are hunted; ordinary
+config a .env migration vaults alongside them is not. `--only` without the
+`cache` category skips the sweep entirely.
 
 With the 1Password CLI installed and signed in, a value that already lives
 in 1Password is vaulted as an op:// reference instead of a copy (one
@@ -73,7 +80,7 @@ jit migrate <file-or-dir>... [flags]
       --dry-run        preview the plan without changing anything
       --mount          for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content
       --no-1password   store plain copies even when a value already lives in 1Password (default: matching values are vaulted as op:// references)
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```
 

--- a/docs/reference/commands/jit_migrate_caches.md
+++ b/docs/reference/commands/jit_migrate_caches.md
@@ -38,7 +38,7 @@ jit migrate caches
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/docs/reference/commands/jit_migrate_path.md
+++ b/docs/reference/commands/jit_migrate_path.md
@@ -21,7 +21,7 @@ jit migrate path <file-or-dir>... [flags]
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/docs/reference/commands/jit_migrate_remove.md
+++ b/docs/reference/commands/jit_migrate_remove.md
@@ -62,7 +62,7 @@ jit migrate remove <file-or-dir>... [flags]
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
 ```
 

--- a/docs/reference/commands/jit_migrate_undo.md
+++ b/docs/reference/commands/jit_migrate_undo.md
@@ -55,7 +55,7 @@ jit migrate undo <path>...
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/internal/audit/agentcache.go
+++ b/internal/audit/agentcache.go
@@ -289,6 +289,46 @@ func eligibleNeedle(v string) bool {
 // read-only scanner and must not depend on the package that writes.
 const pointerValuePrefix = pointerfile.ValuePrefix
 
+// CacheNeedle is one variable/value pair the agent-cache hunt would search
+// for, exported for internal/migrate's cleanup sweep.
+type CacheNeedle struct {
+	Key   string
+	Value string
+}
+
+// EnvFileCacheNeedles reports the needles the agent-cache cross-reference
+// below would hunt for ONE env file: the values the env scanner judges to
+// be real credentials (Finding.claimedRawValues), gated on CountedAsSecret
+// and eligibleNeedle — the same predicate crossReferenceAgentCaches
+// applies, computed by the same classifier.
+//
+// It exists for `jit migrate`, whose env migration deliberately vaults
+// EVERY variable of a .env (ordinary config too, so the pointer file stays
+// complete) and then hunts agent caches for copies of what it vaulted.
+// Hunting every vaulted value meant splicing <jit:redacted:APP_NAME>
+// markers through transcripts under $HOME the user never named, on the
+// strength of an application name (issue #79). EligibleNeedle alone cannot
+// stop that — it tests distinctiveness, not secretness. Read-only and
+// best-effort: an unreadable or finding-free file contributes nothing.
+func EnvFileCacheNeedles(path string) []CacheNeedle {
+	var cfg Config // zero value: the default (filtered) gates scan itself uses
+	findings := classifyEnvFile(cfg, path, filepath.Base(path))
+	tagArchivedAndFixtures(findings) // CountedAsSecret reads TestFixture
+	var out []CacheNeedle
+	for _, f := range findings {
+		if !CountedAsSecret(f) {
+			continue
+		}
+		for _, cv := range f.claimedRawValues {
+			if !eligibleNeedle(cv.Value) {
+				continue
+			}
+			out = append(out, CacheNeedle(cv))
+		}
+	}
+	return out
+}
+
 // crossReferenceAgentCaches searches every present AI agent cache for verbatim
 // copies of the credentials findings already confirmed, and returns one
 // finding per (file, credential).

--- a/internal/audit/agentcache_test.go
+++ b/internal/audit/agentcache_test.go
@@ -88,6 +88,36 @@ func TestEligibleNeedle(t *testing.T) {
 	}
 }
 
+// TestEnvFileCacheNeedlesGatesOnSecretness pins the #79 fix's seam: migrate's
+// sweep needles for a .env come from this helper, which must admit only what
+// the scan-side hunt would — claimed credential values, CountedAsSecret,
+// eligibleNeedle. APP_NAME=jit-e2e-demo passes eligibleNeedle (12 chars,
+// mixed classes), which is exactly how it became a needle that spliced
+// redaction markers through a live agent transcript.
+func TestEnvFileCacheNeedlesGatesOnSecretness(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	writeTree(t, env, "APP_NAME=jit-e2e-demo\nSTRIPE_KEY="+realKey+"\nPORT=8080\n")
+
+	needles := EnvFileCacheNeedles(env)
+	if len(needles) != 1 {
+		t.Fatalf("needles = %+v, want exactly the one claimed credential", needles)
+	}
+	if needles[0].Key != "STRIPE_KEY" || needles[0].Value != realKey {
+		t.Errorf("needle = %+v, want STRIPE_KEY/%s", needles[0], realKey)
+	}
+	for _, n := range needles {
+		if n.Value == "jit-e2e-demo" {
+			t.Error("an ordinary app name must never become a sweep needle")
+		}
+	}
+
+	// Best-effort contract: a missing file contributes nothing, never errors.
+	if got := EnvFileCacheNeedles(filepath.Join(dir, "absent.env")); got != nil {
+		t.Errorf("EnvFileCacheNeedles(missing) = %+v, want nil", got)
+	}
+}
+
 // The headline case: a credential in a .env, copied verbatim into an agent's
 // file cache. env_file_present is a FILE-level finding with no value of its
 // own, so this only works because the env scanner hands its parsed values up

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -95,7 +95,11 @@ var (
 // Keyed by the short token a caller passes, not the display label used in
 // output — keep the two lists in this exact order so error messages and
 // --only's own help text stay in sync with printMigratePlan.
-var migrateCategories = []string{"env", "tfvars", "k8s-secret", "shell", "history", "mcp", "aws", "kube", "terraform", "docker", "git", "gcp", "sops", "npmrc", "netrc", "pypirc", "loose"}
+// "cache" is the one category with no file list of its own: it scopes the
+// post-migrate agent-cache sweep, which rewrites files under $HOME that the
+// run's other categories never name. Before it existed, --only env still ran
+// the sweep and NO token could scope it out (issue #79).
+var migrateCategories = []string{"env", "tfvars", "k8s-secret", "shell", "history", "mcp", "aws", "kube", "terraform", "docker", "git", "gcp", "sops", "npmrc", "netrc", "pypirc", "loose", "cache"}
 
 // discovered holds one run's findings per category. runMigratePath resolves
 // each named target into one of these and hands it to applyMigrate — the
@@ -393,8 +397,8 @@ var migrateCmd = &cobra.Command{
 		"full plan — every file it will rewrite and every CLI it will wrap — and\n" +
 		"asks for confirmation before touching anything. It is exactly the command\n" +
 		"the scan report's \"jit will protect these\" section points at.\n\n" +
-		"With arguments, nothing is discovered or touched except the targets you\n" +
-		"name. Each target is resolved on its own:\n\n" +
+		"With arguments, discovery is scoped to the targets you name (plus the\n" +
+		"agent-cache sweep described below). Each target is resolved on its own:\n\n" +
 		"  A file       is routed to the right category by what it is. A project file\n" +
 		"               (.env, *.tfvars, mcp.json/.mcp.json, .npmrc) has its secrets\n" +
 		"               moved into a profile and the vault, the file keeps working as a\n" +
@@ -419,6 +423,12 @@ var migrateCmd = &cobra.Command{
 		"plan and asks for confirmation before touching anything, and every modified\n" +
 		"file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`\n" +
 		"restores a migrated file from that backup.\n\n" +
+		"After vaulting, the run also clears verbatim copies of the newly vaulted\n" +
+		"credentials from AI agent caches under your home directory — files beyond\n" +
+		"the targets you named, each listed in the plan and backed up before it is\n" +
+		"touched. Only values the scanner counts as secrets are hunted; ordinary\n" +
+		"config a .env migration vaults alongside them is not. `--only` without the\n" +
+		"`cache` category skips the sweep entirely.\n\n" +
 		"With the 1Password CLI installed and signed in, a value that already lives\n" +
 		"in 1Password is vaulted as an op:// reference instead of a copy (one\n" +
 		"authenticated check per run, after you confirm), and a value that already IS\n" +
@@ -548,19 +558,26 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		"pypirc":     &pypircFiles,
 		"loose":      &looseSecretFiles,
 	}
-	if len(categorySlices) != len(migrateCategories) {
+	// len-1: "cache" is file-less (the sweep, not a file list) and lives
+	// outside the table; cacheSelected below is its whole --only handling.
+	if len(categorySlices) != len(migrateCategories)-1 {
 		return false, fmt.Errorf("jit migrate: internal error: category table (%d) out of sync with --only categories (%d)", len(categorySlices), len(migrateCategories))
 	}
 	for _, token := range migrateCategories {
+		if token == "cache" {
+			continue
+		}
 		if _, ok := categorySlices[token]; !ok {
 			return false, fmt.Errorf("jit migrate: internal error: --only category %q has no entry in the category table", token)
 		}
 	}
+	cacheSelected := true
 	if len(migrateOnly) > 0 {
 		selected, err := filterMigrateOnly(migrateOnly)
 		if err != nil {
 			return false, fmt.Errorf("jit migrate: %w", err)
 		}
+		cacheSelected = selected["cache"]
 		for token, items := range categorySlices {
 			if !selected[token] {
 				*items = nil
@@ -650,11 +667,13 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	if extras == nil {
 		extras = &planExtras{}
 	}
-	if needles := migrate.PlanNeedles(envFiles, looseSecretFiles); len(needles) > 0 {
-		if preview, err := migrate.PreviewAgentCaches(home, needles); err != nil {
-			extras.cacheNote = err.Error()
-		} else {
-			extras.cacheEdits = preview.Edited
+	if cacheSelected {
+		if needles := migrate.PlanNeedles(envFiles, looseSecretFiles); len(needles) > 0 {
+			if preview, err := migrate.PreviewAgentCaches(home, needles); err != nil {
+				extras.cacheNote = err.Error()
+			} else {
+				extras.cacheEdits = preview.Edited
+			}
 		}
 	}
 	printMigratePlan(cmd.OutOrStdout(), home, &planned, extras)
@@ -726,6 +745,11 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		}
 		vaultedSecrets = append(vaultedSecrets, migrate.AgentCacheSecret{Value: val, Var: name})
 	}
+	// Captured NOW, not at sweep time: the sweep runs last, after each .env
+	// has been rewritten into a pointer file that no longer parses as its
+	// old values. These are the values the env migration vaults as ordinary
+	// config, which the sweep must not hunt (issue #79).
+	envOrdinary := migrate.EnvOrdinaryValues(envFiles)
 	root, err := vaultRootDir()
 	if err != nil {
 		return false, fmt.Errorf("jit migrate: %w", err)
@@ -1321,7 +1345,15 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	// back into the needle set (nor matter after collection is done).
 	v.OnSet = nil
 	v.LinkOnSet = nil // the sweep's own backups must never be offered for linking
-	cleanup, cleanErr := migrate.CleanAgentCaches(v, home, vaultedSecrets)
+	// DropOrdinaryValues: needle discipline over the OnSet capture — an env
+	// migration vaults ordinary config too, and the sweep must hunt only
+	// what scan's cache hunt would (issue #79). --only without "cache"
+	// scopes the whole sweep out, matching the plan the user confirmed.
+	var cleanup migrate.AgentCacheCleanup
+	var cleanErr error
+	if cacheSelected {
+		cleanup, cleanErr = migrate.CleanAgentCaches(v, home, migrate.DropOrdinaryValues(vaultedSecrets, envOrdinary))
+	}
 
 	summary.print(out)
 	// Rendered after the file summary, through the same helper `jit migrate
@@ -1342,8 +1374,11 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	// pointer, so scan and a future migrate cannot). Binary/hard-link skips
 	// are standing conditions re-running won't fix, so they don't set a
 	// reminder — the one-time output already named them. A run with no live
-	// skips clears any stale crumb.
-	migrate.WriteCacheBreadcrumb(root, cleanup.LiveSkips(), time.Now().UnixNano())
+	// skips clears any stale crumb. A run that never swept (--only without
+	// "cache") learned nothing and must not clear one either.
+	if cacheSelected {
+		migrate.WriteCacheBreadcrumb(root, cleanup.LiveSkips(), time.Now().UnixNano())
+	}
 	reportAgentStatus(out, root, producedMount)
 	// The folder-rename advisory is left to `jit status`: an explicitly named
 	// migrate target can sit under any project, so there's no single "this

--- a/internal/cli/migrate_test.go
+++ b/internal/cli/migrate_test.go
@@ -548,6 +548,76 @@ func TestMigrateDryRunPreviewsAgentCacheSweep(t *testing.T) {
 	}
 }
 
+// TestMigrateDryRunCacheSweepIgnoresOrdinaryEnvValues pins issue #79's
+// headline failure at the plan level: an env migration vaults every
+// variable, but a cache copy of an ORDINARY value (an app name that happens
+// to be an eligible needle) must not put the cache file in the plan — the
+// sweep's needles are gated on what scan itself counts as a secret.
+func TestMigrateDryRunCacheSweepIgnoresOrdinaryEnvValues(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	const secret = "vlt09zXcVbNm2qWe4rTy6uIo8p42"
+	envPath := filepath.Join(cwd, ".env")
+	if err := os.WriteFile(envPath, []byte("APP_NAME=jit-e2e-demo\nSTRIPE_KEY="+secret+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	pastePath := filepath.Join(home, ".claude", "paste-cache", "paste1.txt")
+	if err := os.MkdirAll(filepath.Dir(pastePath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	// The cache copy holds ONLY the app name — the QA transcript case.
+	if err := os.WriteFile(pastePath, []byte("building jit-e2e-demo today\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out, err := execMigrate(t, envPath, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate <env> --dry-run: %v", err)
+	}
+	if strings.Contains(out, "[AI agent cache file]") {
+		t.Errorf("a cache copy of an ordinary value must not enter the plan, got:\n%s", out)
+	}
+	if strings.Contains(out, displayPath(home, pastePath)) {
+		t.Errorf("the cache file must not be named in the plan, got:\n%s", out)
+	}
+}
+
+// TestMigrateOnlyScopesCacheSweep: --only without "cache" excludes the
+// agent-cache sweep from the plan (before #79 no token could), and naming
+// it brings the sweep back.
+func TestMigrateOnlyScopesCacheSweep(t *testing.T) {
+	home := withFixtureHome(t)
+	cwd := withFixtureCwd(t)
+	const secret = "vlt09zXcVbNm2qWe4rTy6uIo8p42"
+	envPath := filepath.Join(cwd, ".env")
+	if err := os.WriteFile(envPath, []byte("STRIPE_KEY="+secret+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	pastePath := filepath.Join(home, ".claude", "paste-cache", "paste1.txt")
+	if err := os.MkdirAll(filepath.Dir(pastePath), 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(pastePath, []byte("here is the key: "+secret+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	out, err := execMigrate(t, envPath, "--dry-run", "--only", "env")
+	if err != nil {
+		t.Fatalf("jit migrate --only env --dry-run: %v", err)
+	}
+	if strings.Contains(out, "[AI agent cache file]") {
+		t.Errorf("--only env must scope the sweep out of the plan, got:\n%s", out)
+	}
+
+	out, err = execMigrate(t, envPath, "--dry-run", "--only", "env,cache")
+	if err != nil {
+		t.Fatalf("jit migrate --only env,cache --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "[AI agent cache file] 1") {
+		t.Errorf("--only env,cache must include the sweep in the plan, got:\n%s", out)
+	}
+}
+
 // TestPlanExtrasWrapAndGuardRows: wraps and the guard render as counted
 // plan categories with the outcome stated per row — the plan row is the
 // consent line (design/dry-run-refactor.md D3). Driven through

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -350,6 +350,15 @@ var scanCmd = &cobra.Command{
 // should be an error, not a silently empty scan (the same choice `jit migrate
 // <path>` makes). Absolute paths keep the findings' file_path locations
 // unambiguous regardless of the process's working directory.
+//
+// A symlink root the user typed by name is resolved to its target, not
+// walked as-is: the walkers refuse symlinks so a recursive walk stays
+// contained, but that policy is about descendants, and letting it apply to
+// the named root made `jit scan /etc` report CLEAN with exit 0 on a stock
+// Mac (where /etc is a symlink) while --fail-on silently passed. Findings
+// then carry the target's real path, which is the unambiguous one. `jit
+// migrate` still refuses a symlink argument — it rewrites files, scan only
+// reads them.
 func resolveScanTargets(args []string) ([]string, error) {
 	targets := make([]string, 0, len(args))
 	for _, arg := range args {
@@ -357,11 +366,22 @@ func resolveScanTargets(args []string) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("resolving %q: %w", arg, err)
 		}
-		if _, err := os.Lstat(abs); err != nil {
+		info, err := os.Lstat(abs)
+		if err != nil {
 			if os.IsNotExist(err) {
 				return nil, fmt.Errorf("no such file or directory: %s", arg)
 			}
 			return nil, fmt.Errorf("%s: %w", arg, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			resolved, err := filepath.EvalSymlinks(abs)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil, fmt.Errorf("no such file or directory: %s (a symlink whose target is gone)", arg)
+				}
+				return nil, fmt.Errorf("%s: %w", arg, err)
+			}
+			abs = resolved
 		}
 		targets = append(targets, abs)
 	}

--- a/internal/cli/scan_test.go
+++ b/internal/cli/scan_test.go
@@ -258,6 +258,63 @@ func TestScanCommandScansNamedFile(t *testing.T) {
 	}
 }
 
+// TestScanCommandFollowsSymlinkRoot pins the fix for issue #78: a symlink the
+// user names as the scan root is resolved and scanned, instead of being
+// silently skipped by the walkers' no-symlink policy — which reported CLEAN
+// with exit 0 and let --fail-on pass over a real finding (`jit scan /etc` on
+// a stock Mac, where /etc is a symlink).
+func TestScanCommandFollowsSymlinkRoot(t *testing.T) {
+	withFixtureHome(t)
+	base := t.TempDir()
+	real := filepath.Join(base, "real")
+	if err := os.Mkdir(real, 0700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	env := filepath.Join(real, ".env")
+	if err := os.WriteFile(env, []byte("STRIPE_LIVE=sk_live_4eC39HqLyjWDarjtT1zdp7dc\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	dirLink := filepath.Join(base, "link")
+	if err := os.Symlink("real", dirLink); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	fileLink := filepath.Join(base, "envlink")
+	if err := os.Symlink(filepath.Join("real", ".env"), fileLink); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	// The gate is the surface where the old behavior did real damage (a CI
+	// check silently passing), so assert through it: both symlink shapes
+	// must trip --fail-on exactly like the target itself does.
+	for _, root := range []string{dirLink, fileLink} {
+		_, err := execScan(t, root, "--fail-on", "any")
+		if err == nil {
+			t.Fatalf("scan of symlink root %s must find the target's secret and trip --fail-on, got nil", root)
+		}
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+			t.Fatalf("expected --fail-on to trip with exit 2 on %s, got: %v", root, err)
+		}
+	}
+}
+
+// TestScanCommandRejectsBrokenSymlink: a named root whose symlink target is
+// gone fails loud like any other mistyped path — never a silently empty scan.
+func TestScanCommandRejectsBrokenSymlink(t *testing.T) {
+	withFixtureHome(t)
+	link := filepath.Join(t.TempDir(), "dangling")
+	if err := os.Symlink("no-such-target", link); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+	_, err := execScan(t, link)
+	if err == nil {
+		t.Fatal("expected an error for a broken symlink root, got nil")
+	}
+	if !strings.Contains(err.Error(), "no such file or directory") {
+		t.Errorf("expected the error to say the target is missing, got: %v", err)
+	}
+}
+
 // TestScanFailOnDefaultAlwaysExitsZero pins the contract that matters most for
 // backward compatibility: without --fail-on, a scan that finds critical
 // secrets still exits 0. Anyone who already runs `jit scan` in a script must

--- a/internal/cli/wrap.go
+++ b/internal/cli/wrap.go
@@ -507,8 +507,14 @@ var wrapUndoCmd = &cobra.Command{
 				wrapBody(out, 2, "    ", hlCmds(glyphBullet+" vault secrets kept: "+strings.Join(prev.VaultPaths, ", ")+" (`jit vault rm <path>` removes one for good)"))
 			}
 			if prev.LastTool {
+				rc := displayPath(home, wrap.RcFile(home, os.Getenv("SHELL")))
 				fmt.Fprint(out, "  ")
-				wrapBody(out, 2, "    ", glyphBullet+" last wrapped tool: the shim PATH line comes out of "+displayPath(home, wrap.RcFile(home, os.Getenv("SHELL"))))
+				if len(prev.Leftovers) == 0 {
+					wrapBody(out, 2, "    ", glyphBullet+" last wrapped tool: the shim PATH line comes out of "+rc)
+				} else {
+					wrapBody(out, 2, "    ", glyphBullet+" last wrapped tool: the shim PATH line stays in "+rc+
+						" ("+strings.Join(prev.Leftovers, ", ")+" still in "+displayPath(home, wrap.ShimDir(home))+")")
+				}
 			}
 			printDryRunTrailer(out, "jit wrap undo "+tool, false)
 			return nil
@@ -523,14 +529,25 @@ var wrapUndoCmd = &cobra.Command{
 		if len(res.VaultPaths) > 0 {
 			fmt.Fprint(out, hlCmds(fmt.Sprintf("Vault secrets were kept: %s, `jit vault rm <path>` removes one for good.\n", strings.Join(res.VaultPaths, ", "))))
 		}
+		// The PATH line comes out only when the shim directory is EMPTY, not
+		// when the wrap manifest is — the docker/git credential helpers live
+		// there too (scripts wrap never counts), are found strictly by $PATH
+		// lookup, and removing the line broke their lookup in the next shell
+		// with no message (issue #77). The directory's contents are the one
+		// honest ledger of who still needs the line.
 		if res.Remaining == 0 {
 			rc := wrap.RcFile(home, os.Getenv("SHELL"))
-			changed, err := wrap.RemovePathLine(rc)
-			if err != nil {
-				return fmt.Errorf("jit wrap undo: %w", err)
-			}
-			if changed {
-				fmt.Fprintf(out, "Last wrapped tool gone, removed the shim PATH line from %s.\n", rc)
+			if len(res.Leftovers) == 0 {
+				changed, err := wrap.RemovePathLine(rc)
+				if err != nil {
+					return fmt.Errorf("jit wrap undo: %w", err)
+				}
+				if changed {
+					fmt.Fprintf(out, "Last wrapped tool gone, removed the shim PATH line from %s.\n", rc)
+				}
+			} else {
+				wrapBody(out, 0, "  ", "Last wrapped tool gone; the shim PATH line stays in "+displayPath(home, rc)+
+					": "+strings.Join(res.Leftovers, ", ")+" still in "+displayPath(home, wrap.ShimDir(home))+".")
 			}
 		}
 		return nil

--- a/internal/cli/wrap_test.go
+++ b/internal/cli/wrap_test.go
@@ -136,6 +136,43 @@ func TestWrapAddListUndoRoundTrip(t *testing.T) {
 	}
 }
 
+// TestWrapUndoKeepsPathLineWhileHelpersRemain pins the #77 fix end to end:
+// undoing the last wrapped tool must NOT remove the shim PATH line while a
+// docker/git credential helper still lives in the shim dir — docker and git
+// find those helpers strictly by $PATH lookup, and yanking the line silently
+// broke their credential lookup in the next shell.
+func TestWrapUndoKeepsPathLineWhileHelpersRemain(t *testing.T) {
+	home := withFixtureHome(t)
+	if _, err := execWrap(t, "add", "faketool", "--env", "FAKE_TOKEN=wrap-faketool/FAKE_TOKEN"); err != nil {
+		t.Fatalf("jit wrap add: %v", err)
+	}
+	helper := filepath.Join(wrap.ShimDir(home), "docker-credential-jit")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexec jit dockercred \"$@\"\n"), 0o700); err != nil { // #nosec G306 -- an executable helper script needs the execute bit
+		t.Fatal(err)
+	}
+	rc := wrap.RcFile(home, os.Getenv("SHELL"))
+
+	// The preview must promise what the real run does: the line stays.
+	out, err := execWrap(t, "undo", "faketool", "--dry-run")
+	if err != nil {
+		t.Fatalf("jit wrap undo --dry-run: %v", err)
+	}
+	if !strings.Contains(out, "stays") || !strings.Contains(out, "docker-credential-jit") {
+		t.Errorf("dry-run should say the PATH line stays and name the helper, got:\n%s", out)
+	}
+
+	out, err = execWrap(t, "undo", "faketool")
+	if err != nil {
+		t.Fatalf("jit wrap undo: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "stays") || !strings.Contains(out, "docker-credential-jit") {
+		t.Errorf("undo should say the PATH line stays and name the helper, got:\n%s", out)
+	}
+	if data, err := os.ReadFile(rc); err != nil || !strings.Contains(string(data), ".jit/shims") {
+		t.Errorf("PATH line must survive the undo while the helper needs it (err=%v):\n%s", err, data)
+	}
+}
+
 func TestWrapAddRequiresEnv(t *testing.T) {
 	withFixtureHome(t)
 	if _, err := execWrap(t, "add", "faketool"); err == nil {

--- a/internal/migrate/agentcache.go
+++ b/internal/migrate/agentcache.go
@@ -190,13 +190,15 @@ func PlanNeedles(envFiles, looseFiles []string) []AgentCacheSecret {
 		seen[value] = true
 		out = append(out, AgentCacheSecret{Value: value, Var: name})
 	}
+	// Only the values scan's own agent-cache hunt would count, NOT every
+	// variable: an env migration vaults ordinary config too (so the pointer
+	// file stays complete), but hunting a vaulted APP_NAME through files the
+	// user never named is how issue #79 spliced redaction markers into a
+	// live transcript. audit.EnvFileCacheNeedles is the scan-side predicate,
+	// so plan, apply (DropEnvOrdinaryValues) and scan can never disagree.
 	for _, path := range envFiles {
-		values, names, _, err := parseEnvFile(path)
-		if err != nil {
-			continue
-		}
-		for _, name := range names {
-			add(values[name], name)
+		for _, n := range audit.EnvFileCacheNeedles(path) {
+			add(n.Value, n.Key)
 		}
 	}
 	for _, path := range looseFiles {
@@ -213,6 +215,66 @@ func PlanNeedles(envFiles, looseFiles []string) []AgentCacheSecret {
 		}
 	}
 	return out
+}
+
+// EnvOrdinaryValues reads the given env files and reports the values an env
+// migration will vault as ordinary configuration — everything audit's own
+// cache-hunt predicate (audit.EnvFileCacheNeedles) would NOT count as a
+// secret. A value that is ordinary in one file but a claimed credential in
+// another is not ordinary — the claimed set wins.
+//
+// MUST be called BEFORE the applies run: the sweep itself runs last, by
+// which time each .env has been rewritten into a pointer file that parses
+// as neither its old values nor a finding. Read-only and best-effort — an
+// unreadable file contributes nothing, erring toward keeping needles.
+func EnvOrdinaryValues(envFiles []string) map[string]bool {
+	if len(envFiles) == 0 {
+		return nil
+	}
+	claimed := map[string]bool{}
+	for _, path := range envFiles {
+		for _, n := range audit.EnvFileCacheNeedles(path) {
+			claimed[n.Value] = true
+		}
+	}
+	ordinary := map[string]bool{}
+	for _, path := range envFiles {
+		values, names, _, err := parseEnvFile(path)
+		if err != nil {
+			continue
+		}
+		for _, name := range names {
+			if v := values[name]; v != "" && !claimed[v] {
+				ordinary[v] = true
+			}
+		}
+	}
+	return ordinary
+}
+
+// DropOrdinaryValues filters the apply-time needle set (collected via
+// vault.Vault.OnSet, i.e. every value the run vaulted) down to what the
+// sweep may hunt, removing the EnvOrdinaryValues capture. Values from every
+// other category pass through untouched: those categories only ever vault
+// real credentials.
+//
+// The asymmetry with the env migration itself is the point (issue #79):
+// vaulting ordinary config keeps the pointer file complete and touches only
+// the file the user named; the sweep rewrites files under $HOME the user
+// never named — splicing <jit:redacted:APP_NAME> markers into a live agent
+// transcript over an application name — so its needles must clear the same
+// bar scan's cache hunt applies.
+func DropOrdinaryValues(secrets []AgentCacheSecret, ordinary map[string]bool) []AgentCacheSecret {
+	if len(secrets) == 0 || len(ordinary) == 0 {
+		return secrets
+	}
+	kept := make([]AgentCacheSecret, 0, len(secrets))
+	for _, s := range secrets {
+		if !ordinary[s.Value] {
+			kept = append(kept, s)
+		}
+	}
+	return kept
 }
 
 // CleanAgentCaches removes verbatim copies of the given credentials from every

--- a/internal/migrate/agentcache_test.go
+++ b/internal/migrate/agentcache_test.go
@@ -31,6 +31,43 @@ func writeCacheTree(t *testing.T, path, content string) {
 	}
 }
 
+// TestNeedleGateDropsOrdinaryEnvValues pins the #79 fix at the migrate
+// layer: an env migration vaults EVERY variable, but neither the plan's
+// needle preview nor the apply-time sweep may hunt values scan's cache hunt
+// would not count as secrets. "jit-e2e-demo" is the shape that got through
+// before — 12 chars, mixed character classes, a perfectly eligible needle
+// and a perfectly ordinary application name.
+func TestNeedleGateDropsOrdinaryEnvValues(t *testing.T) {
+	dir := t.TempDir()
+	env := filepath.Join(dir, ".env")
+	writeCacheTree(t, env, "APP_NAME=jit-e2e-demo\nSTRIPE_KEY="+cacheKey+"\n")
+
+	needles := PlanNeedles([]string{env}, nil)
+	if len(needles) != 1 || needles[0].Value != cacheKey {
+		t.Errorf("PlanNeedles = %+v, want only the credential", needles)
+	}
+
+	ordinary := EnvOrdinaryValues([]string{env})
+	if !ordinary["jit-e2e-demo"] {
+		t.Errorf("EnvOrdinaryValues = %v, want the app name captured", ordinary)
+	}
+	if ordinary[cacheKey] {
+		t.Error("a claimed credential must never be classed ordinary")
+	}
+
+	// The OnSet capture holds env values AND other categories' credentials;
+	// only the env-ordinary ones come out.
+	vaulted := []AgentCacheSecret{
+		{Value: "jit-e2e-demo", Var: "APP_NAME"},
+		{Value: cacheKey, Var: "STRIPE_KEY"},
+		{Value: "ghp_Fq8xW2mN5rTv7yZb3cJd1kLp9sAe4u", Var: "GIT_TOKEN"},
+	}
+	kept := DropOrdinaryValues(vaulted, ordinary)
+	if len(kept) != 2 || kept[0].Value != cacheKey || kept[1].Value != "ghp_Fq8xW2mN5rTv7yZb3cJd1kLp9sAe4u" {
+		t.Errorf("DropOrdinaryValues = %+v, want the app name gone and both credentials kept", kept)
+	}
+}
+
 // The headline case: the agent's copy of a file it edited still holds the
 // credential after the .env was migrated.
 func TestCleanAgentCachesRedactsFileHistoryCopy(t *testing.T) {

--- a/internal/wrap/install.go
+++ b/internal/wrap/install.go
@@ -137,6 +137,29 @@ func RemoveShim(home, tool string) (bool, error) {
 	return true, nil
 }
 
+// ShimDirResidents lists EVERY entry in home's shim dir, sorted — symlink
+// shims and non-symlink residents alike. The docker/git credential helpers
+// are deliberately shell scripts, not symlinks, so wrap's shim dispatch
+// ignores them (see internal/migrate dockercreds.go/gitcreds.go) — but they
+// live in this directory and are found strictly by $PATH lookup, so anything
+// deciding the fate of the rc PATH line must see them. InstalledShims
+// deliberately cannot. A missing dir is an empty list, not an error.
+func ShimDirResidents(home string) ([]string, error) {
+	entries, err := os.ReadDir(ShimDir(home))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
 // InstalledShims lists the symlink names present in home's shim dir,
 // sorted. A missing dir is an empty list, not an error — a machine with no
 // wraps yet is a valid state (same contract as profile.ListNames).

--- a/internal/wrap/undo.go
+++ b/internal/wrap/undo.go
@@ -19,6 +19,13 @@ type UndoResult struct {
 	ProfilePath    string
 	VaultPaths     []string // paths the removed profile referenced, the user's to keep or `jit vault rm`
 	Remaining      int      // wrap-managed tools left after this undo
+	// Leftovers is everything still living in the shim directory after this
+	// undo — the docker/git credential helpers land here (scripts, not
+	// symlinks, so Remaining can never count them). The rc PATH line must
+	// stay while this is non-empty: docker and git find those helpers
+	// strictly by $PATH lookup, and removing the line on Remaining alone
+	// silently broke their credential lookup in the next shell (issue #77).
+	Leftovers []string
 }
 
 // UndoPreview reports what Undo WOULD remove, for `jit wrap undo
@@ -27,7 +34,12 @@ type UndoPreview struct {
 	ShimPath    string
 	ProfilePath string   // "" for grant/capture/run-grant wraps, which have no profile to remove
 	VaultPaths  []string // kept either way; listed so the preview matches the real run's output
-	LastTool    bool     // true: the real run also removes the shim PATH line from the rc
+	LastTool    bool     // true: this undo empties the wrap manifest
+	// Leftovers mirrors UndoResult.Leftovers: what would remain in the shim
+	// directory after this undo (this tool's own shim excluded). The real
+	// run only removes the rc PATH line when LastTool is true AND this is
+	// empty, and the preview must promise the same.
+	Leftovers []string
 }
 
 // PreviewUndo resolves what Undo(home, tool) would do, touching nothing.
@@ -45,6 +57,15 @@ func PreviewUndo(home, tool string) (UndoPreview, error) {
 	prev := UndoPreview{
 		ShimPath: filepath.Join(ShimDir(home), tool),
 		LastTool: len(manifest.Tools) == 1,
+	}
+	residents, err := ShimDirResidents(home)
+	if err != nil {
+		return UndoPreview{}, err
+	}
+	for _, name := range residents {
+		if name != tool {
+			prev.Leftovers = append(prev.Leftovers, name)
+		}
 	}
 	if !entry.IsGrant() && !entry.IsCapture() && !entry.IsRunGrant() {
 		prev.ProfilePath, err = profile.Path(home, entry.Profile)
@@ -116,5 +137,15 @@ func Undo(home, tool string) (UndoResult, error) {
 		return res, err
 	}
 	res.Remaining = len(manifest.Tools)
+	// After the shim removal, so this IS the leftover set — no need to
+	// exclude the tool the way PreviewUndo must. Best-effort: a listing
+	// error must not fail an undo that already converged, and an unknown
+	// directory state reads as "something might still be there", which
+	// keeps the PATH line — the fail-safe direction.
+	if leftovers, err := ShimDirResidents(home); err == nil {
+		res.Leftovers = leftovers
+	} else {
+		res.Leftovers = []string{"(unreadable shim directory)"}
+	}
 	return res, nil
 }

--- a/internal/wrap/undo_test.go
+++ b/internal/wrap/undo_test.go
@@ -5,6 +5,7 @@ package wrap
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -38,6 +39,41 @@ func TestUndoRemovesEverythingAndReportsVaultPaths(t *testing.T) {
 	}
 	if _, ok := m.Tools["gh"]; ok {
 		t.Error("manifest entry survived undo")
+	}
+}
+
+// TestUndoReportsHelperLeftovers pins the #77 fix at the package layer: a
+// credential-helper script in the shim dir (docker/git migrations write
+// those; wrap never counts them) must surface in Leftovers on both the undo
+// and its preview, so the CLI keeps the rc PATH line the helpers need.
+func TestUndoReportsHelperLeftovers(t *testing.T) {
+	home := t.TempDir()
+	addGH(t, home)
+	helper := filepath.Join(ShimDir(home), "docker-credential-jit")
+	if err := os.WriteFile(helper, []byte("#!/bin/sh\nexec jit dockercred \"$@\"\n"), 0o700); err != nil { // #nosec G306 -- an executable helper script needs the execute bit
+		t.Fatal(err)
+	}
+
+	prev, err := PreviewUndo(home, "gh")
+	if err != nil {
+		t.Fatalf("PreviewUndo: %v", err)
+	}
+	if !prev.LastTool {
+		t.Error("PreviewUndo.LastTool = false, want true for the only wrapped tool")
+	}
+	if strings.Join(prev.Leftovers, ",") != "docker-credential-jit" {
+		t.Errorf("PreviewUndo.Leftovers = %v, want just the helper (gh's own shim excluded)", prev.Leftovers)
+	}
+
+	undo, err := Undo(home, "gh")
+	if err != nil {
+		t.Fatalf("Undo: %v", err)
+	}
+	if undo.Remaining != 0 {
+		t.Errorf("Remaining = %d, want 0", undo.Remaining)
+	}
+	if strings.Join(undo.Leftovers, ",") != "docker-credential-jit" {
+		t.Errorf("Undo.Leftovers = %v, want the helper still resident", undo.Leftovers)
 	}
 }
 


### PR DESCRIPTION
Three fixes, one commit per issue, in the priority order the issues were filed.

## #79 — agent-cache sweep redacted non-secrets and rewrote unnamed files

The sweep's needles were every value the run vaulted, gated only on `EligibleNeedle` (distinctiveness, not secretness); an env migration vaults every variable, so `APP_NAME=jit-e2e-demo` became a needle that spliced redaction markers through a live `~/.claude` transcript.

- `audit.EnvFileCacheNeedles` is the new seam: the env classifier + `CountedAsSecret` + `eligibleNeedle` — the exact scan-side predicate, computed by the same code, so the two hunts can no longer disagree.
- `PlanNeedles` uses it for the plan preview; `EnvOrdinaryValues` (captured **before** the applies turn each `.env` into a pointer file) + `DropOrdinaryValues` filter the apply-time `OnSet` capture. Other categories pass through untouched — they only ever vault real credentials.
- New `cache` token in `--only`, so `--only env` no longer drags the sweep along; a run that never swept doesn't clear the cache breadcrumb.
- `--help` stops claiming nothing beyond the named targets is touched and discloses the sweep, its backups, its gate and the scope-out. Docs regenerated.

Considered and rejected: a fresh-mtime skip for the live-writer window — it would under-redact real secrets in just-written caches, the worse failure, and with ordinary values no longer needles the incident case cannot recur.

## #78 — `jit scan <symlink>` reported CLEAN, defeating `--fail-on`

`resolveScanTargets` now resolves a symlink **root** via `EvalSymlinks` (the walkers' no-symlink policy is about descendants, not the root the user typed); a dangling link fails loud. `jit scan /etc` works on a stock Mac, and both symlink shapes trip `--fail-on any` with exit 2 in tests. `jit migrate` keeps refusing symlinks — it rewrites files, scan only reads.

## #77 — `wrap undo` removed the shim PATH line docker/git still needed

The removal gate is now the shim directory's actual contents, not the wrap-manifest count: `ShimDirResidents` sees the credential-helper scripts that `InstalledShims` deliberately cannot, `Undo`/`PreviewUndo` carry the leftover set, and the CLI removes the line only when nothing at all remains — otherwise it says the line stays and names what needs it. Dry-run promises what the real run does.

## Verification

Full local gate: `go test -race ./...`, `gofmt`, `go vet`, `go mod verify/tidy`, `staticcheck`, `govulncheck`, `gosec`, `docs-gen` (committed).

Fixes #77, fixes #78, fixes #79.