### PR TITLE
audit: name a sweep's unidentified readers from the sibling the scan caught

### DIFF
--- a/internal/cli/audit.go
+++ b/internal/cli/audit.go
@@ -464,6 +464,15 @@ type auditEntry struct {
 	// before the write) — the header counts those apart from decoy reads,
 	// because an empty touch and a delivered decoy are different findings.
 	undelivered bool
+
+	// serveReader/serveCount are the serve-row facts the report's sweep-
+	// correlation pass keys on (attachSweepHints): the reader's base name
+	// ("" when the scan missed it) and the event's collapsed read count. A
+	// hint computed from them lands in hint — viewer-side inference only,
+	// never part of the recorded event or the logfmt/json views.
+	serveReader string
+	serveCount  int64
+	hint        string
 }
 
 // printAuditLog merges command records and auth events into one reverse-
@@ -1056,7 +1065,7 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 	if lineColor != nil {
 		line = lineColor.Sprint(plain)
 	}
-	return auditEntry{
+	entry := auditEntry{
 		t:           t,
 		kind:        kind,
 		status:      status,
@@ -1068,6 +1077,13 @@ func authEntry(home string, e agent.SessionEvent) auditEntry {
 		detail:      detail,
 		undelivered: e.Kind == agent.KindServe && e.Undelivered,
 	}
+	if e.Kind == agent.KindServe {
+		if e.By != "" {
+			entry.serveReader = filepath.Base(e.By)
+		}
+		entry.serveCount = e.Count
+	}
+	return entry
 }
 
 // serveReaderName names who read a mount, for the human report's subject.

--- a/internal/cli/auditreport.go
+++ b/internal/cli/auditreport.go
@@ -56,6 +56,7 @@ func printAuditReport(w io.Writer, entries []auditEntry, filtered bool, scale au
 	}
 	writeAuditHeader(w, entries, scale)
 	groups := groupAuditEntries(entries)
+	attachSweepHints(groups)
 	cols := auditColumns(groups)
 
 	day := ""
@@ -262,6 +263,78 @@ func groupAuditEntries(entries []auditEntry) []auditGroup {
 	return out
 }
 
+// sweepHintWindow bounds how far apart two serve rows can sit and still be
+// read as one sweep. The observed pattern is a file-walker touching every
+// registered mount within the same minute; two minutes absorbs the report's
+// minute-granularity fold without reaching into unrelated activity.
+const sweepHintWindow = 2 * time.Minute
+
+// attachSweepHints annotates unidentified serve rows with the one inference
+// the report can responsibly make: when a sweep touches many mounts at once
+// and the lineage scan wins the race on just one of them, the unidentified
+// siblings were almost certainly the same reader. The candidate must be a
+// LONE read (a watcher storm hammering its own mount proves nothing about
+// its neighbors — and at ×45775 it would otherwise nominate itself for
+// every sweep in its hour) on a DIFFERENT mount inside the window; if more
+// than one distinct reader qualifies, no hint is made at all. The hint is
+// phrased as likelihood, never asserted, and exists only in this view —
+// the recorded events and the logfmt/json streams stay inference-free
+// (identifyReader's doctrine: an audit trail that lies is worse than one
+// that admits it doesn't know).
+func attachSweepHints(groups []auditGroup) {
+	for i := range groups {
+		g := &groups[i]
+		if g.e.kind != "serve" || g.e.serveReader != "" {
+			continue
+		}
+		var name string
+		var at time.Time
+		ambiguous := false
+		for j := range groups {
+			c := &groups[j]
+			if i == j || c.e.kind != "serve" || c.e.serveReader == "" {
+				continue
+			}
+			if c.e.serveCount > 1 {
+				continue // a storm can't nominate itself
+			}
+			d := g.e.t.Sub(c.e.t)
+			if d < 0 {
+				d = -d
+			}
+			if d > sweepHintWindow {
+				continue
+			}
+			if labelsOverlap(g.e.labels, c.e.labels) {
+				continue // same mount is the carry-forward's job, not a sweep signal
+			}
+			if name != "" && name != c.e.serveReader {
+				ambiguous = true
+				break
+			}
+			name, at = c.e.serveReader, c.e.t
+		}
+		if name == "" || ambiguous {
+			continue
+		}
+		g.e.hint = fmt.Sprintf("likely %s, which read a sibling mount at %s", name, at.Format("15:04"))
+	}
+}
+
+// labelsOverlap reports whether the two label sets share a mount.
+func labelsOverlap(a, b []string) bool {
+	seen := make(map[string]bool, len(a))
+	for _, l := range a {
+		seen[l] = true
+	}
+	for _, l := range b {
+		if seen[l] {
+			return true
+		}
+	}
+	return false
+}
+
 // unionLabels returns the secret names in a followed by any in b not already
 // present, order-preserving and deduped. It never aliases either input, so
 // folding into a group can't mutate the backing entry's slice.
@@ -369,6 +442,13 @@ func writeAuditRow(w io.Writer, g auditGroup, cols auditCols) {
 	if g.e.detail != "" {
 		fmt.Fprint(w, auditHangIndent)
 		termtext.Wrap(w, auditRowLead, auditHangIndent, g.e.detail)
+	}
+	// The sweep inference hangs as evidence under the row it qualifies,
+	// plain like every other secondary line.
+	if g.e.hint != "" {
+		fmt.Fprint(w, auditHangIndent)
+		fmt.Fprint(w, glyphBranch+" ")
+		termtext.Wrap(w, auditRowLead+2, auditHangIndent+"  ", g.e.hint)
 	}
 	if g.e.action != "" {
 		fmt.Fprint(w, auditHangIndent)

--- a/internal/cli/auditreport_test.go
+++ b/internal/cli/auditreport_test.go
@@ -22,6 +22,91 @@ func renderReport(entries []auditEntry) string {
 	return buf.String()
 }
 
+// serveEntry builds a serve row the way authEntry would: reader "" is a scan
+// miss, count is the event's collapsed read count, labels the mounts touched.
+func serveEntry(at time.Time, reader string, count int64, labels ...string) auditEntry {
+	subject := "opened by an unidentified reader, nothing read"
+	if reader != "" {
+		subject = "decoy served to " + reader
+	}
+	return auditEntry{
+		t: at, kind: "serve", status: "decoy", subject: subject,
+		serveReader: reader, serveCount: count, labels: labels,
+	}
+}
+
+// The one inference the report may responsibly draw: a sweep touched many
+// mounts in one window, the scan won the race on exactly one of them, so the
+// unidentified siblings were almost certainly the same reader. Phrased as
+// likelihood, attached as evidence under the row.
+func TestSweepHintNamesTheLoneSiblingReader(t *testing.T) {
+	base := time.Date(2026, 8, 12, 16, 42, 30, 0, time.Local)
+	out := renderReport([]auditEntry{
+		serveEntry(base, "", 7, "~/a/.env", "~/b/.env"),
+		serveEntry(base.Add(-20*time.Second), "com.apple.Virtualization.VirtualMachine", 1, "~/jamf/.env"),
+	})
+	// Two fragments, because the hint wraps at narrow widths.
+	if !strings.Contains(out, "likely com.apple.Virtualization.VirtualMachine") ||
+		!strings.Contains(out, "sibling mount at 16:42") {
+		t.Errorf("expected the sweep hint under the unidentified row, got:\n%s", out)
+	}
+	if n := strings.Count(out, "likely"); n != 1 {
+		t.Errorf("the hint leaked onto %d rows, want the unidentified row only:\n%s", n, out)
+	}
+}
+
+// A watcher storm proves nothing about its neighbors — and at ×45775 it
+// would otherwise nominate itself for every sweep in its hour.
+func TestSweepHintRefusesAStormAsCandidate(t *testing.T) {
+	base := time.Date(2026, 8, 13, 12, 50, 30, 0, time.Local)
+	out := renderReport([]auditEntry{
+		serveEntry(base, "", 8, "~/a/.env"),
+		serveEntry(base.Add(-10*time.Second), "Code", 45775, "~/okta/.env"),
+	})
+	if strings.Contains(out, "likely") {
+		t.Errorf("a read storm nominated itself as the sweep reader:\n%s", out)
+	}
+}
+
+// Two different identified readers in the window is ambiguity, and an audit
+// view must say less rather than guess between them.
+func TestSweepHintRefusesAmbiguousCandidates(t *testing.T) {
+	base := time.Date(2026, 8, 12, 16, 42, 30, 0, time.Local)
+	out := renderReport([]auditEntry{
+		serveEntry(base, "", 3, "~/a/.env"),
+		serveEntry(base.Add(-15*time.Second), "sharingd", 1, "~/b/.env"),
+		serveEntry(base.Add(-30*time.Second), "backupd", 1, "~/c/.env"),
+	})
+	if strings.Contains(out, "likely") {
+		t.Errorf("two distinct candidates should mean no hint at all:\n%s", out)
+	}
+}
+
+// Outside the window it is not the same sweep, however lone the reader.
+func TestSweepHintRespectsTheWindow(t *testing.T) {
+	base := time.Date(2026, 8, 12, 16, 42, 30, 0, time.Local)
+	out := renderReport([]auditEntry{
+		serveEntry(base, "", 3, "~/a/.env"),
+		serveEntry(base.Add(-5*time.Minute), "sharingd", 1, "~/b/.env"),
+	})
+	if strings.Contains(out, "likely") {
+		t.Errorf("a reader five minutes away is not this sweep:\n%s", out)
+	}
+}
+
+// A read of the SAME mount is the per-mount carry-forward's territory
+// (identifyReader), not sweep evidence — the hint must not double-claim it.
+func TestSweepHintIgnoresSameMountReads(t *testing.T) {
+	base := time.Date(2026, 8, 12, 16, 42, 30, 0, time.Local)
+	out := renderReport([]auditEntry{
+		serveEntry(base, "", 3, "~/a/.env"),
+		serveEntry(base.Add(-15*time.Second), "sharingd", 1, "~/a/.env"),
+	})
+	if strings.Contains(out, "likely") {
+		t.Errorf("a same-mount read must not produce a sweep hint:\n%s", out)
+	}
+}
+
 // The report's whole reason to exist: the facts a person needs, without the
 // key=value scaffolding the machine form carries.
 func TestAuditReportDropsLogfmtScaffolding(t *testing.T) {


### PR DESCRIPTION
## What

Follow-up to #83. A filesystem sweep (backup tool, indexer, the VM file-sharing daemon) touches every registered mount within one minute; the lineage scan usually wins the race on only some of them. The observed trail showed one identified read (`com.apple.Virtualization.VirtualMachine`, jamf mount, 16:42) beside seven "unidentified reader" siblings in the same minute — the report had the evidence to connect them and didn't.

## How

`attachSweepHints` (report view only) annotates an unidentified serve row with a hanging evidence line:

```
    16:42 ○ opened by an unidentified reader, nothing read           ×7
            ~/Documents/…/hibob/.env, …
            the vault session is locked, so no real value is resolved
            └ likely com.apple.Virtualization.VirtualMachine, which read a sibling mount at 16:42
```

Guardrails, in line with identifyReader's doctrine (an audit trail that lies is worse than one that admits it doesn't know):

- Candidate must be a **lone read** (`count == 1`): a watcher storm at ×45775 proves nothing about its neighbors and would otherwise nominate itself for every sweep in its hour.
- Candidate must be on a **different mount**: a same-mount read is the per-mount carry-forward's territory.
- **±2 minute window**, matching the report's minute-granularity fold.
- **Exactly one distinct candidate name**, else no hint at all — the view says less rather than guessing.
- Viewer-side only: recorded events, logfmt, and JSON stay inference-free, and the hint is phrased as likelihood.

## Tests

`TestSweepHintNamesTheLoneSiblingReader`, plus refusal cases: storm candidate, ambiguous candidates, outside the window, same-mount read.

Full `go test -race ./...` passes; gofmt/vet/staticcheck/gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtcxVok6raU8gipeE29Dwx
