### PR TITLE
serve: re-find a known reader with a targeted check before the full walk

### DIFF
--- a/internal/cli/agent_provenance_test.go
+++ b/internal/cli/agent_provenance_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -193,9 +194,10 @@ func TestIdentifyReaderRejectsAReusedPID(t *testing.T) {
 	// A path nothing holds open, so the live scan is guaranteed to miss and
 	// the fallback is what's under test.
 	unread := filepath.Join(t.TempDir(), "nobody-reads-this")
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
 
 	stale := readerIdentity{pid: 999999, execPath: "/usr/bin/python3", identified: true}
-	if got := identifyReader(unread, stale); got.identified {
+	if got := m.identifyReader(unread, stale); got.identified {
 		t.Errorf("carried forward a reader whose pid is dead or now runs another binary: %+v", got)
 	}
 
@@ -215,7 +217,7 @@ func TestIdentifyReaderRejectsAReusedPID(t *testing.T) {
 		t.Fatal("lineage.Describe couldn't identify this test process")
 	}
 	live := readerIdentity{pid: self.PID, execPath: self.ExecPath, identified: true}
-	got := identifyReader(unread, live)
+	got := m.identifyReader(unread, live)
 	if !got.identified || !got.likely {
 		t.Errorf("dropped a live, still-running reader instead of carrying it forward as likely: %+v", got)
 	}

--- a/internal/cli/mountmanager.go
+++ b/internal/cli/mountmanager.go
@@ -171,12 +171,39 @@ type mountManager struct {
 	grantAncestryFn func(pid, root int32) bool
 	grantStartFn    func(pid int32) (unixMicro int64, ok bool)
 
-	// identifyRetryFn is finalizeServe's post-write identity scan; nil means
-	// lineage.IdentifyFIFOReader. A seam for the same reason the grant ones
-	// are: the retry's gating (delivered-only, missed-scan-only) is what
-	// tests pin down, and none of it should need a real lingering reader.
-	identifyRetryFn func(path string) (pid int32, execPath string, ok bool)
+	// The identity scan's kernel lookups, seamed like the grant gate's: the
+	// known-reader fast path's gating and eviction, and the finalize retry's
+	// bounds, are what tests pin down, and none of it should need real
+	// process trees. Nil means the internal/lineage implementations.
+	identifyFn  func(path string) (pid int32, execPath string, ok bool) // full-table scan
+	holdsFIFOFn func(pid int32, path string) bool                       // one-pid targeted check
+	describeFn  func(pid int32) (execPath string, ok bool)              // pid-reuse guard
+	launcherFn  func(pid int32) string                                  // ancestry naming
+
+	// recentReaders is the service-wide memory behind the known-reader fast
+	// check: the last few DIRECTLY-OBSERVED reader identities, newest first.
+	// A sweep touching every mount in one minute is identified by the full
+	// table walk on whichever mount it lingers at; the sibling mounts' scans
+	// then re-find that same reader with a targeted one-pid check cheap
+	// enough to win the race the walk loses. Its own mutex — noted and
+	// consulted on Serve goroutines, and it must never contend with m.mu.
+	readersMu     sync.Mutex
+	recentReaders []recentReader
 }
+
+// recentReader is one remembered identification. The exec path is the
+// pid-reuse guard (a recycled pid running a different binary is evicted,
+// never matched); launchedBy rides along so a fast-path hit doesn't repeat
+// the ancestry walk.
+type recentReader struct {
+	pid        int32
+	execPath   string
+	launchedBy string
+}
+
+// recentReadersCap bounds the memory: mounts share a handful of live readers
+// (an editor, a sweep daemon, a dev server), not a population.
+const recentReadersCap = 8
 
 // readerIdentity is internal/lineage's best-effort answer to "who just
 // opened this mount" — audit-only (RFC.md §5.1), never consulted by the
@@ -701,7 +728,7 @@ func (m *mountManager) noteReaderConnected(path string, sm *servedMount) {
 		previous := sm.pendingReader
 		sm.mu.Unlock()
 
-		next := identifyReader(path, previous)
+		next := m.identifyReader(path, previous)
 
 		sm.mu.Lock()
 		sm.pendingReader = next
@@ -736,48 +763,152 @@ func (m *mountManager) noteReaderConnected(path string, sm *servedMount) {
 	fmt.Fprintf(m.stderr, "jit service: mount %s: reader connected (not identified, best-effort scan missed it)%s\n", path, suffix)
 }
 
-// identifyReader is the best-effort "who is reading this mount" scan, with a
-// fallback to whoever this mount's PREVIOUS scan found.
+// identifyReader is the best-effort "who is reading this mount" scan: the
+// known-reader fast check first, then the full table walk, then a fallback
+// to whoever this mount's PREVIOUS scan found.
 //
-// The fallback exists because the plain scan produced a genuinely useless log:
-// a mount in an editor's watcher loop alternated between "reader pid=57346
-// (…/Code)" and "reader connected (not identified — best-effort scan missed
-// it)" — the same editor both times, one of which jit had just named. The scan
-// is rate-limited and races a reader that closes fast, so misses are normal,
-// not exceptional.
+// The fast check is the sweep fix: a file-walker touching every mount in one
+// minute was identified on whichever mount it lingered at and "unidentified"
+// on all the siblings, because the full walk (milliseconds) loses the race a
+// targeted one-pid check (microseconds) can win. A candidate that still runs
+// the same executable AND currently holds this mount open is a direct
+// observation, reported flatly — the same evidence the walk produces, found
+// faster.
+//
+// The carry-forward fallback exists because the plain scan produced a
+// genuinely useless log: a mount in an editor's watcher loop alternated
+// between "reader pid=57346 (…/Code)" and "reader connected (not identified —
+// best-effort scan missed it)" — the same editor both times, one of which jit
+// had just named. The scan is rate-limited and races a reader that closes
+// fast, so misses are normal, not exceptional.
 //
 // Carried forward only while the remembered pid is still alive AND still
 // running the same executable: pids get reused, and without that check a
 // recycled pid would let jit attribute one process's read to another program
 // entirely — an audit log that lies is worse than one that admits it doesn't
 // know. The result is marked likely, and every display of it says so.
-func identifyReader(path string, previous readerIdentity) readerIdentity {
-	if pid, execPath, ok := lineage.IdentifyFIFOReader(path); ok {
-		return readerIdentity{
+func (m *mountManager) identifyReader(path string, previous readerIdentity) readerIdentity {
+	if r, ok := m.knownReaderHolding(path, previous); ok {
+		return r
+	}
+	identify := m.identifyFn
+	if identify == nil {
+		identify = lineage.IdentifyFIFOReader
+	}
+	if pid, execPath, ok := identify(path); ok {
+		r := readerIdentity{
 			pid:        pid,
 			execPath:   execPath,
-			launchedBy: launcherOf(pid),
+			launchedBy: m.launcherOf(pid),
 			identified: true,
 		}
+		m.noteRecentReader(r)
+		return r
 	}
-	if previous.identified && stillRunning(previous) {
+	if previous.identified && m.stillRunning(previous) {
 		previous.likely = true
 		return previous
 	}
 	return readerIdentity{}
 }
 
+// knownReaderHolding runs the targeted fast check: this mount's previous
+// reader first (in a watcher loop it is almost always the answer), then the
+// service-wide recent list. A candidate must pass the pid-reuse guard (same
+// executable) and then actually hold this mount's pipe open — both direct
+// observations, so a hit is reported flatly, never as "likely". A candidate
+// whose pid now runs something else is evicted rather than skipped: it can
+// never match again, and a dead entry's slot is worth more than its history.
+func (m *mountManager) knownReaderHolding(path string, previous readerIdentity) (readerIdentity, bool) {
+	holds := m.holdsFIFOFn
+	if holds == nil {
+		holds = lineage.PIDHoldsFIFO
+	}
+
+	candidates := make([]recentReader, 0, recentReadersCap+1)
+	if previous.identified {
+		candidates = append(candidates, recentReader{pid: previous.pid, execPath: previous.execPath, launchedBy: previous.launchedBy})
+	}
+	m.readersMu.Lock()
+	for _, c := range m.recentReaders {
+		if !previous.identified || c.pid != previous.pid {
+			candidates = append(candidates, c)
+		}
+	}
+	m.readersMu.Unlock()
+
+	for _, c := range candidates {
+		execPath, ok := m.describePID(c.pid)
+		if !ok || execPath != c.execPath {
+			m.evictRecentReader(c.pid)
+			continue
+		}
+		if !holds(c.pid, path) {
+			continue
+		}
+		r := readerIdentity{pid: c.pid, execPath: c.execPath, launchedBy: c.launchedBy, identified: true}
+		m.noteRecentReader(r) // refresh recency: the live sweep reader stays first
+		return r, true
+	}
+	return readerIdentity{}, false
+}
+
+// noteRecentReader records a DIRECT observation at the front of the recent
+// list, deduplicated by pid, capped at recentReadersCap. Likely-marked
+// identities are never fed here — the list holds only what a scan actually
+// saw, or the fast check's own inference would compound.
+func (m *mountManager) noteRecentReader(r readerIdentity) {
+	if !r.identified || r.likely {
+		return
+	}
+	m.readersMu.Lock()
+	defer m.readersMu.Unlock()
+	out := make([]recentReader, 0, recentReadersCap)
+	out = append(out, recentReader{pid: r.pid, execPath: r.execPath, launchedBy: r.launchedBy})
+	for _, c := range m.recentReaders {
+		if c.pid != r.pid && len(out) < recentReadersCap {
+			out = append(out, c)
+		}
+	}
+	m.recentReaders = out
+}
+
+// evictRecentReader drops a remembered pid whose process is gone or reused.
+func (m *mountManager) evictRecentReader(pid int32) {
+	m.readersMu.Lock()
+	defer m.readersMu.Unlock()
+	out := m.recentReaders[:0]
+	for _, c := range m.recentReaders {
+		if c.pid != pid {
+			out = append(out, c)
+		}
+	}
+	m.recentReaders = out
+}
+
 // stillRunning reports whether a remembered reader is still the same live
 // process — same pid, still executing the same binary. The exec-path check is
 // what makes pid reuse safe to ignore.
-func stillRunning(r readerIdentity) bool {
-	p, ok := lineage.Describe(r.pid)
-	return ok && p.ExecPath == r.execPath
+func (m *mountManager) stillRunning(r readerIdentity) bool {
+	execPath, ok := m.describePID(r.pid)
+	return ok && execPath == r.execPath
+}
+
+// describePID resolves a pid's executable path through the seam.
+func (m *mountManager) describePID(pid int32) (string, bool) {
+	if m.describeFn != nil {
+		return m.describeFn(pid)
+	}
+	p, ok := lineage.Describe(pid)
+	return p.ExecPath, ok
 }
 
 // launcherOf names what launched pid, skipping relay shells — the mount's
 // answer to the same question `jit service status` answers about an unlock.
-func launcherOf(pid int32) string {
+func (m *mountManager) launcherOf(pid int32) string {
+	if m.launcherFn != nil {
+		return m.launcherFn(pid)
+	}
 	chain := lineage.Ancestry(pid)
 	if len(chain) < 2 {
 		return ""
@@ -815,7 +946,7 @@ func (m *mountManager) finalizeServe(path string, sm *servedMount, delivered boo
 	// holds the pipe now almost certainly is this cycle's reader, but a
 	// brand-new non-blocking reader could have arrived in the gap.
 	if delivered && missed && !rec.reader.identified {
-		identify := m.identifyRetryFn
+		identify := m.identifyFn
 		if identify == nil {
 			identify = lineage.IdentifyFIFOReader
 		}
@@ -823,7 +954,7 @@ func (m *mountManager) finalizeServe(path string, sm *servedMount, delivered boo
 			r := readerIdentity{
 				pid:        pid,
 				execPath:   execPath,
-				launchedBy: launcherOf(pid),
+				launchedBy: m.launcherOf(pid),
 				identified: true,
 				likely:     true,
 			}
@@ -833,6 +964,11 @@ func (m *mountManager) finalizeServe(path string, sm *servedMount, delivered boo
 			sm.mu.Lock()
 			sm.pendingReader = r
 			sm.mu.Unlock()
+			// And the service-wide recent list: the scan DID observe this pid
+			// holding the mount just now — only the attribution to the served
+			// cycle is the inference the likely mark carries — so the sibling
+			// mounts' fast checks may use it.
+			m.noteRecentReader(readerIdentity{pid: pid, execPath: execPath, launchedBy: r.launchedBy, identified: true})
 		}
 	}
 

--- a/internal/cli/mountmanager_test.go
+++ b/internal/cli/mountmanager_test.go
@@ -245,6 +245,129 @@ func TestProvideContentRecordsLastServe(t *testing.T) {
 	// here, where no grant machinery is wired.
 }
 
+// TestKnownReaderFastPathNamesASweepReader is the sweep fix end to end at
+// the unit level: the full-table walk identifies the reader on mount A and
+// feeds the service-wide recent list; mount B's scan — where the walk would
+// lose the race — re-finds that same reader with the targeted one-pid check,
+// names it flatly (a direct observation, not a carry-forward), and never
+// pays for a second walk.
+func TestKnownReaderFastPathNamesASweepReader(t *testing.T) {
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+	fullScans := 0
+	m.identifyFn = func(path string) (int32, string, bool) {
+		fullScans++
+		if path == "/tmp/fixture/a.env" {
+			return 555, "/usr/libexec/sharingd", true
+		}
+		return 0, "", false
+	}
+	m.describeFn = func(pid int32) (string, bool) {
+		if pid == 555 {
+			return "/usr/libexec/sharingd", true
+		}
+		return "", false
+	}
+	m.holdsFIFOFn = func(pid int32, path string) bool { return pid == 555 }
+	m.launcherFn = func(int32) string { return "" }
+
+	got := m.identifyReader("/tmp/fixture/a.env", readerIdentity{})
+	if !got.identified || got.pid != 555 || got.likely {
+		t.Fatalf("mount A: identifyReader = %+v, want the walk's flat identification", got)
+	}
+	if fullScans != 1 {
+		t.Fatalf("mount A: full scans = %d, want 1", fullScans)
+	}
+
+	got = m.identifyReader("/tmp/fixture/b.env", readerIdentity{})
+	if !got.identified || got.pid != 555 || got.likely {
+		t.Errorf("mount B: identifyReader = %+v, want the fast check's flat identification", got)
+	}
+	if fullScans != 1 {
+		t.Errorf("mount B: full scans = %d, want still 1 — the fast check must answer before the walk", fullScans)
+	}
+}
+
+// TestKnownReaderFastPathEvictsAReusedPID: a remembered pid now running a
+// different binary can never match again; it must be dropped from the recent
+// list, never matched against, and the scan must fall through to the walk.
+func TestKnownReaderFastPathEvictsAReusedPID(t *testing.T) {
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+	m.noteRecentReader(readerIdentity{pid: 555, execPath: "/usr/libexec/sharingd", identified: true})
+	m.identifyFn = func(string) (int32, string, bool) { return 0, "", false }
+	m.describeFn = func(int32) (string, bool) { return "/usr/bin/python3", true } // recycled
+	m.holdsFIFOFn = func(int32, string) bool {
+		t.Error("holds check ran for a candidate the pid-reuse guard should have dropped")
+		return false
+	}
+
+	if got := m.identifyReader("/tmp/fixture/a.env", readerIdentity{}); got.identified {
+		t.Errorf("identifyReader = %+v, want unidentified after the eviction", got)
+	}
+	m.readersMu.Lock()
+	left := len(m.recentReaders)
+	m.readersMu.Unlock()
+	if left != 0 {
+		t.Errorf("recent list still holds %d entries, want the reused pid evicted", left)
+	}
+}
+
+// TestKnownReaderUpgradesPreviousToDirectObservation: a mount's previous
+// reader that provably still holds the pipe is a fresh observation, not a
+// carry-forward — the row it produces must not be hedged as "likely".
+func TestKnownReaderUpgradesPreviousToDirectObservation(t *testing.T) {
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+	m.identifyFn = func(string) (int32, string, bool) {
+		t.Error("full walk ran although the previous reader answered the targeted check")
+		return 0, "", false
+	}
+	m.describeFn = func(int32) (string, bool) { return "/usr/local/bin/node", true }
+	m.holdsFIFOFn = func(pid int32, _ string) bool { return pid == 700 }
+
+	previous := readerIdentity{pid: 700, execPath: "/usr/local/bin/node", launchedBy: "Code", identified: true}
+	got := m.identifyReader("/tmp/fixture/a.env", previous)
+	if !got.identified || got.pid != 700 || got.likely {
+		t.Errorf("identifyReader = %+v, want the previous reader confirmed flatly, not marked likely", got)
+	}
+	if got.launchedBy != "Code" {
+		t.Errorf("launchedBy = %q, want it carried without a fresh ancestry walk", got.launchedBy)
+	}
+}
+
+// TestNoteRecentReadersCapDedupeAndDoctrine: newest first, one entry per
+// pid, capped — and likely-marked identities are never admitted, or the fast
+// check's own inference would compound.
+func TestNoteRecentReadersCapDedupeAndDoctrine(t *testing.T) {
+	m := &mountManager{stdout: io.Discard, stderr: io.Discard}
+	for i := 0; i < recentReadersCap+4; i++ {
+		m.noteRecentReader(readerIdentity{pid: int32(100 + i), execPath: "/bin/x", identified: true})
+	}
+	m.readersMu.Lock()
+	n, first := len(m.recentReaders), m.recentReaders[0].pid
+	m.readersMu.Unlock()
+	if n != recentReadersCap {
+		t.Errorf("recent list holds %d entries, want capped at %d", n, recentReadersCap)
+	}
+	if first != int32(100+recentReadersCap+3) {
+		t.Errorf("front of the list = pid %d, want the newest observation", first)
+	}
+
+	m.noteRecentReader(readerIdentity{pid: int32(100 + recentReadersCap), execPath: "/bin/x", identified: true})
+	m.readersMu.Lock()
+	n, first = len(m.recentReaders), m.recentReaders[0].pid
+	m.readersMu.Unlock()
+	if n != recentReadersCap || first != int32(100+recentReadersCap) {
+		t.Errorf("re-noting an existing pid: len=%d front=%d, want moved to front without growing", n, first)
+	}
+
+	m.noteRecentReader(readerIdentity{pid: 9999, execPath: "/bin/x", identified: true, likely: true})
+	m.readersMu.Lock()
+	first = m.recentReaders[0].pid
+	m.readersMu.Unlock()
+	if first == 9999 {
+		t.Error("a likely-marked identity entered the recent list; only direct observations may feed the fast check")
+	}
+}
+
 // TestFinalizeServeRecordsUndelivered pins the record's two-moment shape:
 // nothing is published at decision time, and an EPIPE cycle (the reader was
 // gone before the write — it received nothing) reaches lastServe and the
@@ -294,7 +417,7 @@ func TestFinalizeServeIdentityRetryGating(t *testing.T) {
 		sm.decoy = []byte("decoy")
 		m := &mountManager{stdout: io.Discard, stderr: io.Discard}
 		retries := 0
-		m.identifyRetryFn = func(string) (int32, string, bool) {
+		m.identifyFn = func(string) (int32, string, bool) {
 			retries++
 			return 777, "/usr/libexec/sharingd", true
 		}

--- a/internal/lineage/lineage.go
+++ b/internal/lineage/lineage.go
@@ -87,6 +87,33 @@ func IdentifyFIFOReader(path string) (pid int32, execPath string, ok bool) {
 	return 0, "", false
 }
 
+// PIDHoldsFIFO reports whether pid currently holds path open as a FIFO —
+// IdentifyFIFOReader's scan pointed at ONE process instead of the whole
+// table, a few proc_pidfdinfo calls instead of a full pid walk. It exists
+// for the serve path's known-reader fast check: a sweep that touches every
+// mount in one minute is identified by the full walk on whichever mount it
+// lingers at, and this is how the sibling mounts' scans re-find that same
+// reader before it closes, at a cost cheap enough to spend on a guess.
+// Same audit-only doctrine as the rest of this package: a false here means
+// "not observed", never "not present", and it gates nothing.
+func PIDHoldsFIFO(pid int32, path string) bool {
+	if pid <= 0 || pid == int32(os.Getpid()) {
+		return false
+	}
+	target := resolveTarget(path)
+	fds, err := listVnodeFDs(pid)
+	if err != nil {
+		return false // EPERM/ESRCH: not ours or gone, either way not observed
+	}
+	for _, fd := range fds {
+		p, vtype, err := vnodeInfo(pid, fd)
+		if err == nil && vtype == C.VFIFO && p == target {
+			return true
+		}
+	}
+	return false
+}
+
 // PathHeldOpen reports whether ANY currently-visible process (including
 // this one) holds an open fd on path as a FIFO. Unlike IdentifyFIFOReader,
 // this is allowed to gate one narrow decision in internal/mount's serve

--- a/internal/lineage/lineage_test.go
+++ b/internal/lineage/lineage_test.go
@@ -143,6 +143,75 @@ func TestIdentifyFIFOReaderPermissionBoundary(t *testing.T) {
 // same as TestIdentifyFIFOReaderFindsRealReader — a same-process reader
 // would also be seen (PathHeldOpen deliberately includes our own pid),
 // but the separate process is the case that matters.
+// TestPIDHoldsFIFOTargetedCheck pins the one-pid form of the reader scan:
+// true only for the pid that actually holds the FIFO, false for the wrong
+// path, a wrong pid, and our own process (the serve path's writer must never
+// identify itself as its own reader).
+func TestPIDHoldsFIFOTargetedCheck(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.fifo")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	other := filepath.Join(dir, "other.fifo")
+	if err := unix.Mkfifo(other, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	cmd := exec.Command("cat", path)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("starting reader: %v", err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+	pid := int32(cmd.Process.Pid)
+
+	// Complete cat's read-open so it genuinely holds the fd (a blocked
+	// open holds nothing — see TestPathHeldOpenSeesRealHolderAndItsAbsence).
+	opened := make(chan *os.File, 1)
+	openErr := make(chan error, 1)
+	go func() {
+		f, err := os.OpenFile(path, os.O_WRONLY, 0)
+		if err != nil {
+			openErr <- err
+			return
+		}
+		opened <- f
+	}()
+	var f *os.File
+	select {
+	case f = <-opened:
+	case err := <-openErr:
+		t.Fatalf("opening for write: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the reader to connect")
+	}
+	defer f.Close()
+
+	// Poll: rendezvous completing and the fd appearing in proc_pidfdinfo's
+	// view are not the same instant under CI load (same reasoning as
+	// TestIdentifyFIFOReaderFindsRealReader).
+	deadline := time.Now().Add(5 * time.Second)
+	for !PIDHoldsFIFO(pid, path) {
+		if time.Now().After(deadline) {
+			t.Fatal("PIDHoldsFIFO = false for the pid provably holding the FIFO's read end")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if PIDHoldsFIFO(pid, other) {
+		t.Error("PIDHoldsFIFO = true for a FIFO the pid has never opened")
+	}
+	if PIDHoldsFIFO(pid+100000, path) {
+		t.Error("PIDHoldsFIFO = true for an unrelated (almost certainly dead) pid")
+	}
+	if PIDHoldsFIFO(int32(os.Getpid()), path) {
+		t.Error("PIDHoldsFIFO = true for our own pid — the writer must never read as its own reader")
+	}
+}
+
 func TestPathHeldOpenSeesRealHolderAndItsAbsence(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "test.fifo")

--- a/spike/listpidspath/FINDINGS.md
+++ b/spike/listpidspath/FINDINGS.md
@@ -1,0 +1,42 @@
+# Spike Findings: proc_listpidspath(3) as a cheaper FIFO-reader scan
+
+**Question:** The audit-attribution work (PRs #83-#85) left one open lead: `proc_listpidspath` — one libproc call answering "which pids have this path open" — might replace `internal/lineage`'s enumerate-every-pid fd-table walk, shrinking the reader scan enough to relax the serve path's 2s per-mount rate limit (`lineageScanMinGap`). Is it actually cheaper, and does it see FIFO holders at all?
+
+**Environment:** macOS 26.5.0 (dev VM, 4 cores), arm64, Go 1.26.6, CGo enabled. Measured 2026-08-18.
+
+## Result: functionally correct, ~14x SLOWER — dead end, keep the walk
+
+With a real `cat` blocked reading a FIFO and this process holding the write end:
+
+```
+proc_listpidspath found: [writer, reader]   (reader found: true)
+full walk found:         [reader, writer]   (reader found: true)
+
+per-scan average (50 iterations):
+proc_listpidspath: 42.1ms
+full walk:         3.0ms
+```
+
+Consistent across runs (39.9ms vs 2.8ms on a second pass). Both approaches find both holders once the path is symlink-resolved (`/var` → `/private/var` — the fd table reports the resolved spelling, the same normalization `resolveTarget` already does in production).
+
+## Why it's slower
+
+This confirms the suspicion from Apple's Libc source rather than contradicting it: `proc_listpidspath` is implemented in **userspace**, inside libproc, as its own enumerate-all-pids loop — there is no kernel shortcut to inherit. And its loop does strictly more work than ours per pid: it inspects every fd type plus each process's text/cwd/root vnodes with full path resolution, where `internal/lineage` looks only at vnode-type fds and bails on everything else. The convenience call is the same walk with more baggage.
+
+## Two incidental observations
+
+- `proc_listpidspath` reports **both ends** of the pipe (it matched this process's write fd too). Any use would still need a per-pid fd inspection to tell read-side holders from the writer — the exact code it was supposed to replace.
+- The full walk's ~3ms average here (a quiet VM, ~400 visible pids) is consistent with the ~6ms/scan implied by the 63-CPU-minute incident on a loaded machine (`internal/cli/mountmanager.go`'s rate-limit comment).
+
+## Bottom line
+
+- **Do not adopt `proc_listpidspath`.** The existing walk in `internal/lineage` is the faster primitive, by an order of magnitude.
+- **The rate limit stays.** The scan cost that motivated `lineageScanMinGap` is real and unimprovable by this route; the shipped mitigation — the targeted one-pid `PIDHoldsFIFO` fast check with the service-wide recent-readers list (PR #85) — is the right shape: microseconds on the hot path, the full walk only when the fast path misses.
+
+## How to reproduce
+
+```bash
+cd spike/listpidspath
+CGO_ENABLED=1 go build -o spike .
+./spike -iterations 50
+```

--- a/spike/listpidspath/go.mod
+++ b/spike/listpidspath/go.mod
@@ -1,0 +1,3 @@
+module jit/spike/listpidspath
+
+go 1.26.6

--- a/spike/listpidspath/main.go
+++ b/spike/listpidspath/main.go
@@ -1,0 +1,198 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+// Spike: is proc_listpidspath(3) a cheaper way to answer "which pids hold
+// this FIFO open" than internal/lineage's own pid-table walk?
+//
+// The hope (from the audit-attribution work, PRs #83-#85): a single libproc
+// call that the kernel answers directly would shrink the reader scan from
+// milliseconds to microseconds, letting the serve path relax its 2s
+// per-mount rate limit. The doubt: Apple's Libc source suggests
+// proc_listpidspath is implemented in USERSPACE as the very same
+// enumerate-all-pids + per-pid-fd walk, in which case it saves nothing but
+// the Go-side loop. This spike settles it with numbers: correctness on a
+// real FIFO reader, then wall-clock over N iterations of both approaches.
+//
+// Usage:
+//
+//	go build -o spike . && ./spike -iterations 50
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+	"unsafe"
+)
+
+/*
+#include <libproc.h>
+#include <stdlib.h>
+#include <sys/proc_info.h>
+#include <sys/vnode.h>
+
+static int list_pids_with_path(const char *path, pid_t *buf, int bufsize) {
+	return proc_listpidspath(PROC_ALL_PIDS, 0, path, 0, buf, bufsize);
+}
+
+static int list_all_pids(pid_t *buf, int bufsize) {
+	return proc_listpids(PROC_ALL_PIDS, 0, buf, bufsize);
+}
+
+static int list_fds(pid_t pid, struct proc_fdinfo *buf, int bufsize) {
+	return proc_pidinfo(pid, PROC_PIDLISTFDS, 0, buf, bufsize);
+}
+
+static int get_vnode_info(pid_t pid, int32_t fd, struct vnode_fdinfowithpath *out) {
+	return proc_pidfdinfo(pid, fd, PROC_PIDFDVNODEPATHINFO, out, sizeof(*out));
+}
+
+static int is_vnode_type(uint32_t fdtype) {
+	return fdtype == PROX_FDTYPE_VNODE;
+}
+
+static int is_fifo(uint32_t vtype) {
+	return vtype == VFIFO;
+}
+*/
+import "C"
+
+// viaListPidsPath asks proc_listpidspath directly.
+func viaListPidsPath(path string) []int32 {
+	buf := make([]C.pid_t, 4096)
+	cpath := C.CString(path)
+	defer C.free(unsafe.Pointer(cpath))
+	n := C.list_pids_with_path(cpath, &buf[0], C.int(len(buf))*C.int(unsafe.Sizeof(buf[0])))
+	if n <= 0 {
+		return nil
+	}
+	count := int(n) / int(unsafe.Sizeof(buf[0]))
+	out := make([]int32, 0, count)
+	for i := 0; i < count; i++ {
+		if buf[i] != 0 {
+			out = append(out, int32(buf[i]))
+		}
+	}
+	return out
+}
+
+// viaFullWalk is internal/lineage's IdentifyFIFOReader shape: every pid,
+// every vnode fd, match resolved path + VFIFO.
+func viaFullWalk(path string) []int32 {
+	pids := make([]C.pid_t, 8192)
+	n := C.list_all_pids(&pids[0], C.int(len(pids))*C.int(unsafe.Sizeof(pids[0])))
+	if n <= 0 {
+		return nil
+	}
+	count := int(n) / int(unsafe.Sizeof(pids[0]))
+	var out []int32
+	fdbuf := make([]C.struct_proc_fdinfo, 4096)
+	for i := 0; i < count; i++ {
+		pid := pids[i]
+		if pid <= 0 {
+			continue
+		}
+		fn := C.list_fds(pid, &fdbuf[0], C.int(len(fdbuf))*C.int(unsafe.Sizeof(fdbuf[0])))
+		if fn <= 0 {
+			continue
+		}
+		fdcount := int(fn) / int(unsafe.Sizeof(fdbuf[0]))
+		for j := 0; j < fdcount; j++ {
+			if C.is_vnode_type(fdbuf[j].proc_fdtype) == 0 {
+				continue
+			}
+			var info C.struct_vnode_fdinfowithpath
+			if C.get_vnode_info(pid, C.int32_t(fdbuf[j].proc_fd), &info) <= 0 {
+				continue
+			}
+			if C.is_fifo(C.uint32_t(info.pvip.vip_vi.vi_type)) == 0 {
+				continue
+			}
+			if C.GoString(&info.pvip.vip_path[0]) == path {
+				out = append(out, int32(pid))
+			}
+		}
+	}
+	return out
+}
+
+func contains(pids []int32, want int32) bool {
+	for _, p := range pids {
+		if p == want {
+			return true
+		}
+	}
+	return false
+}
+
+func main() {
+	iterations := flag.Int("iterations", 50, "timing iterations per approach")
+	flag.Parse()
+
+	dir, err := os.MkdirTemp("", "listpidspath-spike")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	// Resolve /var -> /private/var the way internal/lineage's resolveTarget
+	// does: the fd table reports the resolved spelling, and comparing the
+	// unresolved one concludes nothing matches.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+	fifo := filepath.Join(dir, "test.fifo")
+	if err := exec.Command("mkfifo", fifo).Run(); err != nil {
+		panic(err)
+	}
+
+	// A real reader: cat blocks in read() once our write-open completes.
+	reader := exec.Command("cat", fifo)
+	if err := reader.Start(); err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = reader.Process.Kill()
+		_, _ = reader.Process.Wait()
+	}()
+	readerPID := int32(reader.Process.Pid)
+
+	f, err := os.OpenFile(fifo, os.O_WRONLY, 0)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	// Let the reader's fd land in the table (the visibility lag the real
+	// tests poll around).
+	time.Sleep(200 * time.Millisecond)
+
+	// Correctness first.
+	lp := viaListPidsPath(fifo)
+	fw := viaFullWalk(fifo)
+	fmt.Printf("reader pid: %d\n", readerPID)
+	fmt.Printf("proc_listpidspath found: %v (reader found: %v)\n", lp, contains(lp, readerPID))
+	fmt.Printf("full walk found:         %v (reader found: %v)\n", fw, contains(fw, readerPID))
+
+	// Timing.
+	start := time.Now()
+	for i := 0; i < *iterations; i++ {
+		viaListPidsPath(fifo)
+	}
+	lpDur := time.Since(start) / time.Duration(*iterations)
+
+	start = time.Now()
+	for i := 0; i < *iterations; i++ {
+		viaFullWalk(fifo)
+	}
+	fwDur := time.Since(start) / time.Duration(*iterations)
+
+	fmt.Printf("\nper-scan average over %d iterations:\n", *iterations)
+	fmt.Printf("proc_listpidspath: %v\n", lpDur)
+	fmt.Printf("full walk:         %v\n", fwDur)
+	if lpDur > 0 {
+		fmt.Printf("ratio (walk/listpidspath): %.1fx\n", float64(fwDur)/float64(lpDur))
+	}
+}


### PR DESCRIPTION
## What

Item 3 of the decoy-attribution work (#83, #84): name the sweep readers outright instead of inferring them after the fact.

A sweep touches every registered mount inside one minute, and the full libproc table walk (milliseconds) loses the identification race on most of them. The observed trail: the VM file-sharing daemon named on one mount, "unidentified reader" on its thirteen siblings, same minute, same process.

## How

- `lineage.PIDHoldsFIFO(pid, path)`: the reader scan pointed at ONE pid — a few `proc_pidfdinfo` calls, microseconds, cheap enough to spend on a guess. Same audit-only doctrine as the rest of the package; excludes our own pid so the serve writer can never read as its own reader.
- `mountManager.recentReaders`: the last few **directly observed** reader identities, service-wide, newest first, capped at 8. Pid-reuse is guarded by exec path: a recycled pid is evicted, never matched. Likely-marked identities never enter the list, or the fast check's own inference would compound.
- `identifyReader` (now a method) tries the targeted check first — this mount's previous reader, then the recent list — and only then pays for the full walk. A candidate that still runs the same binary and provably holds this mount's pipe is a direct observation, reported flatly.

Two upgrades fall out for free:

- A watcher-loop mount's previous reader that provably still holds the pipe is now named flatly instead of hedged "(likely)".
- The finalize retry's find (from #83) feeds the recent list, so it helps sibling mounts too.

## Tests

- `TestPIDHoldsFIFOTargetedCheck` drives a real `cat` reader over a real FIFO (right pid, wrong path, wrong pid, self).
- `TestKnownReaderFastPathNamesASweepReader` pins the sweep scenario: walk identifies on mount A, fast check answers on mount B with no second walk.
- `TestKnownReaderFastPathEvictsAReusedPID`, `TestKnownReaderUpgradesPreviousToDirectObservation`, `TestNoteRecentReadersCapDedupeAndDoctrine` pin the guardrails.

Full `go test -race ./...` passes; gofmt/vet/staticcheck/gosec clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtcxVok6raU8gipeE29Dwx
