### PR TITLE
audit: fold a serve at cycle end, so an empty touch stops reading as served

### DIFF
--- a/internal/agent/protocol.go
+++ b/internal/agent/protocol.go
@@ -476,6 +476,15 @@ type SessionEvent struct {
 	// discipline the mount read-storm logging already applies. Zero/one
 	// everywhere else.
 	Count int64 `json:"count,omitempty"`
+	// Undelivered, on serve events, marks a cycle whose reader received
+	// NOTHING: the write hit EPIPE, proof that zero processes held the read
+	// end by the time content was sent. The verdict (Op) still records what
+	// WOULD have been served — but a touch-and-go reader (a backup tool, an
+	// indexer, a VM file-sharing sweep) that opens and closes without
+	// reading used to be logged as "decoy served", overstating exposure.
+	// False (the default, and the value on every event from before this
+	// field) means content reached the pipe with a reader attached.
+	Undelivered bool `json:"undelivered,omitempty"`
 	// AuthMethod, on the events that involved a FRESH local-auth challenge
 	// (unlock and denied), is a best-effort description of how the user was
 	// asked: "Touch ID or device passcode" when biometry is enrolled on this
@@ -567,4 +576,8 @@ type MountServeEvent struct {
 	// grant (every attached reader verified inside the granted process
 	// tree) rather than by a reveal window. Always false on decoy serves.
 	GrantServed bool `json:"grant_served,omitempty"`
+	// Undelivered marks a cycle whose reader received nothing (the write
+	// hit EPIPE — zero readers held the pipe). Decoy still records the
+	// verdict that was decided; this records that it never arrived.
+	Undelivered bool `json:"undelivered,omitempty"`
 }

--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -459,6 +459,11 @@ type auditEntry struct {
 	subject string
 	detail  string
 	action  string
+
+	// undelivered marks a serve row whose reader received nothing (EPIPE
+	// before the write) — the header counts those apart from decoy reads,
+	// because an empty touch and a delivered decoy are different findings.
+	undelivered bool
 }
 
 // printAuditLog merges command records and auth events into one reverse-
@@ -944,9 +949,16 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 			lineColor = cWarn
 		}
 		reader := serveReaderName(e)
-		if status == agent.OpServeDecoy {
+		switch {
+		case e.Undelivered:
+			// The reader was gone before the write: it received nothing, and
+			// saying "served" here is exactly the overstatement this field
+			// exists to retire. The verdict still rides in status, so
+			// --status decoy keeps matching these rows.
+			subject = "opened by " + reader + ", nothing read"
+		case status == agent.OpServeDecoy:
 			subject = "decoy served to " + reader
-		} else {
+		default:
 			subject = "real value served to " + reader
 		}
 		if e.Count > 1 {
@@ -954,6 +966,9 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 		}
 		pairs = append(pairs,
 			kv{"level", level}, kv{"kind", "serve"}, kv{"status", status})
+		if e.Undelivered {
+			pairs = append(pairs, kv{"undelivered", "true"})
+		}
 		if len(e.Labels) > 0 {
 			pairs = append(pairs, kv{"mount", strings.Join(e.Labels, ", ")})
 		}
@@ -1042,15 +1057,16 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 		line = lineColor.Sprint(plain)
 	}
 	return auditEntry{
-		t:       t,
-		kind:    kind,
-		status:  status,
-		parent:  e.LaunchedBy,
-		labels:  e.Labels,
-		match:   plain,
-		line:    line,
-		subject: subject,
-		detail:  detail,
+		t:           t,
+		kind:        kind,
+		status:      status,
+		parent:      e.LaunchedBy,
+		labels:      e.Labels,
+		match:       plain,
+		line:        line,
+		subject:     subject,
+		detail:      detail,
+		undelivered: e.Kind == agent.KindServe && e.Undelivered,
 	}
 }
 

--- a/internal/cli/audit_test.go
+++ b/internal/cli/audit_test.go
@@ -279,6 +279,32 @@ func TestAuditServeWithoutAnIdentifiedReader(t *testing.T) {
 	}
 }
 
