### PR TITLE
service: client-side heal for a dead broker + migrate trail collapse

### DIFF
--- a/design/service-reliability.md
+++ b/design/service-reliability.md
@@ -337,6 +337,54 @@ editing, and only because it names source files — the
 `agentPlistNeedsRepoint` source guard now reads `servicecmds.go`
 instead of `agent.go`.
 
+## Addendum 2026-08-18: the client-side demand heal
+
+The v0.98.0 kickstart fixes carry a structural limit the first post-fix
+`brew upgrade` exposed: they live in the SERVICE, so they only act once a
+fixed build is already running. The upgrade that delivers a lifecycle fix
+is executed by the outgoing build — the cask has no postflight, `jit
+upgrade` steps aside for Homebrew-managed installs, and the self-retire
+watcher firing at swap time IS the old code. A broker launchd pended
+before or during that upgrade stayed dead until a human noticed
+`jit status`'s advice and typed `jit service restart` themselves.
+
+**D16. Commands that need the broker demand it.** `agent.Client` gains a
+dial-failed hook (`WithDialFailedHook`, fired at most once per Client,
+returning the retry window it earned); the CLI installs
+`healDeadService` on it in `agentClient()` whenever the plist is
+installed. On the first failed dial the heal issues one PLAIN
+`launchctl kickstart` (never `-k`, never bootstrap), prints one stderr
+notice, records a `jit service heal` line in the application audit log,
+and extends the dial wait to `agentStartWait` — a cold demand-spawn
+needs more than the respawn-gap grace. The demand is once per process;
+a kickstart launchd refuses grants nothing and the command falls
+through to `installedNotRunningAdvice` unchanged. Because the heal
+lives in the CLIENT binary — the one the user's next command runs — it
+works for the very upgrade that ships it, and retroactively for any
+broker already sitting dead. Wrap shims re-exec as `jit run`, so every
+wrapped tool invocation is a healer.
+
+The line it draws: **commands that NEED the broker heal; probes and
+reporters that ask ABOUT the broker never do.** `jit service status`,
+`jit lock` and rekey's lock bracket take `agentClientNoHeal` — a
+reporter that quietly revived the service would erase the state its
+advice describes, and locking a dead service means the goal is already
+true. The `Reachable()` probes (foreground run's refuse-to-steal,
+`ensureAgentInstalled`'s orphan gate) and `SessionUnlocked` (a Tab
+press must never spawn work) already bypass `agentClient` and stay
+bare. Build skew is deliberately NOT healed client-side: self-retire
+owns it behind the quiescent gate, and a client demand would bypass
+the gate and kill a live session mid-upgrade.
+
+Honest residuals: a wedged-but-running process holding a dead socket is
+only reported (plain kickstart no-ops on a running job; automating `-k`
+is the live-session-killer above); a bare `cat` on a mounted FIFO never
+dials the socket, so a dead broker still hangs it until the first jit
+command runs; fully headless setups run no jit command at all. Full
+coverage remains the parked `Sockets` activation — the audit trail's
+`jit service heal` records are now the field evidence for whether it is
+ever needed.
+
 ## Test plan
 
 Through the existing `launchctlRun` fake plus the new wait seam:

--- a/internal/agent/client.go
+++ b/internal/agent/client.go
@@ -57,6 +57,7 @@ const (
 type Client struct {
 	socketPath  string
 	dialRetry   time.Duration
+	dialFailed  func() time.Duration
 	waitNotify  func()
 	respTimeout time.Duration
 	// bounded records that respTimeout was deliberately shortened below the
@@ -129,6 +130,24 @@ func (c *Client) WithDialRetry(d time.Duration) *Client {
 	return c
 }
 
+// WithDialFailedHook registers fn, fired at most once per Client when a
+// dial attempt fails — the caller's one chance to CAUSE the socket to come
+// up rather than just wait for it (the CLI's hook demands a launchd start
+// of an installed-but-not-running service). fn returns how long the dial
+// should keep retrying, replacing WithDialRetry's window when longer: a
+// cold demand-spawn needs more than the respawn-gap grace that window is
+// sized for. A hook that did nothing returns 0 and changes nothing.
+//
+// At most once per Client, not per dial: a multi-call client (Status then
+// the real request) must not issue a fresh demand for every call that
+// finds the socket still dead. This package stays free of launchctl —
+// what "cause the socket to come up" means is entirely the caller's.
+// Returns c for chaining.
+func (c *Client) WithDialFailedHook(fn func() time.Duration) *Client {
+	c.dialFailed = fn
+	return c
+}
+
 // dialRetryInterval paces WithDialRetry's re-dials. 100ms matches the
 // poll the CLI's own install/restart wait uses; a respawning agent binds
 // its socket within a couple of these.
@@ -149,13 +168,24 @@ func (c *Client) Reachable() bool {
 }
 
 // dial connects to the agent socket, retrying for up to dialRetry (see
-// WithDialRetry) when set.
+// WithDialRetry) when set. A first failure fires the dial-failed hook (see
+// WithDialFailedHook), which may lengthen the retry window it just earned.
 func (c *Client) dial() (net.Conn, error) {
 	conn, err := net.DialTimeout("unix", c.socketPath, dialTimeout)
-	if err == nil || c.dialRetry <= 0 {
+	if err == nil {
+		return conn, nil
+	}
+	retry := c.dialRetry
+	if fn := c.dialFailed; fn != nil {
+		c.dialFailed = nil
+		if window := fn(); window > retry {
+			retry = window
+		}
+	}
+	if retry <= 0 {
 		return conn, err
 	}
-	deadline := time.Now().Add(c.dialRetry)
+	deadline := time.Now().Add(retry)
 	for time.Now().Before(deadline) {
 		time.Sleep(dialRetryInterval)
 		conn, err = net.DialTimeout("unix", c.socketPath, dialTimeout)

--- a/internal/agent/dialfailedhook_test.go
+++ b/internal/agent/dialfailedhook_test.go
@@ -1,0 +1,124 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package agent
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// hookSocketDir returns a /tmp-based dir for a test socket: t.TempDir() on
+// macOS lives under /var/folders/... and can push a socket path past
+// sun_path's 104-byte limit.
+func hookSocketDir(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "jit-hook-test-")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// listenAndAccept keeps a test listener draining connections so a client
+// dial completes; closed by the test via the returned listener.
+func listenAndAccept(t *testing.T, sock string) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+	return ln
+}
+
+// TestDialFailedHookCausesTheSocketAndExtendsTheWindow pins the hook's
+// contract: with NO retry window of its own, a failed dial fires the hook,
+// and the window the hook returns is what lets the retry find the socket
+// the hook just caused to exist — the CLI's service heal in miniature.
+func TestDialFailedHookCausesTheSocketAndExtendsTheWindow(t *testing.T) {
+	sock := filepath.Join(hookSocketDir(t), "agent.sock")
+
+	fired := 0
+	var ln net.Listener
+	c := NewClient(sock).WithDialFailedHook(func() time.Duration {
+		fired++
+		ln = listenAndAccept(t, sock)
+		return 2 * time.Second
+	})
+	defer func() {
+		if ln != nil {
+			_ = ln.Close()
+		}
+	}()
+
+	if !c.Reachable() {
+		t.Fatal("dial must succeed inside the hook-granted window")
+	}
+	if fired != 1 {
+		t.Fatalf("hook fired %d times, want 1", fired)
+	}
+	// The socket is up now: further dials succeed without the hook, and the
+	// hook must not fire again even if it were still armed.
+	if !c.Reachable() {
+		t.Fatal("second dial must succeed")
+	}
+	if fired != 1 {
+		t.Fatalf("hook re-fired (%d times) after being consumed", fired)
+	}
+}
+
+// TestDialFailedHookNeverFiresOnSuccess: a healthy socket means the hook is
+// dead weight that must cost nothing.
+func TestDialFailedHookNeverFiresOnSuccess(t *testing.T) {
+	sock := filepath.Join(hookSocketDir(t), "agent.sock")
+	ln := listenAndAccept(t, sock)
+	defer func() { _ = ln.Close() }()
+
+	fired := 0
+	c := NewClient(sock).WithDialFailedHook(func() time.Duration {
+		fired++
+		return time.Second
+	})
+	if !c.Reachable() {
+		t.Fatal("dial against a live listener must succeed")
+	}
+	if fired != 0 {
+		t.Fatalf("hook fired %d times on a successful dial, want 0", fired)
+	}
+}
+
+// TestDialFailedHookReturningZeroChangesNothing: a hook that could not act
+// leaves the client exactly as configured — here, no retry window at all,
+// so the failure is immediate.
+func TestDialFailedHookReturningZeroChangesNothing(t *testing.T) {
+	sock := filepath.Join(hookSocketDir(t), "agent.sock")
+
+	fired := 0
+	c := NewClient(sock).WithDialFailedHook(func() time.Duration {
+		fired++
+		return 0
+	})
+	start := time.Now()
+	if c.Reachable() {
+		t.Fatal("nothing listens; dial must fail")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("a zero-window hook must not delay the failure, took %s", elapsed)
+	}
+	if fired != 1 {
+		t.Fatalf("hook fired %d times, want 1", fired)
+	}
+}

--- a/internal/cli/agentclient.go
+++ b/internal/cli/agentclient.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"golang.org/x/term"
@@ -60,6 +61,22 @@ func SessionUnlocked() bool {
 }
 
 func agentClient() (*agent.Client, error) {
+	return configuredAgentClient(true)
+}
+
+// agentClientNoHeal is agentClient for the surfaces that must never SPAWN
+// the service as a side effect of asking about it: the health reporters
+// (`jit service status`) and the session reducers (`jit lock`, rekey's
+// lock bracket). A reporter that quietly revived what it was reporting on
+// would erase the very state its advice describes, and locking a service
+// that isn't running means the goal — no session — is already true; a
+// demand-start there trades an honest "already locked" for a pointless
+// spawn. Everything that NEEDS the broker up takes agentClient and heals.
+func agentClientNoHeal() (*agent.Client, error) {
+	return configuredAgentClient(false)
+}
+
+func configuredAgentClient(heal bool) (*agent.Client, error) {
 	root, err := vaultRootDir()
 	if err != nil {
 		return nil, err
@@ -67,6 +84,9 @@ func agentClient() (*agent.Client, error) {
 	c := agent.NewClient(agent.SocketPath(root))
 	if agentInstalled() {
 		c = c.WithDialRetry(agentRestartGrace)
+		if heal {
+			c = c.WithDialFailedHook(healDeadService)
+		}
 	}
 	c = c.WithWaitNotifier(announceTouchIDWait)
 	// A LAUNCH with no terminal on stderr is one where nobody can see the
@@ -102,6 +122,66 @@ var boundedPromptWait bool
 // timeout with room to spare, so the host reports jit's own message from the
 // server log instead of killing jit mid-handshake and blaming the server.
 const headlessPromptWait = 20 * time.Second
+
+// healDeadService is the dial-failed hook every healing agentClient carries:
+// a command that finds the socket dead while the launchd plist is installed
+// demands a start instead of failing with restart advice the user must type
+// themselves. It is the client half of the 2026-08-17 incident fix
+// (design/service-reliability.md): the service-side kickstart only acts once
+// a fixed build is already running, so the upgrade that DELIVERS a fix — and
+// any broker already sitting dead — still needed a human to notice and run
+// `jit service restart`. This demand lives in the client binary the user's
+// next command runs, so it works for the very upgrade that ships it, and
+// retroactively for a broker launchd already pended.
+//
+// Plain kickstart, never -k and never bootstrap. On a running job kickstart
+// merely reports it running, which is what makes concurrent healers (a burst
+// of wrap shims hitting a dead broker) cost one spawn and no kills; on a
+// dropped job it fails and the command falls through to
+// installedNotRunningAdvice, which already tells that state apart.
+// Re-registering a dropped job stays `jit service restart`'s work. Build
+// skew is deliberately NOT healed here: the service's own self-retire owns
+// it, behind the quiescent gate that keeps an upgrade from killing a live
+// session — a client-side demand would bypass that gate.
+//
+// Returns agentStartWait when the demand went out, so the dial waits out a
+// cold spawn (agentRestartGrace is sized for a respawn already in flight,
+// not a fresh exec), and 0 when it didn't — the dial keeps its ordinary
+// grace and the existing advice paths do their work.
+func healDeadService() time.Duration {
+	var window time.Duration
+	agentHealOnce.Do(func() {
+		fmt.Fprintln(os.Stderr, serviceHealNotice)
+		if _, err := launchctlRun("kickstart", agentServiceTarget()); err != nil {
+			return
+		}
+		by := invocationCommandPath
+		if by == "" {
+			by = "jit"
+		}
+		// The heal must stay visible after it succeeds: a surface that
+		// quietly fixes the dead-broker state would also erase the field
+		// evidence of how often launchd pends spawns — the signal that
+		// decides whether the parked Sockets-activation work is ever needed.
+		// Args mimic argv words, not prose: commandEntry renders (and --grep
+		// matches) "jit " + args, so prose here made the line lose "heal".
+		recordSideEffect("jit service heal",
+			[]string{"service", "heal", "(was not running; demanded start)"}, by)
+		window = agentStartWait
+	})
+	return window
+}
+
+// serviceHealNotice is the one stderr line healDeadService prints, so the
+// seconds the demand-spawn takes read as jit doing something rather than a
+// silent hang — the same job announceTouchIDWait does for a prompt wait.
+// stderr, like every transient notice, so it never corrupts stdout output.
+const serviceHealNotice = "the background service isn't running; starting it..."
+
+// agentHealOnce bounds healDeadService to one demand per process: if the
+// service cannot come up, the command should fail with the honest advice,
+// not churn launchd with repeated demands. Tests reset it.
+var agentHealOnce sync.Once
 
 // announceTouchIDWait is the wait notifier every CLI agent client carries: it
 // prints one line to stderr when a request has been blocked long enough to

--- a/internal/cli/agentheal_test.go
+++ b/internal/cli/agentheal_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/agent"
+	"github.com/jitpass/jit/internal/auditlog"
+)
+
+// These are healDeadService's tests: the client-side demand that revives an
+// installed-but-not-running service on the first command that needs it,
+// instead of failing with restart advice (design/service-reliability.md's
+// addendum; the 2026-08-17 pended-spawn incident is why the demand exists).
+// The launchctlRun seam plays launchd; a real agent.Server on a real socket
+// plays the spawn it grants.
+
+// healFixture installs the preconditions the heal keys on: a temp HOME, the
+// launchd plist marker (agentInstalled must answer true), the vault root
+// dir, and a fresh once-guard so tests don't observe each other's heal.
+func healFixture(t *testing.T) (home, root string) {
+	t.Helper()
+	home = shortFixtureHome(t)
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(plistDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(plistDir, agentPlistLabel+".plist"), []byte("<plist/>"), 0o600); err != nil {
+		t.Fatalf("writing plist marker: %v", err)
+	}
+	root = filepath.Join(home, "Library", "Application Support", "jitpass")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	agentHealOnce = sync.Once{}
+	t.Cleanup(func() { agentHealOnce = sync.Once{} })
+	return home, root
+}
+
+// TestAgentClientHealsDeadService is the whole feature end to end: the
+// socket is dead, the plist is installed, and the SAME invocation that
+// found it dead succeeds — one plain kickstart (never -k), the spawn it
+// grants answered within the extended window, and the heal left its
+// evidence in the application audit log rather than hiding the incident.
+func TestAgentClientHealsDeadService(t *testing.T) {
+	_, root := healFixture(t)
+
+	mek := bytes.Repeat([]byte{0x24}, 32)
+	ctx, cancel := context.WithCancel(context.Background())
+	var server *agent.Server
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		cancel()
+		if server != nil {
+			_ = server.Close()
+			<-done
+		}
+	})
+
+	var calls [][]string
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		calls = append(calls, args)
+		if args[0] == "kickstart" {
+			// launchd honoring the demand: the service comes up.
+			server = agent.NewServer(agent.SocketPath(root), func() agent.MEKFetcher { return &fakeMEKFetcher{key: mek} }, time.Minute)
+			if err := server.Listen(); err != nil {
+				t.Errorf("Listen: %v", err)
+			}
+			go func() { _ = server.Serve(ctx); close(done) }()
+		}
+		return nil, nil
+	}
+
+	c, err := agentClient()
+	if err != nil {
+		t.Fatalf("agentClient: %v", err)
+	}
+	if _, err := c.Status(); err != nil {
+		t.Fatalf("Status must succeed on the healing invocation itself, got: %v", err)
+	}
+
+	if len(calls) != 1 || calls[0][0] != "kickstart" {
+		t.Fatalf("want exactly one kickstart, got %v", calls)
+	}
+	for _, a := range calls[0] {
+		// -k would kill a process launchd may have just spawned; the heal
+		// only ever starts, never restarts.
+		if a == "-k" {
+			t.Fatalf("heal kickstart must not use -k: %v", calls[0])
+		}
+	}
+	if calls[0][len(calls[0])-1] != agentServiceTarget() {
+		t.Errorf("kickstart must target the service, got %v", calls[0])
+	}
+
+	var healed bool
+	for _, r := range auditlog.New(root, io.Discard).Load(0) {
+		if r.Command == "jit service heal" {
+			healed = true
+		}
+	}
+	if !healed {
+		t.Error("the heal must leave a 'jit service heal' record in the audit log")
+	}
+}
+
+// TestHealDeadServiceOnceAndFailureAddsNothing: a kickstart launchd refuses
+// (a dropped job) grants no extra wait — the command falls through to the
+// existing advice — and the demand is one per process, not one per dial.
+func TestHealDeadServiceOnceAndFailureAddsNothing(t *testing.T) {
+	_, root := healFixture(t)
+
+	var calls int
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		calls++
+		return []byte(`Could not find service "com.jitpass.agent" in domain for user gui: 502`), errors.New("exit status 113")
+	}
+
+	if w := healDeadService(); w != 0 {
+		t.Fatalf("a refused kickstart must grant no extra window, got %s", w)
+	}
+	if w := healDeadService(); w != 0 {
+		t.Fatalf("second call must be a no-op, got %s", w)
+	}
+	if calls != 1 {
+		t.Fatalf("want exactly one launchctl call across repeated heals, got %d", calls)
+	}
+	for _, r := range auditlog.New(root, io.Discard).Load(0) {
+		if r.Command == "jit service heal" {
+			t.Error("a failed demand must not be recorded as a heal")
+		}
+	}
+}
+
+// TestReportersAndReducersNeverHeal pins the needs-vs-probes line: the
+// health reporter (`jit service status`) and the session reducer (`jit
+// lock`) keep telling the truth about a dead service instead of quietly
+// reviving it, and the prompt-free shim probe (SessionUnlocked) spawns
+// nothing on a Tab press.
+func TestReportersAndReducersNeverHeal(t *testing.T) {
+	healFixture(t)
+
+	var kickstarts int
+	restore := launchctlRun
+	t.Cleanup(func() { launchctlRun = restore })
+	launchctlRun = func(args ...string) ([]byte, error) {
+		if args[0] == "kickstart" {
+			kickstarts++
+		}
+		// queryLaunchdJobState's "print" lands here too: a definitively
+		// not-loaded job, so the advice paths have a state to phrase.
+		return []byte(`Could not find service "com.jitpass.agent" in domain for user gui: 502`), errors.New("exit status 113")
+	}
+
+	if SessionUnlocked() {
+		t.Fatal("SessionUnlocked must answer false against a dead socket")
+	}
+
+	agentStatusFormat = "text"
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"service", "status"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("jit service status: %v", err)
+	}
+
+	out.Reset()
+	rootCmd.SetArgs([]string{"lock"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("jit lock: %v", err)
+	}
+	if got := out.String(); !bytes.Contains([]byte(got), []byte("Already locked")) {
+		t.Errorf("jit lock against a dead service must stay honest, got %q", got)
+	}
+
+	if kickstarts != 0 {
+		t.Fatalf("reporters/reducers issued %d kickstarts, want 0", kickstarts)
+	}
+}

--- a/internal/cli/format.go
+++ b/internal/cli/format.go
@@ -38,6 +38,31 @@ func newProgress(cmd *cobra.Command, machineMode bool) *ui.Tracker {
 	return ui.New(cmd.ErrOrStderr(), enabled, animate)
 }
 
+// collapsedCategoryTrail wires an audit scan's per-category progress onto
+// progress as SCAFFOLDING: the steps animate while the walk runs (a
+// ten-second home walk must not look hung), their settled lines are marked
+// transient, and the returned settle func replaces the whole trail with one
+// "N categories scanned" line. Settle BEFORE any result is written — the
+// trail lives on stderr and its in-place line must be finished before
+// stdout output begins.
+//
+// One component for `jit scan` and `jit migrate`, whose pre-plan walk is
+// the same sixteen categories. Migrate long kept all sixteen "✓ Scanned …"
+// lines above its plan on the reasoning that settled trail lines record
+// what a command CHANGED — but the walk changes nothing, and the plan
+// (like the scan report before it) then fought sixteen lines of its own
+// scaffolding for a short window. The rekey trail stays uncollapsed: its
+// settled lines really are the record of work done.
+func collapsedCategoryTrail(progress *ui.Tracker) (step func(category string), settle func()) {
+	progress.Collapse()
+	return func(category string) {
+			progress.Step("Scanning "+category+"…", "Scanned "+category)
+		}, func() {
+			progress.StopCollapsed(fmt.Sprintf("%s scanned",
+				countWord(progress.Steps(), "category", "categories")))
+		}
+}
+
 // validateOutputFormat is the shared --format check for commands whose
 // machine-readable output is a single JSON snapshot rather than a stream
 // of records — doctor, vault list, agent status, and jit status

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -1421,11 +1421,10 @@ func runMigrateAll(cmd *cobra.Command) error {
 	}
 
 	progress := newProgress(cmd, false)
-	defer progress.Stop()
-	cfg.Progress = func(category string) {
-		progress.Step("Scanning "+category+"…", "Scanned "+category)
-	}
+	step, settleTrail := collapsedCategoryTrail(progress)
+	cfg.Progress = step
 	findings, summary, err := audit.Scan(cfg)
+	settleTrail()
 	if err != nil {
 		return fmt.Errorf("jit migrate: %w", err)
 	}
@@ -1478,7 +1477,6 @@ func runMigrateAll(cmd *cobra.Command) error {
 	}
 
 	if len(files) == 0 && len(tools) == 0 && !offerGuard {
-		progress.Stop()
 		fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Nothing to protect — the scan found no secrets jit can act on. Run `jit scan` for the full picture."))
 		return nil
 	}
@@ -1493,7 +1491,6 @@ func runMigrateAll(cmd *cobra.Command) error {
 		}
 	}
 	d.dedupe()
-	progress.Stop()
 
 	out := cmd.OutOrStdout()
 	if d.total() == 0 && len(tools) == 0 && !offerGuard {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -125,6 +125,15 @@ func newRootCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFirstRun(cmd)
 		},
+		// Captures the resolved command path before any RunE, for code that
+		// runs mid-command with no *cobra.Command in reach (the service heal's
+		// audit record names which command found the broker dead). NOTE: cobra
+		// runs only the NEAREST PersistentPreRun in the command chain — no
+		// subcommand defines one today, and any that does must set
+		// invocationCommandPath itself or this record loses its "(by ...)".
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			invocationCommandPath = cmd.CommandPath()
+		},
 	}
 	cmd.AddGroup(
 		&cobra.Group{ID: groupWorkflow, Title: "Find & fix exposed secrets:"},
@@ -364,6 +373,12 @@ func Execute() error {
 // record itself before Execute regains control — `jit run`, which ends in
 // syscall.Exec and never returns.
 var invocationStart time.Time
+
+// invocationCommandPath is the resolved command path of the invocation being
+// run ("jit vault get"), set by the root PersistentPreRun above. Empty until
+// a command actually dispatches (completion, help). Portable file on purpose:
+// the darwin-only heal reads it, but root.go owns the cobra lifecycle.
+var invocationCommandPath string
 
 // invocationRecorded is set once a command has written its own audit line, so
 // Execute does not record it a second time.

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -226,23 +226,13 @@ var scanCmd = &cobra.Command{
 
 		machineScan := scanFormat == "ndjson" || scanFormat == "markdown" || scanFormat == "md" || scanOutput != ""
 		progress := newProgress(cmd, machineScan)
-		// The trail is scaffolding for either view, not part of the result: a
-		// scan report is a page the reader works down, and sixteen settled
-		// "✓ Scanned …" lines pushed its top off a short window. They still
-		// animate while the scan runs — a ten-second home walk must not look
-		// hung — and collapse to one line the moment it finishes.
-		//
-		// --full used to keep its trail, on the reasoning that per-category
-		// lines above an inventory read as a table of contents. They don't:
-		// the actual table of contents is the category count table three lines
-		// below the header, which carries the same sixteen names AND their
-		// counts. So the trail was sixteen lines of duplication at the top of
-		// the longest view in the tool, and it was the largest remaining
-		// difference between the two views of one command.
-		progress.Collapse()
-		cfg.Progress = func(category string) {
-			progress.Step("Scanning "+category+"…", "Scanned "+category)
-		}
+		// The trail is scaffolding, not result (see collapsedCategoryTrail).
+		// --full gets the collapse too: its per-category lines were once kept
+		// as a table of contents, but the category count table three lines
+		// below the header carries the same sixteen names AND their counts,
+		// so the trail was pure duplication at the top of the longest view.
+		step, settleTrail := collapsedCategoryTrail(progress)
+		cfg.Progress = step
 
 		var findings []audit.Finding
 		var summary audit.ScanSummary
@@ -256,11 +246,7 @@ var scanCmd = &cobra.Command{
 		} else {
 			findings, summary, err = audit.Scan(cfg)
 		}
-		// Stop before any result is written — the trail lives on stderr, but
-		// the spinner's in-place line must be settled before stdout output (or
-		// the confirm-free score line) begins.
-		progress.StopCollapsed(fmt.Sprintf("%s scanned",
-			countWord(progress.Steps(), "category", "categories")))
+		settleTrail()
 		if err != nil {
 			return fmt.Errorf("jit scan: %w", err)
 		}

--- a/internal/cli/servicecmds.go
+++ b/internal/cli/servicecmds.go
@@ -360,7 +360,10 @@ var lockCmd = &cobra.Command{
 		"live-mounted files serve placeholder values until then.",
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := agentClient()
+		// NoHeal: a not-running service holds no session, so the state lock
+		// wants is already true — demand-starting one just to lock it would
+		// trade the honest "Already locked" below for a pointless spawn.
+		c, err := agentClientNoHeal()
 		if err != nil {
 			return fmt.Errorf("jit lock: %w", err)
 		}

--- a/internal/cli/servicestatus.go
+++ b/internal/cli/servicestatus.go
@@ -94,7 +94,9 @@ var agentStatusCmd = &cobra.Command{
 			return fmt.Errorf("jit service status: %w", err)
 		}
 
-		client, err := agentClient()
+		// NoHeal: a health reporter that quietly revived the service would
+		// erase the very state its advice describes (see agentClientNoHeal).
+		client, err := agentClientNoHeal()
 		if err != nil {
 			return fmt.Errorf("jit service status: %w", err)
 		}

--- a/internal/cli/vaultrekey.go
+++ b/internal/cli/vaultrekey.go
@@ -156,7 +156,9 @@ var vaultRekeyCmd = &cobra.Command{
 // bracket around the rotation. Deliberately quiet on failure: no agent
 // (or an unreachable one) is the common, fine case.
 func lockAgent() {
-	if c, err := agentClient(); err == nil && c.Reachable() {
+	// NoHeal: a dead service already holds no session — the bracket's goal —
+	// so demand-starting one just to lock it would be a pointless spawn.
+	if c, err := agentClientNoHeal(); err == nil && c.Reachable() {
 		_ = c.Lock()
 	}
 }

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -144,9 +144,12 @@ func (t *Tracker) Stop() {
 // that earns its keep (a home scan takes ten seconds and must not look hung);
 // only their residue goes.
 //
-// Opt-in, and only meaningful in animate mode: `jit migrate` and `vault rekey`
-// keep their trails because there the settled lines are a record of what was
-// changed, not scaffolding. A dumb terminal cannot erase, so it is unaffected
+// Opt-in, and only meaningful in animate mode: `vault rekey` keeps its trail
+// because there the settled lines are a record of what was changed, not
+// scaffolding — the same reasoning that long kept `jit migrate`'s trail,
+// wrongly: its sixteen lines narrate the pre-plan category WALK, which
+// changes nothing, so migrate now collapses like scan (see the CLI's
+// collapsedCategoryTrail). A dumb terminal cannot erase, so it is unaffected
 // and keeps its one-line-per-step feedback.
 func (t *Tracker) Collapse() {
 	t.mu.Lock()


### PR DESCRIPTION
Two changes, both validated live on a real launchd (edge cases below).

## 1. Client-side service heal (design/service-reliability.md D16)

The v0.98.0 kickstart fixes live in the service, so they only act once a fixed build is already running — the upgrade that *delivers* a lifecycle fix is executed by the outgoing build (no cask postflight, `jit upgrade` steps aside for Homebrew, the swap-time self-retire IS the old code). A broker launchd pended before or during that upgrade stayed dead until a human read the advice and typed `jit service restart`.

Now the client heals it:

- `agent.Client` gains `WithDialFailedHook` — fired at most once per Client on the first failed dial; the window it returns extends the retry deadline. The package stays free of launchctl.
- `agentClient` installs `healDeadService` whenever the plist is installed: one **plain** `launchctl kickstart` (never `-k`, never bootstrap), one stderr notice, a `jit service heal` record in the application audit log, and the dial wait extended to `agentStartWait` — a cold demand-spawn needs more than the respawn-gap grace.
- A refused kickstart grants nothing; the command falls through to `installedNotRunningAdvice` unchanged.
- **Needs vs probes:** commands that need the broker heal; surfaces that ask about it never do. `jit service status`, `jit lock` and rekey's lock bracket move to `agentClientNoHeal`; the `Reachable()` probes and `SessionUnlocked` already bypass `agentClient` and stay bare. Build skew is deliberately NOT healed client-side — self-retire owns it behind the quiescent gate.

Because the heal lives in the client binary the user's next command runs, it works for the very upgrade that ships it, and retroactively for a broker already sitting dead. Wrap shims re-exec as `jit run`, so every wrapped tool invocation is a healer.

Edge cases validated on this Mac (real launchd):

| State | Result |
|---|---|
| loaded, spawn pended (the 2026-08-17 incident shape) | same invocation heals and succeeds, exit 0, audit record |
| job dropped (bootout) | one refused demand, honest "launchd has dropped it" advice, exit 1, no bootstrap behind the user's back |
| reporters (`service status`, `lock`) against dead broker | truthful output, zero spawns |
| wedged (running process, dead socket) | one no-op demand, bounded 5s, honest advice, recoverable |

## 2. Migrate's category walk collapses like scan's

Bare `jit migrate` (and `--dry-run`) left sixteen settled "Scanned …" lines above its plan while `jit scan` collapses the same walk to one "16 categories scanned" line. The walk changes nothing, so the trail is scaffolding, not a record. One shared component (`collapsedCategoryTrail` in format.go) now owns the pattern and both commands call it, so they can't drift again. Path-scoped migrate's per-target lines and rekey's trail stay: those really are a record.

## Tests

- `internal/agent`: hook fires once, never on success, zero-window changes nothing.
- `internal/cli`: end-to-end heal against a real socket (one kickstart, no `-k`, audit record present), refused-kickstart once-semantics, and a pin that reporters/reducers/Tab-completion issue zero kickstarts.
- Full `go test -race`, gofmt, vet, staticcheck, govulncheck, gosec all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9gMZinyQE6rBopopQW61q