+// An undelivered serve handed over nothing: the reader was gone before the
+// write (EPIPE). Logging it as "served" was overstating exposure — the row
+// must read as a touch, in both views, while status stays decoy so the
+// existing filter still reaches it.
+func TestAuditUndeliveredServeReadsAsATouch(t *testing.T) {
+	e := authEntry("/Users/alice", agent.SessionEvent{
+		UnixTime: 6000, Kind: agent.KindServe, Op: agent.OpServeDecoy,
+		Labels: []string{"gcp"}, Undelivered: true,
+	})
+	if !strings.Contains(e.subject, "nothing read") {
+		t.Errorf("report subject = %q, want it to say nothing was read", e.subject)
+	}
+	if strings.Contains(e.subject, "served") {
+		t.Errorf("report subject = %q, must not claim a serve that delivered nothing", e.subject)
+	}
+	if !strings.Contains(e.match, "undelivered=true") {
+		t.Errorf("logfmt line = %q, want undelivered=true", e.match)
+	}
+	if e.status != "decoy" {
+		t.Errorf("status = %q, want decoy — the verdict axis must survive for --status", e.status)
+	}
+	if !e.undelivered {
+		t.Error("entry.undelivered = false, the header count depends on it")
+	}
+}
+
 // The header counts decoy ROWS, not the collapsed count each row carries: one
 // looping watcher would otherwise report thousands and read like a breach.
 func TestAuditHeaderCountsDecoyRowsNotReads(t *testing.T) {
@@ -290,6 +316,25 @@ func TestAuditHeaderCountsDecoyRowsNotReads(t *testing.T) {
 	writeAuditHeader(&buf, entries, auditScaleOf(entries))
 	if got := buf.String(); !strings.Contains(got, "1 decoy read") {
 		t.Errorf("header = %q, want it to count 1 decoy row (not 34 reads)", got)
+	}
+}
+
+// Empty reads get their own header count: folding a sweep's touch-and-go
+// opens into "decoy reads" made a backup tool read like an exposure.
+func TestAuditHeaderCountsEmptyReadsApart(t *testing.T) {
+	var buf bytes.Buffer
+	entries := []auditEntry{
+		{t: time.Unix(5000, 0), kind: "serve", status: "decoy", subject: "decoy served to node"},
+		{t: time.Unix(4000, 0), kind: "serve", status: "decoy", undelivered: true,
+			subject: "opened by an unidentified reader, nothing read ×13"},
+	}
+	writeAuditHeader(&buf, entries, auditScaleOf(entries))
+	got := buf.String()
+	if !strings.Contains(got, "1 decoy read") {
+		t.Errorf("header = %q, want the delivered row counted as the only decoy read", got)
+	}
+	if !strings.Contains(got, "1 empty read") {
+		t.Errorf("header = %q, want the undelivered row counted as an empty read", got)
 	}
 }
 

--- a/internal/cli/auditreport.go
+++ b/internal/cli/auditreport.go
@@ -120,6 +120,9 @@ type auditScale struct {
 	oldest, newest time.Time
 	failed, denied int
 	decoy          int
+	// empty counts serve rows whose reader received nothing — kept out of
+	// decoy so the header can't call a sweep's touch-and-go opens "reads".
+	empty int
 }
 
 // auditScaleOf measures the full match set. Entries arrive newest-first.
@@ -130,7 +133,7 @@ func auditScaleOf(entries []auditEntry) auditScale {
 	}
 	s.newest, s.oldest = entries[0].t, entries[len(entries)-1].t
 	s.failed, s.denied = auditOutcomeCounts(entries)
-	s.decoy = auditDecoyRows(entries)
+	s.decoy, s.empty = auditDecoyRows(entries)
 	return s
 }
 
@@ -161,9 +164,14 @@ func writeAuditHeader(w io.Writer, entries []auditEntry, scale auditScale) {
 	// Decoy reads are counted in ROWS, not in the collapsed Count each row
 	// carries: the header's job is "how much of what follows is this", and a
 	// single looping watcher would otherwise report thousands and read like a
-	// breach.
+	// breach. Empty reads — a reader connected but received nothing — are
+	// their own count for the same reason: folding them into "decoy reads"
+	// made a backup tool's sweep read like an exposure.
 	if scale.decoy > 0 {
 		head += fmt.Sprintf(" · %s", countWord(scale.decoy, "decoy read", "decoy reads"))
+	}
+	if scale.empty > 0 {
+		head += fmt.Sprintf(" · %s", countWord(scale.empty, "empty read", "empty reads"))
 	}
 	_, _ = fmt.Fprintln(w, head)
 	fmt.Fprintln(w)
@@ -183,16 +191,24 @@ func auditOutcomeCounts(entries []auditEntry) (failed, denied int) {
 	return failed, denied
 }
 
-// auditDecoyRows counts serve events that handed over a decoy — the rows the
-// header calls out and the footer offers a filter for.
-func auditDecoyRows(entries []auditEntry) int {
-	n := 0
+// auditDecoyRows counts serve rows two ways: decoy is the rows where a
+// reader actually RECEIVED decoy values (what the header calls out and the
+// footer offers a filter for), empty the rows where a reader connected but
+// received nothing at all — any verdict, since nothing was delivered either
+// way.
+func auditDecoyRows(entries []auditEntry) (decoy, empty int) {
 	for _, e := range entries {
-		if e.kind == "serve" && e.status == "decoy" {
-			n++
+		if e.kind != "serve" {
+			continue
+		}
+		switch {
+		case e.undelivered:
+			empty++
+		case e.status == "decoy":
+			decoy++
 		}
 	}
-	return n
+	return decoy, empty
 }
 
 func sameDay(a, b time.Time) bool {

--- a/internal/cli/clissocapture.go
+++ b/internal/cli/clissocapture.go
@@ -447,7 +447,7 @@ func serveClissoConfig(openV vaultOpener) (fifo string, serving bool, cleanup fu
 	// precisely the isolation that prevents it.
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
-		_ = mount.Serve(ctx, fifo, func() []byte { return rendered }, nil, nil, nil)
+		_ = mount.Serve(ctx, fifo, func() []byte { return rendered }, nil, nil, nil, nil)
 	}()
 	// Idempotent: the caller both defers this and calls it explicitly
 	// before propagating clisso's exit code (os.Exit skips defers).

--- a/internal/cli/mountgrants.go
+++ b/internal/cli/mountgrants.go
@@ -178,16 +178,15 @@ func (m *mountManager) serveContent(path string, sm *servedMount) []byte {
 		content, decoy = sm.real, false
 	}
 	rec := serveRecord{at: now, decoy: decoy, reader: sm.pendingReader, grantServed: !decoy && grantServed}
-	sm.lastServe = &rec
 	hadReal, resolveErr := sm.real != nil, sm.lastResolveErr
+	// The decision is only HALF the record: what the reader actually received
+	// is not knowable until the write lands. Stash it; finalizeServe (the
+	// onCycleEnd hook, same cycle, same goroutine) folds in the outcome and
+	// publishes to lastServe and the durable trail. Recording here — the old
+	// shape — logged "decoy served" for a reader that closed before the
+	// write and received nothing at all.
+	sm.pendingServe = &pendingServe{rec: rec, reason: serveReason(decoy, grantServed, hadReal, resolveErr)}
 	sm.mu.Unlock()
-
-	// Durable audit, outside sm.mu on purpose: the auditor takes its own lock
-	// and a finished aggregate is appended to a file, neither of which belongs
-	// on a mount's critical section — every reader of every mount waits behind
-	// it. The auditor collapses before writing, so this call is a map lookup
-	// and a counter increment on all but one read in a window.
-	m.serveAudit.record(now, path, serveReason(decoy, grantServed, hadReal, resolveErr), rec)
 	return content
 }
 

--- a/internal/cli/mountgrants_test.go
+++ b/internal/cli/mountgrants_test.go
@@ -246,6 +246,7 @@ func TestServeContentServesRealToInTreeHolders(t *testing.T) {
 	if got := m.serveContent("/tmp/fixture/.env", sm); string(got) != "API_KEY=real\n" {
 		t.Fatalf("serveContent = %q, want real content for an all-in-tree holder set", got)
 	}
+	m.finalizeServe("/tmp/fixture/.env", sm, true)
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if sm.lastServe == nil || !sm.lastServe.grantServed || sm.lastServe.decoy {
@@ -265,6 +266,7 @@ func TestServeContentFailsClosedOnStrangerHolder(t *testing.T) {
 	if got := m.serveContent("/tmp/fixture/.env", sm); string(got) != "decoy" {
 		t.Fatalf("serveContent = %q, want decoy when any holder is out-of-tree", got)
 	}
+	m.finalizeServe("/tmp/fixture/.env", sm, true)
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
 	if sm.lastServe == nil || !sm.lastServe.decoy || sm.lastServe.grantServed {
@@ -422,6 +424,7 @@ func TestMountRevealStatusesReportsGrant(t *testing.T) {
 	if got := m.serveContent("/tmp/fixture/.env", sm); string(got) != "API_KEY=real\n" {
 		t.Fatalf("setup: serveContent = %q, want real", got)
 	}
+	m.finalizeServe("/tmp/fixture/.env", sm, true)
 
 	statuses := m.mountRevealStatuses()
 	if len(statuses) != 1 {

--- a/internal/cli/mountmanager.go
+++ b/internal/cli/mountmanager.go
@@ -170,6 +170,12 @@ type mountManager struct {
 	grantHoldersFn  func(path string) (pids []int32, ok bool)
 	grantAncestryFn func(pid, root int32) bool
 	grantStartFn    func(pid int32) (unixMicro int64, ok bool)
+
+	// identifyRetryFn is finalizeServe's post-write identity scan; nil means
+	// lineage.IdentifyFIFOReader. A seam for the same reason the grant ones
+	// are: the retry's gating (delivered-only, missed-scan-only) is what
+	// tests pin down, and none of it should need a real lingering reader.
+	identifyRetryFn func(path string) (pid int32, execPath string, ok bool)
 }
 
 // readerIdentity is internal/lineage's best-effort answer to "who just
@@ -216,6 +222,22 @@ type serveRecord struct {
 	// Status reports it so a real serve reads as "only this run's tree could
 	// have read it", never an ambient exposure.
 	grantServed bool
+	// undelivered marks a cycle whose reader received nothing: the write hit
+	// EPIPE, proof that zero processes held the read end when content was
+	// sent. The decision (decoy/real) still happened; delivery didn't — and
+	// recording the two as the same fact was overstating exposure, which for
+	// a tripwire trail is the wrong direction to be wrong in.
+	undelivered bool
+}
+
+// pendingServe is a serveRecord between its two moments: the content
+// DECISION (serveContent, before the write) and the cycle's OUTCOME
+// (finalizeServe, after it — did the reader actually receive anything).
+// The reason is captured at decision time because it explains the verdict,
+// which is decided then; the outcome only annotates it.
+type pendingServe struct {
+	rec    serveRecord
+	reason string
 }
 
 // servedMount is one mount's live, dynamic state — read fresh by
@@ -260,10 +282,18 @@ type servedMount struct {
 	lastResolveErr string
 	// pendingReader is set by the onReaderConnected hook (which mount.Serve
 	// guarantees fires before provideContent in the same cycle, on the same
-	// goroutine); provideContent folds it into lastServe when it decides
-	// what that reader actually gets.
+	// goroutine); provideContent captures it into pendingServe when it
+	// decides what that reader gets, and finalizeServe — the onCycleEnd
+	// hook, same cycle, same goroutine — folds that into lastServe and the
+	// durable trail once the write's outcome is known.
 	pendingReader readerIdentity
-	lastServe     *serveRecord
+	pendingServe  *pendingServe
+	// scanMissed is true when THIS cycle's lineage scan actually ran and
+	// found nobody (not when the rate limit skipped it) — the one case
+	// finalizeServe spends a second scan on. Set by noteReaderConnected,
+	// consumed and cleared by finalizeServe, both on the Serve goroutine.
+	scanMissed bool
+	lastServe  *serveRecord
 
 	// grantVerdicts is this mount's per-(holder,root) ancestry verdict
 	// cache — the read gate's amortization of the libproc ancestry walk
@@ -532,13 +562,20 @@ func (m *mountManager) ensureServing(entries []mount.Entry) {
 			}
 		}(entry.MountPath)
 
+		// finalizeServe is the record's second half: serveContent decided
+		// what to serve, this learns whether it was received, and only then
+		// does the record reach lastServe and the durable trail.
+		onCycleEnd := func(path string, sm *servedMount) func(bool) {
+			return func(delivered bool) { m.finalizeServe(path, sm, delivered) }
+		}(entry.MountPath, sm)
+
 		go func(path string, sm *servedMount) {
 			defer m.wg.Done()
 			defer close(sm.done)
 			onError := func(err error) {
 				m.noteServeError(path, sm, err)
 			}
-			if err := mount.Serve(ctx, path, provideContent, onError, onReaderConnected, hasLingeringReader); err != nil && !errors.Is(err, context.Canceled) {
+			if err := mount.Serve(ctx, path, provideContent, onError, onReaderConnected, hasLingeringReader, onCycleEnd); err != nil && !errors.Is(err, context.Canceled) {
 				fmt.Fprintf(m.stderr, "jit service: mount %s stopped: %v\n", path, err)
 				// A mount whose Serve loop died structurally must not
 				// stay in the map looking alive (GAPS.md #44): a stale
@@ -668,6 +705,10 @@ func (m *mountManager) noteReaderConnected(path string, sm *servedMount) {
 
 		sm.mu.Lock()
 		sm.pendingReader = next
+		// A scan that ran and found nobody (not one the rate limit skipped)
+		// is finalizeServe's cue to try once more after the write, when a
+		// slow reader is still holding the pipe. Cleared there.
+		sm.scanMissed = !next.identified
 		sm.mu.Unlock()
 	}
 	if !doLog {
@@ -744,6 +785,65 @@ func launcherOf(pid int32) string {
 	return lineage.LaunchedBy(chain[1:])
 }
 
+// finalizeServe is every mount's onCycleEnd hook (mount.Serve guarantees it
+// fires once per cycle, after the write and close, on the Serve goroutine).
+// It completes the record serveContent opened: folds in whether the reader
+// actually RECEIVED the content (delivered=false is EPIPE — proof it got
+// nothing), spends one more identity scan when this cycle's scan ran and
+// missed a reader that turned out to linger, and only then publishes the
+// record to lastServe and the durable trail. Recording at decision time —
+// the old shape — wrote "decoy served" for cycles that delivered nothing,
+// and left a late-found identity with no record to land in.
+func (m *mountManager) finalizeServe(path string, sm *servedMount, delivered bool) {
+	sm.mu.Lock()
+	ps := sm.pendingServe
+	sm.pendingServe = nil
+	missed := sm.scanMissed
+	sm.scanMissed = false
+	sm.mu.Unlock()
+	if ps == nil {
+		return // no decision this cycle (cannot happen in Serve's contract; refuse to invent one)
+	}
+	rec := ps.rec
+	rec.undelivered = !delivered
+
+	// The second scan, bounded on purpose: only when content was delivered
+	// (an EPIPE reader is provably gone), only when this cycle's own scan ran
+	// and found nobody (so it inherits noteReaderConnected's rate limit — at
+	// most one extra walk per lineageScanMinGap per mount, and none at all in
+	// an identified reader's storm). Marked likely, never asserted: whoever
+	// holds the pipe now almost certainly is this cycle's reader, but a
+	// brand-new non-blocking reader could have arrived in the gap.
+	if delivered && missed && !rec.reader.identified {
+		identify := m.identifyRetryFn
+		if identify == nil {
+			identify = lineage.IdentifyFIFOReader
+		}
+		if pid, execPath, ok := identify(path); ok {
+			r := readerIdentity{
+				pid:        pid,
+				execPath:   execPath,
+				launchedBy: launcherOf(pid),
+				identified: true,
+				likely:     true,
+			}
+			rec.reader = r
+			// Feed the carry-forward too: the next cycle's skipped or missed
+			// scan can now name this reader instead of starting from nothing.
+			sm.mu.Lock()
+			sm.pendingReader = r
+			sm.mu.Unlock()
+		}
+	}
+
+	sm.mu.Lock()
+	sm.lastServe = &rec
+	sm.mu.Unlock()
+	// Outside sm.mu for the same reason serveContent kept it there: the
+	// auditor takes its own lock and may append to a file.
+	m.serveAudit.record(rec.at, path, ps.reason, rec)
+}
+
 // noteServeError logs a mount's transient write/close errors with the same
 // collapse as noteReaderConnected — a watcher loop produces one broken-pipe
 // line per read, which is pure repetition once the first has said what's
@@ -797,7 +897,7 @@ func (m *mountManager) mountRevealStatuses() []agent.MountRevealStatus {
 		}
 		sm.mu.Lock()
 		if ls := sm.lastServe; ls != nil {
-			status.LastServe = &agent.MountServeEvent{UnixTime: ls.at.Unix(), Decoy: ls.decoy, GrantServed: ls.grantServed}
+			status.LastServe = &agent.MountServeEvent{UnixTime: ls.at.Unix(), Decoy: ls.decoy, GrantServed: ls.grantServed, Undelivered: ls.undelivered}
 			if ls.reader.identified {
 				status.LastServe.ReaderPID = ls.reader.pid
 				status.LastServe.ReaderPath = ls.reader.execPath

--- a/internal/cli/mountmanager_test.go
+++ b/internal/cli/mountmanager_test.go
@@ -41,9 +41,13 @@ import (
 // serveNoGrant runs the unified content decision (serveContent) with no
 // grant runs active — the fast path: always decoy, since real content flows
 // only to a run-scoped grant's own process tree.
+// serveNoGrant is one COMPLETED read: the content decision plus the
+// cycle-end fold (delivered), the way mount.Serve drives the two hooks.
 func serveNoGrant(sm *servedMount) []byte {
 	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
-	return m.serveContent("/tmp/fixture/.env", sm)
+	content := m.serveContent("/tmp/fixture/.env", sm)
+	m.finalizeServe("/tmp/fixture/.env", sm, true)
+	return content
 }
 
 func TestEnsureServingConcurrentCallsClaimSlotOnce(t *testing.T) {
@@ -239,6 +243,94 @@ func TestProvideContentRecordsLastServe(t *testing.T) {
 	// under a run-scoped grant now (there is no reveal window), so it's
 	// exercised by the grant e2e tests (rungrant_e2e_test.go) rather than
 	// here, where no grant machinery is wired.
+}
+
+// TestFinalizeServeRecordsUndelivered pins the record's two-moment shape:
+// nothing is published at decision time, and an EPIPE cycle (the reader was
+// gone before the write — it received nothing) reaches lastServe and the
+// durable trail marked undelivered, instead of as the "decoy served" it
+// used to be logged as.
+func TestFinalizeServeRecordsUndelivered(t *testing.T) {
+	sm := newTestServedMount()
+	sm.decoy = []byte("decoy")
+	c := &collector{}
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+	m.serveAudit = serveAuditor{window: time.Hour, emit: c.append}
+
+	if got := m.serveContent("/tmp/fixture/.env", sm); string(got) != "decoy" {
+		t.Fatalf("serveContent = %q, want decoy", got)
+	}
+	sm.mu.Lock()
+	published := sm.lastServe
+	sm.mu.Unlock()
+	if published != nil {
+		t.Fatalf("lastServe = %+v before the cycle ended, want nil until the outcome is known", published)
+	}
+
+	m.finalizeServe("/tmp/fixture/.env", sm, false)
+
+	sm.mu.Lock()
+	ls := sm.lastServe
+	sm.mu.Unlock()
+	if ls == nil || !ls.undelivered || !ls.decoy {
+		t.Fatalf("lastServe = %+v, want a decoy record marked undelivered", ls)
+	}
+	m.serveAudit.stopFlusher()
+	events := c.all()
+	if len(events) != 1 || !events[0].Undelivered {
+		t.Fatalf("durable trail = %+v, want one event marked Undelivered", events)
+	}
+}
+
+// TestFinalizeServeIdentityRetryGating: the post-write identity scan is spent
+// only where it can pay — content was delivered (an EPIPE reader is provably
+// gone) AND this cycle's own scan ran and found nobody. Its find is marked
+// likely (a post-hoc observation, not the open itself) and feeds the
+// carry-forward so the next cycle starts with a name.
+func TestFinalizeServeIdentityRetryGating(t *testing.T) {
+	run := func(t *testing.T, delivered, missed bool) (*servedMount, int) {
+		t.Helper()
+		sm := newTestServedMount()
+		sm.decoy = []byte("decoy")
+		m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+		retries := 0
+		m.identifyRetryFn = func(string) (int32, string, bool) {
+			retries++
+			return 777, "/usr/libexec/sharingd", true
+		}
+		if got := m.serveContent("/tmp/fixture/.env", sm); string(got) != "decoy" {
+			t.Fatalf("serveContent = %q, want decoy", got)
+		}
+		sm.mu.Lock()
+		sm.scanMissed = missed
+		sm.mu.Unlock()
+		m.finalizeServe("/tmp/fixture/.env", sm, delivered)
+		return sm, retries
+	}
+
+	sm, retries := run(t, true, true)
+	if retries != 1 {
+		t.Fatalf("delivered+missed: retries = %d, want 1", retries)
+	}
+	sm.mu.Lock()
+	ls, carried := sm.lastServe, sm.pendingReader
+	if sm.scanMissed {
+		t.Error("scanMissed not cleared by finalizeServe")
+	}
+	sm.mu.Unlock()
+	if ls == nil || !ls.reader.identified || !ls.reader.likely || ls.reader.pid != 777 {
+		t.Errorf("lastServe.reader = %+v, want the retry's find, marked likely", ls.reader)
+	}
+	if !carried.identified || carried.pid != 777 || !carried.likely {
+		t.Errorf("pendingReader = %+v, want the retry's find fed to the carry-forward", carried)
+	}
+
+	if _, retries := run(t, false, true); retries != 0 {
+		t.Errorf("undelivered cycle: retries = %d, want 0 — an EPIPE reader is provably gone", retries)
+	}
+	if _, retries := run(t, true, false); retries != 0 {
+		t.Errorf("no missed scan: retries = %d, want 0 — the rate limit must bound the extra walk", retries)
+	}
 }
 
 // TestMountRevealStatusesIncludesLastServe confirms the serve record crosses

--- a/internal/cli/mountserveaudit.go
+++ b/internal/cli/mountserveaudit.go
@@ -98,18 +98,21 @@ const serveAuditFlushInterval = time.Minute
 // and writing them early costs a slightly shorter window, not a lost fact.
 const maxPendingServes = 64
 
-// serveKey is one aggregate's identity. Deliberately includes the reader and
-// the verdict: collapsing across either would merge facts an investigation
-// needs separated ("who read it" and "what did they get"). The reader is its
+// serveKey is one aggregate's identity. Deliberately includes the reader,
+// the verdict, and whether anything was received: collapsing across any of
+// them would merge facts an investigation needs separated ("who read it",
+// "what did they get", "did they get it at all" — a sweep's empty touches
+// and an app's actual decoy reads are different findings). The reader is its
 // executable path, NOT its pid: a watcher that re-execs per read gets a
 // fresh pid every time, and a pid-keyed aggregate minted one event per read
 // — defeating the hour window the auditor exists to enforce and letting the
 // noisiest reader flood the durable trail. The first read's pid still rides
 // in the event payload (ByPID); the follow-up pids were noise, not facts.
 type serveKey struct {
-	mount  string
-	reader string
-	decoy  bool
+	mount       string
+	reader      string
+	decoy       bool
+	undelivered bool
 }
 
 type serveAggregate struct {
@@ -163,7 +166,7 @@ func (a *serveAuditor) record(now time.Time, mount, reason string, rec serveReco
 	if a == nil || a.emit == nil {
 		return
 	}
-	key := serveKey{mount: mount, reader: rec.reader.execPath, decoy: rec.decoy}
+	key := serveKey{mount: mount, reader: rec.reader.execPath, decoy: rec.decoy, undelivered: rec.undelivered}
 
 	a.mu.Lock()
 	if a.pending == nil {
@@ -177,10 +180,11 @@ func (a *serveAuditor) record(now time.Time, mount, reason string, rec serveReco
 			op = agent.OpServeDecoy
 		}
 		e := agent.SessionEvent{
-			UnixTime: now.Unix(),
-			Kind:     agent.KindServe,
-			Op:       op,
-			Cause:    reason,
+			UnixTime:    now.Unix(),
+			Kind:        agent.KindServe,
+			Op:          op,
+			Cause:       reason,
+			Undelivered: rec.undelivered,
 		}
 		if rec.reader.identified {
 			e.By = rec.reader.execPath

--- a/internal/cli/mountserveaudit_test.go
+++ b/internal/cli/mountserveaudit_test.go
@@ -255,6 +255,40 @@ func TestServeReasonNamesTheCause(t *testing.T) {
 	}
 }
 
+// TestServeAuditKeepsUndeliveredApart pins the key's fourth axis: a cycle
+// whose reader received nothing (EPIPE before the write) must never collapse
+// into the same aggregate as one whose reader actually got the decoy — a
+// sweep's empty touches and an app's decoy reads are different findings, and
+// merging them is how "75 decoy reads" came to describe a backup tool.
+func TestServeAuditKeepsUndeliveredApart(t *testing.T) {
+	a, c := newTestAuditor(time.Hour)
+	now := time.Unix(1_700_000_000, 0)
+
+	delivered := decoyRead(1, "/usr/libexec/backupd")
+	empty := decoyRead(1, "/usr/libexec/backupd")
+	empty.undelivered = true
+
+	a.record(now, "/tmp/m.env", "r", delivered)
+	a.record(now, "/tmp/m.env", "r", empty)
+	a.record(now, "/tmp/m.env", "r", empty)
+
+	a.emitAll(a.take(true, now))
+	events := c.all()
+	if len(events) != 2 {
+		t.Fatalf("delivered and undelivered reads collapsed into %d events, want 2", len(events))
+	}
+	byUndelivered := map[bool]agent.SessionEvent{}
+	for _, e := range events {
+		byUndelivered[e.Undelivered] = e
+	}
+	if e, ok := byUndelivered[true]; !ok || e.Count != 2 {
+		t.Errorf("undelivered aggregate = %+v, want present with Count 2", e)
+	}
+	if e, ok := byUndelivered[false]; !ok || e.Count != 1 {
+		t.Errorf("delivered aggregate = %+v, want present with Count 1", e)
+	}
+}
+
 // TestServeAuditFoldsReExecingReader pins the key's identity choice: a
 // watcher that re-execs per read arrives with a fresh pid every time, and a
 // pid-keyed aggregate minted one event per read — defeating the hour window

--- a/internal/cli/servicestatus.go
+++ b/internal/cli/servicestatus.go
@@ -331,6 +331,10 @@ func printMountStatuses(w io.Writer, mounts []agent.MountRevealStatus) {
 			reader := describeReader(ls)
 			ago := humanAgo(time.Since(time.Unix(ls.UnixTime, 0)))
 			switch {
+			case ls.Undelivered:
+				// Not counted in decoyReads: nothing was received, so the
+				// "run it through jit run --live" advice doesn't apply.
+				_, _ = fmt.Fprintf(w, "      opened %s ago by %s · nothing read\n", ago, reader)
 			case ls.Decoy:
 				decoyReads++
 				_, _ = fmt.Fprintf(w, "      read %s ago by %s · decoy\n", ago, reader)

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -661,7 +661,10 @@ func printStatusText(w io.Writer, r statusResult) {
 	// about yesterday.
 	decoyReads := 0
 	for _, m := range r.Agent.Mounts {
-		if m.LastServe != nil && m.LastServe.Decoy {
+		// An undelivered serve handed over nothing, so it isn't "served
+		// decoy values" — saying so here was the overstatement the field
+		// exists to retire.
+		if m.LastServe != nil && m.LastServe.Decoy && !m.LastServe.Undelivered {
 			decoyReads++
 		}
 	}

--- a/internal/mount/mount.go
+++ b/internal/mount/mount.go
@@ -117,7 +117,24 @@ func CreateFIFO(path string) error {
 // only logs a write/close failure and continues. Only a failure to OPEN
 // the FIFO at all (path gone, disk error — something structurally wrong,
 // not a reader race) ends the loop.
-func Serve(ctx context.Context, path string, provideContent func() []byte, onError func(error), onReaderConnected func(), hasLingeringReader func() bool) error {
+//
+// onCycleEnd, if non-nil, is called exactly once per reader cycle, after
+// the write and the close/isolation handling, with whether this cycle's
+// content was DELIVERED. delivered is false only on EPIPE — the write
+// outcome that proves zero readers held the pipe when content was sent,
+// so the reader received nothing (the same race
+// spike/fifo-reader-identify/FINDINGS.md notes: a reader fast enough to
+// evade classification is also too fast to be served). Strictly, an EPIPE
+// midway through a payload larger than the pipe buffer could follow a
+// partial transfer — but env-file content fits the buffer many times
+// over, so the single write either lands whole or moves nothing. Every
+// other outcome — a clean write, even a failed one where bytes may have
+// reached a reader — reports delivered=true, because an audit trail must
+// err toward overstating exposure, never understating it. This is the
+// hook a caller folds its per-cycle audit record on: the content decision
+// (provideContent) happens before the write, but what the reader actually
+// RECEIVED is only known here.
+func Serve(ctx context.Context, path string, provideContent func() []byte, onError func(error), onReaderConnected func(), hasLingeringReader func() bool, onCycleEnd func(delivered bool)) error {
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -169,6 +186,12 @@ func Serve(ctx context.Context, path string, provideContent func() []byte, onErr
 		}
 		if closeErr != nil && onError != nil {
 			onError(fmt.Errorf("closing %s: %w", path, closeErr))
+		}
+		// Before the recreateErr return, deliberately: a cycle that kills the
+		// loop still completed its write, and its audit record must fold
+		// rather than vanish with the goroutine.
+		if onCycleEnd != nil {
+			onCycleEnd(!errors.Is(writeErr, syscall.EPIPE))
 		}
 		if recreateErr != nil {
 			return recreateErr

--- a/internal/mount/mount_test.go
+++ b/internal/mount/mount_test.go
@@ -66,7 +66,7 @@ func TestServeSequentialReaders(t *testing.T) {
 	defer cancel()
 
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, fixedContent, nil, nil, nil) }()
+	go func() { serveErr <- Serve(ctx, path, fixedContent, nil, nil, nil, nil) }()
 
 	for i := 0; i < 3; i++ {
 		got := readFIFO(t, path)
@@ -109,6 +109,81 @@ func readFIFO(t *testing.T, path string) []byte {
 // the read end without draining reliably produces EPIPE on the pending
 // write (the pipe's kernel buffer fills, so the write is still in flight
 // when the reader disappears) — this must be deterministic, not a maybe.
+// TestServeCycleEndReportsDelivery pins onCycleEnd's contract: exactly one
+// call per reader cycle, delivered=false only on EPIPE (the write outcome
+// that proves the reader received nothing), delivered=true on a drained
+// read. The distinction is what lets the audit trail stop logging a
+// touch-and-go reader's empty open as "decoy served".
+func TestServeCycleEndReportsDelivery(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".env")
+	if err := CreateFIFO(path); err != nil {
+		t.Fatalf("CreateFIFO: %v", err)
+	}
+
+	// Oversized payload, borrowed from TestServeContinuesAfterReaderClosesEarly:
+	// it makes the EPIPE deterministic, because the in-flight write is only
+	// unblocked by the reader's close.
+	content := bytes.Repeat([]byte("x"), 256*1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	outcomes := make(chan bool, 8)
+	onCycleEnd := func(delivered bool) { outcomes <- delivered }
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- Serve(ctx, path, func() []byte { return content }, nil, nil, nil, onCycleEnd)
+	}()
+
+	// Cycle 1: open and close without reading — the reader receives nothing.
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("opening %s for read: %v", path, err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("closing early: %v", err)
+	}
+	select {
+	case delivered := <-outcomes:
+		if delivered {
+			t.Error("onCycleEnd(delivered=true) for an EPIPE cycle, want false: the reader provably received nothing")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("onCycleEnd did not fire for the early-closing reader's cycle")
+	}
+
+	// Cycle 2: a reader that drains the content.
+	if got := readFIFO(t, path); !bytes.Equal(got, content) {
+		t.Fatal("drained reader did not get the full content")
+	}
+	select {
+	case delivered := <-outcomes:
+		if !delivered {
+			t.Error("onCycleEnd(delivered=false) for a drained read, want true")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("onCycleEnd did not fire for the drained cycle")
+	}
+
+	cancel()
+	select {
+	case err := <-serveErr:
+		if err != context.Canceled {
+			t.Errorf("Serve returned %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Serve did not exit within 5s of cancellation")
+	}
+	// One call per cycle, none extra from shutdown.
+	select {
+	case extra := <-outcomes:
+		t.Errorf("unexpected extra onCycleEnd(%v) after two cycles", extra)
+	default:
+	}
+}
+
 func TestServeContinuesAfterReaderClosesEarly(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, ".env")
@@ -131,7 +206,7 @@ func TestServeContinuesAfterReaderClosesEarly(t *testing.T) {
 	}
 
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, fixedContent, onError, nil, nil) }()
+	go func() { serveErr <- Serve(ctx, path, fixedContent, onError, nil, nil, nil) }()
 
 	// First reader: opens then closes immediately without draining.
 	f, err := os.Open(path)
@@ -202,7 +277,7 @@ func TestServeIsolatesStaleReaderFromNextCycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, nil) }()
+	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, nil, nil) }()
 
 	// Reader 1: open and read cycle 1's content in full, but deliberately
 	// hold the fd open afterward instead of closing it right away — the
@@ -286,7 +361,7 @@ func TestServeReusesPipeWhenReaderClosedCleanly(t *testing.T) {
 	onError := func(err error) { errCh <- err }
 
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, fixedContent, onError, nil, nil) }()
+	go func() { serveErr <- Serve(ctx, path, fixedContent, onError, nil, nil, nil) }()
 
 	// Reader that opens then closes without draining — guaranteed fully
 	// closed by the time Serve's cycle-end probe runs, since its close is
@@ -372,7 +447,7 @@ func TestServeReusesPipeAfterDrainedReadWhenNothingLingers(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, func() []byte { return content }, nil, nil, noLinger) }()
+	go func() { serveErr <- Serve(ctx, path, func() []byte { return content }, nil, nil, noLinger, nil) }()
 
 	// A full drain — the exact read shape that always renamed before.
 	if got := readFIFO(t, path); !bytes.Equal(got, content) {
@@ -443,7 +518,7 @@ func TestServeIsolatesWhenLingeringReaderReported(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, linger) }()
+	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, linger, nil) }()
 
 	// Reader 1 drains cycle 1 and HOLDS its fd — the genuine lingerer the
 	// callback is reporting.
@@ -504,7 +579,7 @@ func TestServeStopsCleanlyWithNoReaders(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
 	defer cancel()
 
-	err := Serve(ctx, path, func() []byte { return []byte("A=1\n") }, nil, nil, nil)
+	err := Serve(ctx, path, func() []byte { return []byte("A=1\n") }, nil, nil, nil, nil)
 	if err != context.DeadlineExceeded {
 		t.Errorf("Serve = %v, want context.DeadlineExceeded (no reader ever connected)", err)
 	}
@@ -543,7 +618,7 @@ func TestServeGatesRealContentFreshEachCycle(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, nil) }()
+	go func() { serveErr <- Serve(ctx, path, provideContent, nil, nil, nil, nil) }()
 
 	// Unauthorized: must get decoy content, never the real value.
 	got := readFIFO(t, path)
@@ -609,7 +684,7 @@ func TestServeCallsOnReaderConnectedBeforeWriting(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	serveErr := make(chan error, 1)
-	go func() { serveErr <- Serve(ctx, path, content, nil, onReaderConnected, nil) }()
+	go func() { serveErr <- Serve(ctx, path, content, nil, onReaderConnected, nil, nil) }()
 
 	readFIFO(t, path)
 	readFIFO(t, path)


### PR DESCRIPTION
## What

A mount serve was recorded at decision time, before the write — so a touch-and-go reader (a backup tool, an indexer, the VM file-sharing sweep) that opened a mount and closed before receiving a byte was logged as **"decoy served to an unidentified reader"**. The trail overstated exposure, which for a tripwire surface is the wrong direction to be wrong in.

## How

- `mount.Serve` gains an `onCycleEnd(delivered bool)` hook, fired once per reader cycle after the write. `delivered=false` only on EPIPE — the write outcome that proves zero readers held the pipe when content was sent, so nothing was received. Any other outcome errs toward delivered, so the trail can overstate delivery but never understate it.
- The record now folds at cycle end (`finalizeServe`): the content decision is stashed by `serveContent`, the outcome joins it, and only then does it reach `lastServe` and the durable trail. Undelivered cycles get their own aggregate axis (`serveKey`), so a sweep's empty touches can never merge with real decoy reads.
- Moving the fold creates the seam a late identity needed: when a cycle's own lineage scan ran and missed but content WAS delivered, one more scan runs — bounded by the existing per-mount rate limit — and a lingering reader it finds is named (marked "likely") and fed to the carry-forward.

## Surface changes

- `jit audit` rows: `opened by an unidentified reader, nothing read ×13` instead of `decoy served to …` for undelivered cycles; header splits `62 decoy reads · 13 empty reads`.
- logfmt: `undelivered=true` on those events; `--status decoy` still matches them.
- `jit service status`: `opened 2m ago by … · nothing read`; undelivered serves no longer count toward the "run it through jit run --live" tip or the status rollup's "served decoy values" note.
- Events from older builds have no field and render exactly as before.

## Tests

- `TestServeCycleEndReportsDelivery` pins the hook's contract (EPIPE→false, drained→true, once per cycle).
- `TestFinalizeServeRecordsUndelivered` pins the two-moment record; `TestFinalizeServeIdentityRetryGating` pins the retry's bounds (delivered-only, missed-scan-only, feeds carry-forward).
- `TestServeAuditKeepsUndeliveredApart`, `TestAuditUndeliveredServeReadsAsATouch`, `TestAuditHeaderCountsEmptyReadsApart` cover the aggregation and both views.

Full `go test -race ./...` passes; gofmt/vet/staticcheck/gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtcxVok6raU8gipeE29Dwx
