### PR TITLE
sessions: expiry as vault metadata, a status row, and clisso status from the vault

### DIFF
--- a/design/sessions-and-path-repair.md
+++ b/design/sessions-and-path-repair.md
@@ -1,0 +1,269 @@
+# Sessions, and repairing a recorded jit path
+
+**Status: PR 1 in progress (2026-09-05); PR 2 and the runbook edit proposed.**
+
+## What prompted this
+
+A morning lost to `clisso get` failing with `406 Not Acceptable`. The cause
+was an expired OneLogin password (406 is OneLogin's lockout after repeated
+failures; the honest 401 `Invalid user credentials` only shows once the
+lockout clears), and jit was not involved. Taking the failure apart still
+found three real defects in jit, and one in the runbook that wraps it.
+
+What the investigation established, so nobody re-derives it:
+
+- The config jit renders and serves over the FIFO reaches clisso complete
+  and correct (`clisso --log-level debug get` prints every field it read).
+  The OAuth call, whose only jit-supplied input is the vaulted
+  client-secret, succeeds. jit contributes zero bytes to the call that
+  fails.
+- `clisso status` under the wrap is a pure `syscall.Exec` passthrough. It
+  reads the on-disk config's `global.output: ~/.aws/credentials`, the file
+  jit deliberately empties, and reports "No apps with valid credentials"
+  while a valid session sits in the vault. Upstream cannot fix this either:
+  clisso's `status` for `credential_process` mode is a bare `// TODO` that
+  returns nothing. Every script that reuses a session by grepping
+  `clisso status` (the team's `k8s` login function does) therefore
+  re-logins with full MFA on every call.
+- `jit doctor` reports a version-pinned `~/.kube/config` exec path
+  (`Caskroom/jitpass/0.84.0/jit`, written before `internal/selfpath`) and
+  prescribes `jit migrate ~/.kube/config`. On an already-migrated file that
+  prints "Nothing to migrate" and changes nothing. There is no repair path
+  for a recorded jit path anywhere in jit, and `kindJitPathUpgrade` names
+  the same dead action.
+- "Heal on `jit upgrade`" cannot work: a Homebrew jit refuses `jit upgrade`
+  and hands off to `brew upgrade`, which never runs jit — and Homebrew is
+  exactly where version-pinned paths come from. Repair must be explicit.
+- `dev`/`admin` are NOT broken under the wrap. `StoreAWSSession` upserts the
+  `credential_process` line into `~/.aws/config` on every capture; a profile
+  is missing only until its first successful login.
+- `jit status` opens the vault with `openVaultReadOnly()` — no unlock, by
+  design. Any dashboard row must be answerable from envelope metadata
+  (`Info()`), never from a decrypted value.
+
+## PR 1 — sessions
+
+### The feature
+
+A **session** is a vaulted credential with a known end. jit already stores
+one tool-agnostically: `EXPIRATION` is written by the clisso capture AND by
+migrating a `~/.aws/credentials` that carries `aws_expiration` (aws sso,
+saml2aws, aws-vault, any SAML minter), and `aws-credential-process` already
+honors it, refusing a dead session by name. What is missing is a surface.
+`jit status` shows expiry for grants and nothing for sessions.
+
+Three layers, bottom up.
+
+### Layer 0 — expiry as envelope metadata (`internal/vault`)
+
+`Meta` and `SecretInfo` gain `ExpiresUnix int64`; the envelope gains
+`expires_unix` (omitempty), AAD-bound like the timestamps and provenance,
+and `envelopeVersion` moves to 5. Rationale: an expiry is not a secret
+(the SDK receives it, clisso writes it in plaintext), and the dashboard
+must read it without an unlock. Binding it into the AAD keeps the property
+the `[storage format]` doctor finding exists for: a stamp edited on disk
+fails decryption rather than resurrecting a dead session.
+
+Writers: `StoreAWSSession` (capture) and the `~/.aws/credentials` migration
+set it on every secret of the session from the parsed RFC3339 stamp. The
+`EXPIRATION` variable stays — it is what `credential_process` serves — so
+this is additive. A stamp that does not parse sets nothing, matching
+`buildAWSCredentialProcessOutput`'s "pass it through, let the SDK complain"
+rule.
+
+Older envelopes have no stamp and render as unknown, never as 1970 — the
+same rule `SecretInfo` already states for v1 timestamps. They heal on the
+next login. `Verify`/`GetStored` accept version 5 the way they accept 4.
+
+### Layer 1 — one query (`internal/migrate`)
+
+    ListSessions(v *vault.Vault, root string, now time.Time) ([]Session, error)
+
+For every profile manifest under root (global `~/.jit/profiles` for the
+dashboard; `profile.ListAll` already enumerates) whose variables include
+`EXPIRATION`: name, expiry, remaining, and the origin path from `Info()` —
+which tool minted it. Keyed on the variable, not on a tool name, so a
+future capture wrap (`aws sso login`, `gcloud auth`, `saml2aws`) is covered
+by following the convention that already exists. Reads `Info()` only; never
+`Get()`.
+
+### Layer 2 — surfaces
+
+**`jit status`** gains a `sessions` row beside `grants`, same shape
+(`printGrantsSection` is the template), and a `sessions` object in
+`--format json` so a script can ask without parsing text:
+
+    sessions  2 valid · stage expires in 9h12m · prod expired 3h ago
+
+Naming was checked: the dashboard renders the broker as
+"unlocked / locks in", not "session", and "AWS session" is already the
+code's and docs' word for a minted credential (38 uses vs 5 for the
+broker's). No collision on the surface the user reads.
+
+**`clisso status` under the wrap** becomes a third intercepted family in
+`runClissoCapture`, beside `get` and the config mutators. Gated the way
+`get` is: only when the on-disk config carries a `jit://vault` pointer (the
+wrap owns it) and the user passed no `-r/--read-from-file` — an explicit
+`-r` is the user asking for clisso's own behavior, the same rule `-o`
+applies to `get`. It renders `ListSessions` filtered to the apps
+`~/.clisso.yaml` defines — not to origin, which is birth-immutable and
+would disown a profile first migrated out of `~/.aws/credentials` and
+re-minted by clisso ever after — in clisso's own `App / Expire At /
+Remaining` table (EXPIRE AT as a date and time, the one departure), so
+`clisso status | grep -qw stage` and every other script keep working
+unchanged. jit's stdout stays clisso-shaped on purpose; a jit-styled report
+would break exactly the callers this fixes. jit's own commentary goes to
+stderr, per the file's existing rule. Unlock-free, thanks to layer 0.
+
+Held back, deliberately: a `jit status --session <name>` exit-code check for
+scripts. `--format json` covers it; add the flag when a second script asks.
+
+### Tests
+
+- vault: v5 round-trip; a v4 envelope reads with `ExpiresUnix == 0`;
+  editing `expires_unix` on disk fails decryption (AAD).
+- migrate: `ListSessions` over a temp profiles dir with a live, an expired,
+  a stampless (old) and a non-`EXPIRATION` profile; capture and
+  credentials-migration both stamp; a malformed stamp stamps nothing.
+- cli: the status row and JSON for 0 / 1 / n sessions, expired and live;
+  `parseClissoArgs` routing for `status`, `status -r x`,
+  `--log-level warn status`; the rendered table fed through `grep -qw`.
+- Terminal output is previewed to the user before the row is wired
+  (CLAUDE.md rule); `TestNoGlyphLiterals`/`TestPaletteIsCentralised` hold.
+
+## PR 2 — `jit doctor --fix`
+
+### Scope
+
+One flag, one finding class: `[jit path]` (`kindJitPath` and
+`kindJitPathUpgrade`). doctor stays a report; `--fix` is the narrow
+exception, in the shape `jit vault orphans --prune` already has. Nothing
+else in doctor becomes writable.
+
+### One rule for detect and repair
+
+Both use `jitPathArtifacts` (which files), `recordedJitPath` (which line),
+and `selfpath.Durable()` (the answer). If `Durable()` refuses — a `/tmp` jit,
+an unmatched Caskroom copy — doctor reports the refusal instead of writing.
+It never records a path it would itself flag next run.
+
+### Mechanics
+
+Line-anchored substitution on the matched line only, so YAML, comments and
+every other entry survive byte-for-byte; encrypted backup through
+`BackupTracker.backupOnce` so `jit migrate undo` covers it; atomic write
+via `vault.AtomicWriteFile`; mode preserved. Idempotent: a second `--fix`
+finds nothing. Each rewrite prints one `✓` line naming the file and the
+new path.
+
+### Action text
+
+Both kinds change from `jit migrate <file>` to `jit doctor --fix`. This is
+the part that repairs trust regardless of whether anyone runs the flag: a
+user who follows doctor's prescription and still sees `✗` stops believing
+doctor.
+
+### Deferred
+
+Auto-heal from `jit service` at login (it runs after every `brew upgrade`).
+Rewriting `~/.aws/config` unprompted from a daemon needs its own note; ship
+the explicit form first.
+
+### Tests
+
+Golden files for each of the five artifacts: versioned → bin symlink;
+already-durable → untouched; an unrelated `/usr/bin/jit` in a comment →
+untouched; `Durable()` refusal reports and writes nothing; undo restores
+the original.
+
+## Runbook (Notion "Kubernetes Login V2") — no PR
+
+- Session test: `aws sts get-caller-identity --profile "$env"` — truthful
+  with or without jit, catches a revoked session (which `clisso status`
+  never could), and works on a machine that has not picked up PR 1.
+- The "must be sourced" guard is dead code in zsh: `BASH_SOURCE` is never
+  set and `$0` is the file either way (verified, zsh 5.9). Use
+  `[[ $ZSH_EVAL_CONTEXT == *:file:* ]]` for the zsh branch.
+- Setup step 2: one sentence that on a jit machine `jit wrap clisso` moves
+  the client-secret to the vault and leaves a `jit://vault/...` pointer in
+  `~/.clisso.yaml`; that is expected.
+- Troubleshooting entry, the lesson of the day: **401 = wrong password;
+  406 = OneLogin lockout after repeated failures, almost always an expired
+  password. Reset it in OneLogin, then `clisso providers passwd blockaid`.**
+- Nothing about creating AWS profiles: the capture creates them.
+
+## How the code gets written
+
+The repo's conventions are the review checklist; the plan commits to them
+up front rather than discovering them in review.
+
+**Layering is fixed, and the plan respects it.** `vault` < `migrate` <
+`cli`, with `selfpath` and `style` below all three. `ListSessions` lives in
+`migrate` because it reads profile manifests and vault metadata and is
+needed by two `cli` surfaces; the envelope field lives in `vault` because
+nothing else may know the on-disk format. No new package: a `Session`
+struct and one function are not a package.
+
+**Pure core, thin shell.** The repo's stated pattern (`resolveRunPlan`,
+`buildAWSCredentialProcessOutput`) is to split what a command decides from
+the `RunE` that performs it, so the decision is testable without a vault
+or a Touch ID. Applied here: `ListSessions` takes `now` as a parameter and
+reads only `Info()`; the clisso table and the status row are pure renderers
+over its result; the path repair is `repairRecordedPath(line, durable) ->
+(newLine, changed)` with the file I/O around it. Every test in the plan is
+a table test over these, not a pty capture.
+
+**No speculative abstraction.** One `Session` type keyed on a variable, not
+a `SessionProvider` interface with a clisso implementation. A second
+capture tool changes nothing here — that is the test that the abstraction
+is at the right altitude (`TECH_STACK.md` §3).
+
+**Read the `doc.go` first, then write the `why`.** Comments in this tree
+explain the decision and the failure it prevents, not what the line does.
+Each new function carries the one it exists for: why expiry is metadata
+(the dashboard is prompt-free), why the table is clisso-shaped (existing
+grep callers), why `-r` opts out (the user asked for clisso's behavior),
+why repair refuses on `Durable()` error (never record what doctor flags).
+
+**Format compatibility is explicit.** Envelope v5 is additive: a v4 file
+reads with `ExpiresUnix == 0`, `Verify`/`GetStored` list v5 beside v4, and
+the "newer than this jit understands" error stays the answer for v6. The
+test for "an edited stamp fails decryption" is what proves the field is
+AAD-bound and not merely present.
+
+**Output goes through the seam.** Every glyph and ink via `internal/style`
+(`cOK`, `glyphOK`, …) — `TestNoGlyphLiterals` and `TestPaletteIsCentralised`
+enforce it. One clause per line, ~72 chars, variable content truncated not
+wrapped. The status row is previewed with a script the user runs at their
+own width before it is wired (CLAUDE.md rule). clisso's table is the one
+place house style does not apply: it is clisso's output, imitated on
+purpose.
+
+**Errors name the one command.** `"…; run `jit doctor --fix`"` — not a
+paragraph, and never a command that does nothing, which is the defect PR 2
+fixes.
+
+**No new dependencies.** Both PRs are stdlib plus what is already in
+`go.mod`. `TECH_STACK.md` §2 is not touched.
+
+**Security annotations are justified, not sprinkled.** Any `#nosec` on the
+file writes says why (fixed, jit-owned artifact paths), matching the
+existing ones in `doctorsections.go`. The repair writes only lines that
+matched `recordedJitPath` under the artifact's `Key`, so a hostile config
+cannot steer it to rewrite something else.
+
+**Every file carries the SPDX header**, `gofmt`/`vet`/`staticcheck`/
+`gosec`/`govulncheck` at the pinned versions pass locally before push, and
+`go run ./cmd/jit docs-gen` runs after the `--fix` flag lands (CI checks
+`git status --porcelain`, so an untracked page fails it).
+
+**One PR per feature, explicit staging.** `git add <paths>`, never `-A`;
+`git diff --cached --name-only` before commit; no stash. Commit messages
+in the tree's voice (`feat(status): …`, `fix(doctor): …`, one sentence
+saying what changed for the user). No sign-off trailer on the maintainer's
+own commits. No commits Sun–Thu 09:00–18:00.
+
+## Order
+
+PR 1 (layer 0 → 1 → 2, one PR, output preview before the row is wired),
+PR 2, then the Notion edit. Each is independent of the others.

--- a/docs/reference/commands/jit_status.md
+++ b/docs/reference/commands/jit_status.md
@@ -10,6 +10,8 @@ The Secrets section reconciles the vault against the profiles jit can see: every
 
 An unreferenced group holding the same key names as a group still in use is called out as such: usually a second migration renamed the group and left the original copy behind, and those leftovers are usually the bulk of what jit vault orphans would prune. Key names are compared, never values, since status never decrypts.
 
+A sessions row appears once a wrapped SSO tool (jit wrap clisso) has minted temporary credentials into the vault: each with its expiry, so the morning's login can be checked without re-running it. Read from envelope metadata, so this too never prompts.
+
 --format json prints a machine-readable snapshot instead of the default text report, in the same shape jit service status/vault list/doctor's own --format json use for their overlapping sections.
 
 ```

--- a/docs/wrap/clisso.md
+++ b/docs/wrap/clisso.md
@@ -77,10 +77,12 @@ this wrap exists to remove.
 ## When the session expires
 
 Nothing changes from your current routine: when the session dies (your
-`duration`, up to 12 h), AWS commands report the credentials expired and
-you run `clisso get <app>` again. jit serves the real `Expiration` to
-SDKs, so long-running processes refresh on schedule instead of caching a
-dead token.
+`duration`, up to 12 h), AWS commands report the credentials expired -
+jit's error names the exact command, `clisso get <app>` - and you run it
+again. jit serves the real `Expiration` to SDKs, so long-running
+processes refresh on schedule instead of caching a dead token, and
+`jit status` shows every session's expiry so you can check before a
+command fails.
 
 ## `clisso status` answers from the vault
 

--- a/docs/wrap/clisso.md
+++ b/docs/wrap/clisso.md
@@ -82,11 +82,38 @@ you run `clisso get <app>` again. jit serves the real `Expiration` to
 SDKs, so long-running processes refresh on schedule instead of caching a
 dead token.
 
+## `clisso status` answers from the vault
+
+clisso's own `status` reads `~/.aws/credentials` - the file this wrap keeps
+empty - so passed through it would say "No apps with valid credentials"
+while a perfectly good session sits in the vault, and a login script that
+checks it before calling `clisso get` would re-login with full MFA every
+time. Under the wrap, `clisso status` lists the sessions jit captured, in
+clisso's own table, so `clisso status | grep -qw stage` keeps working:
+
+```
++-------+------------------+-----------+
+|  APP  |    EXPIRE AT     | REMAINING |
++-------+------------------+-----------+
+| stage | 2026-09-05 21:11 | 9h11m     |
++-------+------------------+-----------+
+```
+
+The one difference from clisso's table is EXPIRE AT: a date and time
+instead of the raw epoch. It reads the expiry from vault metadata, never a
+value, so it never prompts. A `-r/--read-from-file` you pass yourself is
+honored - that is clisso's own status, on the file you named. The same
+sessions appear as a row in `jit status`.
+
+Sessions captured by a jit older than the expiry stamp are left out of the
+table until their next `clisso get` (a script that saw one would skip the
+login; one that doesn't logs in once and the stamp is there from then on).
+
 ## What passes through untouched
 
-Every clisso invocation that isn't a plain `get` - `clisso apps`,
-`clisso providers`, `clisso status`, `clisso cp`, `--help` - and any `get`
-where you explicitly chose an output (`-o/--output`, `-w/--write-to-file`,
+Every clisso invocation that isn't a plain `get` or `status` - `clisso
+apps`, `clisso providers`, `clisso cp`, `--help` - and any `get` where you
+explicitly chose an output (`-o/--output`, `-w/--write-to-file`,
 `-s/--shell`) runs the real clisso unchanged (config still served,
 `apps`/`providers`/`cp` still reconciled). The shim reroutes the default
 destination; it doesn't argue with explicit flags. A `-c/--config` you pass

--- a/internal/cli/awscred.go
+++ b/internal/cli/awscred.go
@@ -74,7 +74,7 @@ var awsCredentialProcessCmd = &cobra.Command{
 			return fmt.Errorf("jit aws-credential-process: %w", err)
 		}
 
-		out, err := buildAWSCredentialProcessOutput(values, time.Now())
+		out, err := buildAWSCredentialProcessOutput(values, clissoMint(awsCredProfile, clissoApps()), time.Now())
 		if err != nil {
 			return fmt.Errorf("jit aws-credential-process: profile %q: %w", awsCredProfile, err)
 		}
@@ -101,17 +101,25 @@ var awsCredentialProcessCmd = &cobra.Command{
 // the stamp is in the past the answer is an error naming the expiry, not
 // the dead token: every AWS call made with it would fail ExpiredToken
 // anyway, and this error is the only place the user can be told to mint
-// fresh credentials with the tool that issued them. A stamp that doesn't
-// parse as RFC3339 is passed through untouched: the SDK's own complaint
-// about it beats jit guessing, and refusing to serve live credentials
-// over a malformed timestamp would be the wrong trade.
-func buildAWSCredentialProcessOutput(values map[string]string, now time.Time) (awsCredentialProcessOutput, error) {
+// fresh credentials with the tool that issued them — by name when mint
+// says which command that is (clissoMint: the app is one ~/.clisso.yaml
+// defines), generically otherwise. It is the error kubectl and the AWS
+// CLI surface when the morning's login has run out, so the command to
+// type belongs in it. A stamp that doesn't parse as RFC3339 is passed
+// through untouched: the SDK's own complaint about it beats jit guessing,
+// and refusing to serve live credentials over a malformed timestamp would
+// be the wrong trade.
+func buildAWSCredentialProcessOutput(values map[string]string, mint string, now time.Time) (awsCredentialProcessOutput, error) {
 	if values["ACCESS_KEY_ID"] == "" || values["SECRET_ACCESS_KEY"] == "" {
 		return awsCredentialProcessOutput{}, fmt.Errorf("missing ACCESS_KEY_ID/SECRET_ACCESS_KEY")
 	}
 	expiration := values["EXPIRATION"]
 	if expiration != "" {
 		if t, perr := time.Parse(time.RFC3339, expiration); perr == nil && !t.After(now) {
+			if mint != "" {
+				return awsCredentialProcessOutput{}, fmt.Errorf(
+					"temporary credentials expired at %s; run `%s` to mint fresh ones, then retry", expiration, mint)
+			}
 			return awsCredentialProcessOutput{}, fmt.Errorf(
 				"temporary credentials expired at %s; mint fresh ones with the tool that issued them (for a SAML/SSO CLI, its get/login command), then retry",
 				expiration)

--- a/internal/cli/awscred_test.go
+++ b/internal/cli/awscred_test.go
@@ -16,7 +16,7 @@ func TestBuildAWSCredentialProcessOutputShape(t *testing.T) {
 	out, err := buildAWSCredentialProcessOutput(map[string]string{
 		"ACCESS_KEY_ID":     "AKIAIOSFODNN7EXAMPLE",
 		"SECRET_ACCESS_KEY": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-	}, time.Now())
+	}, "", time.Now())
 	if err != nil {
 		t.Fatalf("buildAWSCredentialProcessOutput: %v", err)
 	}
@@ -45,7 +45,7 @@ func TestBuildAWSCredentialProcessOutputIncludesSessionToken(t *testing.T) {
 		"ACCESS_KEY_ID":     "AKIA1",
 		"SECRET_ACCESS_KEY": "secret1",
 		"SESSION_TOKEN":     "tok123",
-	}, time.Now())
+	}, "", time.Now())
 	if err != nil {
 		t.Fatalf("buildAWSCredentialProcessOutput: %v", err)
 	}
@@ -56,10 +56,10 @@ func TestBuildAWSCredentialProcessOutputIncludesSessionToken(t *testing.T) {
 }
 
 func TestBuildAWSCredentialProcessOutputMissingKeysErrors(t *testing.T) {
-	if _, err := buildAWSCredentialProcessOutput(map[string]string{"ACCESS_KEY_ID": "AKIA1"}, time.Now()); err == nil {
+	if _, err := buildAWSCredentialProcessOutput(map[string]string{"ACCESS_KEY_ID": "AKIA1"}, "", time.Now()); err == nil {
 		t.Fatal("expected an error for a profile missing SECRET_ACCESS_KEY")
 	}
-	if _, err := buildAWSCredentialProcessOutput(map[string]string{}, time.Now()); err == nil {
+	if _, err := buildAWSCredentialProcessOutput(map[string]string{}, "", time.Now()); err == nil {
 		t.Fatal("expected an error for an empty profile")
 	}
 }
@@ -71,7 +71,7 @@ func TestBuildAWSCredentialProcessOutputPassesExpirationThrough(t *testing.T) {
 		"SECRET_ACCESS_KEY": "secret1",
 		"SESSION_TOKEN":     "tok123",
 		"EXPIRATION":        "2026-07-29T19:00:11Z",
-	}, now)
+	}, "", now)
 	if err != nil {
 		t.Fatalf("buildAWSCredentialProcessOutput: %v", err)
 	}
@@ -88,7 +88,7 @@ func TestBuildAWSCredentialProcessOutputRefusesExpiredToken(t *testing.T) {
 		"SECRET_ACCESS_KEY": "secret1",
 		"SESSION_TOKEN":     "tok123",
 		"EXPIRATION":        "2026-07-29T19:00:11Z",
-	}, now)
+	}, "", now)
 	if err == nil {
 		t.Fatal("expected an error for an expired token, got credentials")
 	}
@@ -96,6 +96,28 @@ func TestBuildAWSCredentialProcessOutputRefusesExpiredToken(t *testing.T) {
 	// what to do — it must name the expiry time.
 	if !strings.Contains(err.Error(), "2026-07-29T19:00:11Z") {
 		t.Errorf("expected the expiry timestamp in the error, got: %v", err)
+	}
+	if strings.Contains(err.Error(), "clisso") {
+		t.Errorf("no mint command was known, yet the error names one: %v", err)
+	}
+
+	// When jit knows which tool minted the session, the error says the
+	// exact command — this is what kubectl shows when the login ran out.
+	_, err = buildAWSCredentialProcessOutput(map[string]string{
+		"ACCESS_KEY_ID": "AKIA1", "SECRET_ACCESS_KEY": "secret1", "EXPIRATION": "2026-07-29T19:00:11Z",
+	}, "clisso get stage", now)
+	if err == nil || !strings.Contains(err.Error(), "run `clisso get stage` to mint fresh ones") {
+		t.Errorf("expected the mint command in the error, got: %v", err)
+	}
+}
+
+func TestClissoMint(t *testing.T) {
+	apps := map[string]bool{"stage": true}
+	if got := clissoMint("aws-stage", apps); got != "clisso get stage" {
+		t.Errorf("clissoMint(aws-stage) = %q", got)
+	}
+	if got := clissoMint("aws-ci", apps); got != "" {
+		t.Errorf("clissoMint(aws-ci) = %q, want \"\" for an app clisso does not define", got)
 	}
 }
 
@@ -106,7 +128,7 @@ func TestBuildAWSCredentialProcessOutputMalformedExpirationServed(t *testing.T) 
 		"ACCESS_KEY_ID":     "AKIA1",
 		"SECRET_ACCESS_KEY": "secret1",
 		"EXPIRATION":        "not-a-timestamp",
-	}, time.Now())
+	}, "", time.Now())
 	if err != nil {
 		t.Fatalf("buildAWSCredentialProcessOutput: %v", err)
 	}

--- a/internal/cli/clissocapture.go
+++ b/internal/cli/clissocapture.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -107,6 +108,23 @@ func runClissoCapture(real string, args []string) error {
 	app, capturable := clissoCaptureApp(args)
 	isGet := inv.sub == "get"
 	openV := memoizedVaultOpener()
+
+	// `clisso status` reads ~/.aws/credentials — the file this wrap keeps
+	// empty — so passed through it denies every session the vault holds,
+	// and a script that reuses a session by grepping it re-logins with
+	// full MFA each time. Answer it from the vault instead: metadata only,
+	// no unlock. Not when the user named a file with -r (their own
+	// arrangement, the same rule -o applies to get), and not when the
+	// config isn't wrapped at all (clisso's own answer is honest then).
+	if inv.sub == "status" && !inv.help && !inv.explicitRead {
+		wrapped, err := clissoConfigWrapped()
+		if err != nil {
+			return fmt.Errorf("jit clisso-capture: %w", err)
+		}
+		if wrapped {
+			return runClissoStatus(os.Stdout, os.Stderr, time.Now())
+		}
+	}
 
 	// Any `get` needs the REAL config: after `jit wrap clisso` the on-disk
 	// ~/.clisso.yaml holds a jit://vault pointer where the OneLogin
@@ -237,12 +255,13 @@ func runClissoCapture(real string, args []string) error {
 // independent scans, because every question here depends on the same fact:
 // where the subcommand actually is.
 type clissoInvocation struct {
-	sub         string // the subcommand ("get", "apps", …), "" if none
-	app         string // first bare argument after the subcommand
-	configPath  string // the user's own -c/--config, if any
-	explicitOut bool   // -o/--output, -w/--write-to-file, or -s/--shell
-	help        bool
-	cacheEnable bool
+	sub          string // the subcommand ("get", "apps", …), "" if none
+	app          string // first bare argument after the subcommand
+	configPath   string // the user's own -c/--config, if any
+	explicitOut  bool   // -o/--output, -w/--write-to-file, or -s/--shell
+	explicitRead bool   // status's -r/--read-from-file: the user named the file
+	help         bool
+	cacheEnable  bool
 }
 
 // clissoValueFlags are the flags that consume the NEXT argument — root
@@ -253,9 +272,11 @@ var clissoValueFlags = map[string]bool{
 	"--log-file": true, "--log-level": true,
 	"-m": true, "--mfa-device": true,
 	"-o": true, "--output": true,
-	"--cache-path":    true,
-	"-w":              true,
-	"--write-to-file": true,
+	"--cache-path":     true,
+	"-w":               true,
+	"--write-to-file":  true,
+	"-r":               true,
+	"--read-from-file": true,
 }
 
 // clissoOutputFlags are the ways a user explicitly chooses where
@@ -306,6 +327,8 @@ func parseClissoArgs(args []string) clissoInvocation {
 			// A bool flag: bare means true, and only an explicit
 			// =false turns it off.
 			inv.cacheEnable = !hasEq || !strings.EqualFold(val, "false")
+		case name == "-r" || name == "--read-from-file":
+			inv.explicitRead = true
 		}
 		if clissoOutputFlags[name] {
 			inv.explicitOut = true
@@ -460,6 +483,46 @@ func serveClissoConfig(openV vaultOpener) (fifo string, serving bool, cleanup fu
 	}, nil
 }
 
+// clissoConfigWrapped reports whether ~/.clisso.yaml is the wrap's: it
+// holds a jit://vault pointer where a client-secret was. A missing config
+// is simply not wrapped.
+func clissoConfigWrapped() (bool, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, err
+	}
+	data, err := os.ReadFile(migrate.ClissoConfigPath(home)) // #nosec G304 -- fixed ~/.clisso.yaml under the user's home
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return bytes.Contains(data, []byte(pointerfile.ValuePrefix)), nil
+}
+
+// runClissoStatus is the wrapped `clisso status`: clisso's own sessions,
+// from the vault, in clisso's own table. Read-only vault, so it never
+// prompts — the whole point of stamping expiry as metadata. jit's one
+// line of attribution goes to stderr; stdout stays what a script expects.
+func runClissoStatus(stdout, stderr io.Writer, now time.Time) error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("jit clisso-capture: %w", err)
+	}
+	v, err := openVaultReadOnly()
+	if err != nil {
+		return fmt.Errorf("jit clisso-capture: %w", err)
+	}
+	sessions, err := migrate.ListSessions(v, home, now)
+	if err != nil {
+		return fmt.Errorf("jit clisso-capture: listing sessions: %w", err)
+	}
+	fmt.Fprintln(stderr, "jit: answered from the vault; the wrap keeps ~/.aws/credentials empty")
+	renderClissoStatusTable(stdout, clissoStatusRows(sessions, clissoApps(), now))
+	return nil
+}
+
 // clissoCaptureApp decides whether args are a capturable `clisso get` and,
 // if so, which app is being fetched — the name that becomes the AWS profile
 // (clisso writes credentials under the app's name, so app name == profile
@@ -557,26 +620,51 @@ func warnClissoCredentialProcess() {
 // any failure returns "", and the caller passes through to clisso, whose
 // own "no app specified" error is the right message.
 func clissoSelectedApp(configPath string) string {
+	return readClissoConfig(configPath).Global.SelectedApp
+}
+
+// clissoConfig is the little of ~/.clisso.yaml the shim reads: the default
+// app, and which apps clisso knows at all — the rule for "is this vaulted
+// session clisso's". Origin cannot answer that: a profile first migrated
+// out of ~/.aws/credentials and re-minted by clisso ever after keeps its
+// birth origin, and would never count.
+type clissoConfig struct {
+	Global struct {
+		SelectedApp string `yaml:"selected-app"`
+	} `yaml:"global"`
+	Apps map[string]any `yaml:"apps"`
+}
+
+// readClissoConfig parses configPath ("" for ~/.clisso.yaml). Unreadable
+// or unparsable reads as an empty config — every caller's fallback is
+// "clisso's own answer wins", never an error.
+func readClissoConfig(configPath string) clissoConfig {
+	var cfg clissoConfig
 	if configPath == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return ""
+			return cfg
 		}
 		configPath = filepath.Join(home, ".clisso.yaml")
 	}
 	data, err := os.ReadFile(configPath) // #nosec G304 -- clisso's own config path: the fixed ~/.clisso.yaml or the -c value the user themselves passed
 	if err != nil {
-		return ""
-	}
-	var cfg struct {
-		Global struct {
-			SelectedApp string `yaml:"selected-app"`
-		} `yaml:"global"`
+		return cfg
 	}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return ""
+		return clissoConfig{}
 	}
-	return cfg.Global.SelectedApp
+	return cfg
+}
+
+// clissoApps is the set of app names ~/.clisso.yaml defines.
+func clissoApps() map[string]bool {
+	cfg := readClissoConfig("")
+	apps := make(map[string]bool, len(cfg.Apps))
+	for name := range cfg.Apps {
+		apps[name] = true
+	}
+	return apps
 }
 
 // captureFilter streams clisso's stdout to the terminal while intercepting

--- a/internal/cli/clissocapture.go
+++ b/internal/cli/clissocapture.go
@@ -652,7 +652,7 @@ func readClissoConfig(configPath string) clissoConfig {
 		return cfg
 	}
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return clissoConfig{}
+		return clissoConfig{} // a half-decoded config is not "what clisso knows"
 	}
 	return cfg
 }

--- a/internal/cli/grant.go
+++ b/internal/cli/grant.go
@@ -433,26 +433,7 @@ func grantClock(unix int64) string {
 // grantRemaining renders time left in at most two units ("6h12m", "3d2h",
 // "45m"), matching how --for was typed rather than time.Duration's seconds.
 func grantRemaining(expiresUnix int64) string {
-	d := time.Until(time.Unix(expiresUnix, 0))
-	if d <= 0 {
-		return "0m"
-	}
-	d = d.Round(time.Minute)
-	days := d / (24 * time.Hour)
-	hours := (d % (24 * time.Hour)) / time.Hour
-	mins := (d % time.Hour) / time.Minute
-	switch {
-	case days > 0 && hours > 0:
-		return fmt.Sprintf("%dd%dh", days, hours)
-	case days > 0:
-		return fmt.Sprintf("%dd", days)
-	case hours > 0 && mins > 0:
-		return fmt.Sprintf("%dh%02dm", hours, mins)
-	case hours > 0:
-		return fmt.Sprintf("%dh", hours)
-	default:
-		return fmt.Sprintf("%dm", mins)
-	}
+	return remainingUnits(time.Until(time.Unix(expiresUnix, 0)))
 }
 
 // truncateEnd cuts s to max runes with a trailing ellipsis — variable content

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/jitpass/jit/internal/migrate"
+)
+
+// statusSession is one vaulted temporary credential with a known end, as
+// `jit status` reports it (design/sessions-and-path-repair.md). It is the
+// JSON shape and the row's input alike, so a script and the eye read the
+// same facts.
+type statusSession struct {
+	Profile string `json:"profile"`
+	// Origin names the tool that minted it, by the config it was captured
+	// from ("~/.clisso.yaml"); empty when the secrets predate provenance.
+	Origin string `json:"origin,omitempty"`
+	// ExpiresUnix is 0 when the stamp is unknown — a capture stored before
+	// the vault recorded expiry, healed by its next login — never 1970.
+	ExpiresUnix int64 `json:"expires_unix,omitempty"`
+	// Live is the listing's verdict at report time; a session with no
+	// known stamp is reported live (see migrate.Session.Live).
+	Live             bool  `json:"live"`
+	RemainingSeconds int64 `json:"remaining_seconds,omitempty"`
+	// Mint is the command that mints a fresh session, when jit can name it
+	// — an app ~/.clisso.yaml defines gets "clisso get <app>". Empty when
+	// the minting tool is unknown; jit does not guess.
+	Mint string `json:"mint,omitempty"`
+}
+
+// sessionsStatusFrom shapes the listing for the report. clissoApps is
+// what ~/.clisso.yaml defines; a session whose app is among them is
+// clisso's to re-mint.
+func sessionsStatusFrom(sessions []migrate.Session, clissoApps map[string]bool, now time.Time) []statusSession {
+	out := make([]statusSession, 0, len(sessions))
+	for _, s := range sessions {
+		entry := statusSession{
+			Profile:          s.Profile,
+			Origin:           s.Origin,
+			ExpiresUnix:      s.ExpiresUnix,
+			Live:             s.Live(now),
+			RemainingSeconds: int64(s.Remaining(now).Seconds()),
+		}
+		if app := sessionApp(s.Profile); clissoApps[app] {
+			entry.Mint = "clisso get " + app
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// sessionApp is the name the minting tool knows a session by: the capture
+// stores "aws-<app>", and `clisso get <app>` is what mints it again.
+func sessionApp(profile string) string {
+	return strings.TrimPrefix(profile, "aws-")
+}
+
+// sessionClock renders an expiry as a full local date and time. Not the
+// today/tomorrow axis grants use: a session's end is a fact to compare
+// against a clock, and the reader asked for the actual date.
+func sessionClock(unix int64) string {
+	return time.Unix(unix, 0).Local().Format("2006-01-02 15:04")
+}
+
+// clauseSpace joins the words of one clause so the window wraps the row
+// only between clauses, never inside one: termtext.Wrap breaks on the
+// plain space alone, and "stage expires 2026-09-05" / "21:00" split
+// across two lines reads as two facts. A non-breaking space is one column
+// and renders as a space; the JSON carries the same facts for anything
+// that greps.
+const clauseSpace = "\u00a0"
+
+func atomicClause(s string) string { return strings.ReplaceAll(s, " ", clauseSpace) }
+
+// printSessionsSection is the dashboard's last row. Omitted entirely when
+// nothing on this machine is a session: unlike grants, there is no on-ramp
+// to offer — a session exists only once a wrapped SSO tool has minted one.
+//
+// The glyph carries the rollup (all live, some expired, all expired); each
+// session gets one clause; the action names the mint command when the
+// origin says which tool that is, and stays silent otherwise rather than
+// guess.
+func printSessionsSection(w io.Writer, sessions []statusSession, now time.Time) {
+	if len(sessions) == 0 {
+		return
+	}
+	statusLabel(w, "sessions")
+	live, expired := 0, 0
+	clauses := make([]string, 0, len(sessions))
+	var remint []string
+	for _, s := range sessions {
+		switch {
+		case s.ExpiresUnix == 0:
+			live++
+			clauses = append(clauses, sessionApp(s.Profile)+" expiry unknown until its next login")
+		case s.Live:
+			live++
+			clauses = append(clauses, fmt.Sprintf("%s expires %s", sessionApp(s.Profile), sessionClock(s.ExpiresUnix)))
+		default:
+			expired++
+			clauses = append(clauses, fmt.Sprintf("%s expired %s ago", sessionApp(s.Profile), humanAgo(now.Sub(time.Unix(s.ExpiresUnix, 0)))))
+			if s.Mint != "" {
+				remint = append(remint, s.Mint)
+			}
+		}
+	}
+	var rollup string
+	switch {
+	case expired == 0:
+		_, _ = cOK.Fprint(w, glyphOK+" ")
+		rollup = fmt.Sprintf("%d live", live)
+	case live == 0:
+		_, _ = cRisk.Fprint(w, glyphRisk+" ")
+		rollup = fmt.Sprintf("%d expired", expired)
+	default:
+		_, _ = cWarn.Fprint(w, glyphWarn+" ")
+		rollup = fmt.Sprintf("%d live, %d expired", live, expired)
+	}
+	for i, c := range clauses {
+		clauses[i] = atomicClause(c)
+	}
+	printStatusGlyphValue(w, "%s · %s", atomicClause(rollup), strings.Join(clauses, " · "))
+	switch len(remint) {
+	case 0:
+	case 1:
+		printStatusAction(w, "`"+remint[0]+"`")
+	default:
+		// One command to type, then the rest by app name: every mint here
+		// is the same tool, so repeating it would only cost the line room.
+		rest := make([]string, 0, len(remint)-1)
+		for _, m := range remint[1:] {
+			rest = append(rest, m[strings.LastIndex(m, " ")+1:])
+		}
+		printStatusAction(w, "`"+remint[0]+"`, then "+strings.Join(rest, ", "))
+	}
+}
+
+// clissoStatusRow is one line of the wrapped `clisso status` table.
+type clissoStatusRow struct {
+	App       string
+	ExpireAt  string
+	Remaining string
+}
+
+// clissoStatusRows selects what the wrapped `clisso status` reports: the
+// apps ~/.clisso.yaml defines, live, with a known end. A pre-stamp capture
+// is left out on purpose — a script that saw it would skip the login,
+// while one that doesn't logs in once and stamps it.
+func clissoStatusRows(sessions []migrate.Session, clissoApps map[string]bool, now time.Time) []clissoStatusRow {
+	var rows []clissoStatusRow
+	for _, s := range sessions {
+		if !clissoApps[sessionApp(s.Profile)] || s.ExpiresUnix == 0 || !s.Live(now) {
+			continue
+		}
+		rows = append(rows, clissoStatusRow{
+			App:       sessionApp(s.Profile),
+			ExpireAt:  sessionClock(s.ExpiresUnix),
+			Remaining: remainingUnits(s.Remaining(now)),
+		})
+	}
+	return rows
+}
+
+// renderClissoStatusTable prints rows in the shape clisso's own status
+// draws (its tablewriter defaults: +- borders, centered headers, left-
+// aligned cells, one space of padding), so `clisso status | grep -qw
+// stage` and every script like it keeps working. House style does not
+// apply here on purpose: this is clisso's output, imitated. The one
+// departure is the EXPIRE AT column — a date and time instead of the raw
+// epoch clisso prints, which no script keys on and no human can read.
+func renderClissoStatusTable(w io.Writer, rows []clissoStatusRow) {
+	if len(rows) == 0 {
+		fmt.Fprintln(w, "No apps with valid credentials")
+		return
+	}
+	headers := [3]string{"APP", "EXPIRE AT", "REMAINING"}
+	widths := [3]int{len(headers[0]), len(headers[1]), len(headers[2])}
+	for _, r := range rows {
+		for i, cell := range [3]string{r.App, r.ExpireAt, r.Remaining} {
+			if n := len(cell); n > widths[i] {
+				widths[i] = n
+			}
+		}
+	}
+	border := "+"
+	for _, wd := range widths {
+		border += strings.Repeat("-", wd+2) + "+"
+	}
+	center := func(s string, wd int) string {
+		left := (wd - len(s)) / 2
+		return strings.Repeat(" ", left) + s + strings.Repeat(" ", wd-len(s)-left)
+	}
+	fmt.Fprintln(w, border)
+	fmt.Fprintf(w, "| %s | %s | %s |\n", center(headers[0], widths[0]), center(headers[1], widths[1]), center(headers[2], widths[2]))
+	fmt.Fprintln(w, border)
+	for _, r := range rows {
+		fmt.Fprintf(w, "| %-*s | %-*s | %-*s |\n", widths[0], r.App, widths[1], r.ExpireAt, widths[2], r.Remaining)
+	}
+	fmt.Fprintln(w, border)
+}
+
+// remainingUnits renders a duration in at most two units ("6h12m", "3d2h",
+// "45m"), the way a TTL is typed rather than time.Duration's seconds.
+func remainingUnits(d time.Duration) string {
+	if d <= 0 {
+		return "0m"
+	}
+	d = d.Round(time.Minute)
+	days := d / (24 * time.Hour)
+	hours := (d % (24 * time.Hour)) / time.Hour
+	mins := (d % time.Hour) / time.Minute
+	switch {
+	case days > 0 && hours > 0:
+		return fmt.Sprintf("%dd%dh", days, hours)
+	case days > 0:
+		return fmt.Sprintf("%dd", days)
+	case hours > 0 && mins > 0:
+		return fmt.Sprintf("%dh%02dm", hours, mins)
+	case hours > 0:
+		return fmt.Sprintf("%dh", hours)
+	default:
+		return fmt.Sprintf("%dm", mins)
+	}
+}

--- a/internal/cli/sessions.go
+++ b/internal/cli/sessions.go
@@ -47,9 +47,7 @@ func sessionsStatusFrom(sessions []migrate.Session, clissoApps map[string]bool, 
 			Live:             s.Live(now),
 			RemainingSeconds: int64(s.Remaining(now).Seconds()),
 		}
-		if app := sessionApp(s.Profile); clissoApps[app] {
-			entry.Mint = "clisso get " + app
-		}
+		entry.Mint = clissoMint(s.Profile, clissoApps)
 		out = append(out, entry)
 	}
 	return out
@@ -59,6 +57,16 @@ func sessionsStatusFrom(sessions []migrate.Session, clissoApps map[string]bool, 
 // stores "aws-<app>", and `clisso get <app>` is what mints it again.
 func sessionApp(profile string) string {
 	return strings.TrimPrefix(profile, "aws-")
+}
+
+// clissoMint is the command that mints profile afresh when its app is one
+// clissoApps (what ~/.clisso.yaml defines) knows, "" otherwise: jit names a
+// command only when it can be sure which tool the session belongs to.
+func clissoMint(profile string, clissoApps map[string]bool) string {
+	if app := sessionApp(profile); clissoApps[app] {
+		return "clisso get " + app
+	}
+	return ""
 }
 
 // sessionClock renders an expiry as a full local date and time. Not the
@@ -83,9 +91,9 @@ func atomicClause(s string) string { return strings.ReplaceAll(s, " ", clauseSpa
 // to offer — a session exists only once a wrapped SSO tool has minted one.
 //
 // The glyph carries the rollup (all live, some expired, all expired); each
-// session gets one clause; the action names the mint command when the
-// origin says which tool that is, and stays silent otherwise rather than
-// guess.
+// session gets one clause; the action names the mint command for every
+// expired session that has one (sessionsStatusFrom sets it from clisso's
+// own app list), and stays silent otherwise rather than guess.
 func printSessionsSection(w io.Writer, sessions []statusSession, now time.Time) {
 	if len(sessions) == 0 {
 		return

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -1,0 +1,173 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/migrate"
+)
+
+var sessionNow = time.Date(2026, 9, 5, 12, 0, 0, 0, time.Local)
+
+func stampAt(d time.Duration) int64 { return sessionNow.Add(d).Unix() }
+
+func TestSessionsRowStates(t *testing.T) {
+	mint := func(app string) string { return "clisso get " + app }
+	for _, tc := range []struct {
+		name     string
+		sessions []statusSession
+		want     []string
+		absent   []string
+	}{
+		{"omitted when nothing is a session", nil, nil, []string{"sessions"}},
+		{"all live", []statusSession{
+			{Profile: "aws-stage", ExpiresUnix: stampAt(9 * time.Hour), Live: true, Mint: mint("stage")},
+			{Profile: "aws-dev", ExpiresUnix: stampAt(6 * time.Hour), Live: true, Mint: mint("dev")},
+		}, []string{"sessions ● 2 live", "stage expires 2026-09-05 21:00", "dev expires 2026-09-05 18:00"}, []string{"→"}},
+		{"one expired names the mint command", []statusSession{
+			{Profile: "aws-stage", ExpiresUnix: stampAt(9 * time.Hour), Live: true, Mint: mint("stage")},
+			{Profile: "aws-prod", ExpiresUnix: stampAt(-3 * time.Hour), Mint: mint("prod")},
+		}, []string{"○ 1 live, 1 expired", "prod expired 3h ago", "→ clisso get prod"}, nil},
+		{"all expired, several", []statusSession{
+			{Profile: "aws-stage", ExpiresUnix: stampAt(-3 * time.Hour), Mint: mint("stage")},
+			{Profile: "aws-prod", ExpiresUnix: stampAt(-30 * time.Hour), Mint: mint("prod")},
+		}, []string{"✗ 2 expired", "prod expired 30h ago", "→ clisso get stage, then prod"}, nil},
+		{"a pre-stamp capture counts as live and says so", []statusSession{
+			{Profile: "aws-dev", Live: true, Mint: mint("dev")},
+		}, []string{"● 1 live", "dev expiry unknown until its next login"}, []string{"1970", "→"}},
+		{"an expired session no tool claims gets no command", []statusSession{
+			{Profile: "aws-ci", Origin: "~/.aws/credentials", ExpiresUnix: stampAt(-time.Hour)},
+		}, []string{"✗ 1 expired", "ci expired 1h ago"}, []string{"→"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printSessionsSection(&buf, tc.sessions, sessionNow)
+			// Wrap-insensitive: the assertions are about facts, and the
+			// non-breaking joins are an implementation of the layout.
+			out := strings.Join(strings.Fields(strings.ReplaceAll(buf.String(), clauseSpace, " ")), " ")
+			for _, w := range tc.want {
+				if !strings.Contains(out, w) {
+					t.Errorf("row missing %q:\n%s", w, out)
+				}
+			}
+			for _, a := range tc.absent {
+				if strings.Contains(out, a) {
+					t.Errorf("row must not contain %q:\n%s", a, out)
+				}
+			}
+		})
+	}
+}
+
+func TestSessionsStatusFromReportsLiveAndRemaining(t *testing.T) {
+	// stage was born from a ~/.aws/credentials migration and is re-minted
+	// by clisso ever after: the app list, not the origin, says it is
+	// clisso's.
+	got := sessionsStatusFrom([]migrate.Session{
+		{Profile: "aws-stage", Origin: "~/.aws/credentials", ExpiresUnix: stampAt(90 * time.Minute)},
+		{Profile: "aws-prod", ExpiresUnix: stampAt(-time.Minute)},
+		{Profile: "aws-dev"},
+	}, map[string]bool{"stage": true}, sessionNow)
+	if len(got) != 3 {
+		t.Fatalf("got %d entries, want 3", len(got))
+	}
+	if !got[0].Live || got[0].RemainingSeconds != 90*60 || got[0].Mint != "clisso get stage" {
+		t.Errorf("stage = %+v, want live with 5400s left and its mint command", got[0])
+	}
+	if got[1].Mint != "" {
+		t.Errorf("prod = %+v, want no mint command for an app clisso does not define", got[1])
+	}
+	if got[1].Live || got[1].RemainingSeconds != 0 {
+		t.Errorf("prod = %+v, want expired with 0 left", got[1])
+	}
+	if !got[2].Live || got[2].ExpiresUnix != 0 {
+		t.Errorf("dev = %+v, want live with unknown expiry", got[2])
+	}
+}
+
+// The wrapped `clisso status` must be byte-compatible with clisso's own
+// table where scripts look (the APP column, the borders, the empty-state
+// sentence); only EXPIRE AT departs, from a raw epoch to a date.
+func TestClissoStatusTableShape(t *testing.T) {
+	var buf bytes.Buffer
+	renderClissoStatusTable(&buf, []clissoStatusRow{
+		{App: "stage", ExpireAt: "2026-09-05 21:11", Remaining: "9h11m"},
+		{App: "dev", ExpireAt: "2026-09-05 18:35", Remaining: "6h35m"},
+	})
+	want := "" +
+		"+-------+------------------+-----------+\n" +
+		"|  APP  |    EXPIRE AT     | REMAINING |\n" +
+		"+-------+------------------+-----------+\n" +
+		"| stage | 2026-09-05 21:11 | 9h11m     |\n" +
+		"| dev   | 2026-09-05 18:35 | 6h35m     |\n" +
+		"+-------+------------------+-----------+\n"
+	if buf.String() != want {
+		t.Errorf("table =\n%s\nwant\n%s", buf.String(), want)
+	}
+	// The line a login function greps.
+	if !strings.Contains(buf.String(), "| stage |") {
+		t.Error("APP column lost the shape scripts grep for")
+	}
+
+	buf.Reset()
+	renderClissoStatusTable(&buf, nil)
+	if buf.String() != "No apps with valid credentials\n" {
+		t.Errorf("empty table = %q, want clisso's own sentence", buf.String())
+	}
+}
+
+func TestClissoStatusRowsSelectsClissoLiveStamped(t *testing.T) {
+	apps := map[string]bool{"stage": true, "prod": true, "dev": true}
+	rows := clissoStatusRows([]migrate.Session{
+		{Profile: "aws-stage", Origin: "~/.aws/credentials", ExpiresUnix: stampAt(9*time.Hour + 11*time.Minute)}, // clisso's by app, whatever its origin
+		{Profile: "aws-prod", ExpiresUnix: stampAt(-time.Hour)},                                                  // expired
+		{Profile: "aws-dev"}, // pre-stamp
+		{Profile: "aws-ci", ExpiresUnix: stampAt(time.Hour)}, // not an app clisso defines
+	}, apps, sessionNow)
+	if len(rows) != 1 || rows[0].App != "stage" || rows[0].Remaining != "9h11m" || rows[0].ExpireAt != "2026-09-05 21:11" {
+		t.Errorf("rows = %+v, want exactly stage / 2026-09-05 21:11 / 9h11m", rows)
+	}
+}
+
+func TestRemainingUnits(t *testing.T) {
+	for d, want := range map[time.Duration]string{
+		0:                            "0m",
+		-time.Hour:                   "0m",
+		45 * time.Minute:             "45m",
+		9*time.Hour + 11*time.Minute: "9h11m",
+		2 * time.Hour:                "2h",
+		26 * time.Hour:               "1d2h",
+		48 * time.Hour:               "2d",
+	} {
+		if got := remainingUnits(d); got != want {
+			t.Errorf("remainingUnits(%s) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+// status routes to the vault only when it is a plain status: -r is the
+// user naming the file, and global flags before the subcommand still
+// count (cobra's own parse).
+func TestParseClissoArgsStatus(t *testing.T) {
+	for _, tc := range []struct {
+		args         []string
+		sub          string
+		explicitRead bool
+	}{
+		{[]string{"status"}, "status", false},
+		{[]string{"--log-level", "warn", "status"}, "status", false},
+		{[]string{"status", "-r", "/tmp/creds"}, "status", true},
+		{[]string{"status", "--read-from-file=/tmp/creds"}, "status", true},
+		{[]string{"-r", "/tmp/creds", "status"}, "status", true},
+	} {
+		inv := parseClissoArgs(tc.args)
+		if inv.sub != tc.sub || inv.explicitRead != tc.explicitRead {
+			t.Errorf("parseClissoArgs(%v) = sub %q explicitRead %v, want %q %v", tc.args, inv.sub, inv.explicitRead, tc.sub, tc.explicitRead)
+		}
+	}
+}

--- a/internal/cli/sessions_test.go
+++ b/internal/cli/sessions_test.go
@@ -5,6 +5,9 @@ package cli
 
 import (
 	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -169,5 +172,63 @@ func TestParseClissoArgsStatus(t *testing.T) {
 		if inv.sub != tc.sub || inv.explicitRead != tc.explicitRead {
 			t.Errorf("parseClissoArgs(%v) = sub %q explicitRead %v, want %q %v", tc.args, inv.sub, inv.explicitRead, tc.sub, tc.explicitRead)
 		}
+	}
+}
+
+// End to end against a real (read-only) vault: a wrapped ~/.clisso.yaml,
+// a captured session whose envelope carries the stamp, and `clisso
+// status` answered from the vault without ever decrypting — the envelope
+// here has a junk payload that could never open, which is the proof.
+func TestClissoStatusFromVault(t *testing.T) {
+	home := withFixtureHome(t)
+	writeClissoConfig := func(body string) {
+		if err := os.WriteFile(filepath.Join(home, ".clisso.yaml"), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeClissoConfig("apps:\n  stage:\n    app-id: \"1\"\n  prod:\n    app-id: \"2\"\nproviders:\n  acme:\n    client-secret: jit://vault/wrap-clisso/acme-client-secret\n")
+	wrapped, err := clissoConfigWrapped()
+	if err != nil || !wrapped {
+		t.Fatalf("clissoConfigWrapped = %v, %v; want true, nil", wrapped, err)
+	}
+
+	expires := sessionNow.Add(9*time.Hour + 11*time.Minute).Unix()
+	plant := func(profile string, stamp int64) {
+		writeVaultEnc(t, home, profile+"/EXPIRATION",
+			fmt.Sprintf(`{"version":5,"expires_unix":%d,"origin":"~/.clisso.yaml","recipients":{"test":"00"},"payload":"00"}`, stamp))
+		dir := filepath.Join(home, ".jit", "profiles")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		manifest := fmt.Sprintf("ACCESS_KEY_ID: %s/ACCESS_KEY_ID\nEXPIRATION: %s/EXPIRATION\n", profile, profile)
+		if err := os.WriteFile(filepath.Join(dir, profile+".yaml"), []byte(manifest), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	plant("aws-stage", expires)
+	plant("aws-prod", sessionNow.Add(-time.Hour).Unix()) // expired: not listed
+	plant("aws-other", expires)                          // not an app clisso defines: not listed
+
+	var stdout, stderr bytes.Buffer
+	if err := runClissoStatus(&stdout, &stderr, sessionNow); err != nil {
+		t.Fatalf("runClissoStatus: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "| stage | "+sessionClock(expires)+" | 9h11m     |") {
+		t.Errorf("stdout = %q, want the stage row with its date", stdout.String())
+	}
+	for _, absent := range []string{"prod", "other"} {
+		if strings.Contains(stdout.String(), absent) {
+			t.Errorf("stdout lists %q, which must not appear:\n%s", absent, stdout.String())
+		}
+	}
+	if !strings.HasPrefix(stderr.String(), "jit: answered from the vault") {
+		t.Errorf("stderr = %q, want jit's attribution line", stderr.String())
+	}
+
+	// A config with no pointer is not the wrap's: clisso's own status
+	// must answer, so the shim must not intercept.
+	writeClissoConfig("apps:\n  stage:\n    app-id: \"1\"\nproviders:\n  acme:\n    client-secret: plaintext\n")
+	if wrapped, err := clissoConfigWrapped(); err != nil || wrapped {
+		t.Errorf("clissoConfigWrapped on an unwrapped config = %v, %v; want false, nil", wrapped, err)
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -35,6 +35,10 @@ type statusResult struct {
 	Agent   statusAgent   `json:"agent"`
 	Secrets statusSecrets `json:"secrets"`
 	Mounts  statusMounts  `json:"mounts"`
+	// Sessions are the vaulted temporary credentials with a known end (a
+	// wrapped SSO tool's mints) — the "is the morning's login still good"
+	// row. Metadata only, like everything else here: never a decrypt.
+	Sessions []statusSession `json:"sessions,omitempty"`
 }
 
 // statusCLI identifies the jit binary answering this very command — the
@@ -239,6 +243,10 @@ var statusCmd = &cobra.Command{
 		"original copy behind, and those leftovers are usually the bulk of what " +
 		"jit vault orphans would prune. Key names are compared, never values, since " +
 		"status never decrypts.\n\n" +
+		"A sessions row appears once a wrapped SSO tool (jit wrap clisso) has minted " +
+		"temporary credentials into the vault: each with its expiry, so the morning's " +
+		"login can be checked without re-running it. Read from envelope metadata, so " +
+		"this too never prompts.\n\n" +
 		"--format json prints a machine-readable snapshot instead of the default " +
 		"text report, in the same shape jit service status/vault list/doctor's own " +
 		"--format json use for their overlapping sections.",
@@ -283,13 +291,19 @@ var statusCmd = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("jit status: reading mount registry: %w", err)
 		}
+		now := time.Now()
+		sessions, err := migrate.ListSessions(v, cwd, now)
+		if err != nil {
+			return fmt.Errorf("jit status: listing sessions: %w", err)
+		}
 
 		result := statusResult{
-			CLI:     statusCLI{Version: agent.Version(), Build: agent.BuildID()},
-			Vault:   vaultStatus,
-			Agent:   agentStatus,
-			Secrets: secretsStatusFrom(rec, statusSecretsDetail),
-			Mounts:  mountStatus,
+			CLI:      statusCLI{Version: agent.Version(), Build: agent.BuildID()},
+			Vault:    vaultStatus,
+			Agent:    agentStatus,
+			Secrets:  secretsStatusFrom(rec, statusSecretsDetail),
+			Mounts:   mountStatus,
+			Sessions: sessionsStatusFrom(sessions, clissoApps(), now),
 		}
 		if statusFormat == "json" {
 			return writeJSON(cmd.OutOrStdout(), result)
@@ -675,6 +689,7 @@ func printStatusText(w io.Writer, r statusResult) {
 	}
 
 	printGrantsSection(w, r)
+	printSessionsSection(w, r.Sessions, time.Now())
 }
 
 // printGrantsSection reports the live process grants, and is where `jit grant`

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -97,6 +97,7 @@ type vaultSecretJSON struct {
 	Origin         string `json:"origin,omitempty"`
 	Storage        string `json:"storage,omitempty"`
 	OriginSeenUnix int64  `json:"origin_seen_unix,omitempty"`
+	ExpiresUnix    int64  `json:"expires_unix,omitempty"`
 	CreatedUnix    int64  `json:"created_unix,omitempty"`
 	UpdatedUnix    int64  `json:"updated_unix,omitempty"`
 }
@@ -114,6 +115,7 @@ type vaultGetResult struct {
 	GroupID        string `json:"group_id,omitempty"`
 	Origin         string `json:"origin,omitempty"`
 	OriginSeenUnix int64  `json:"origin_seen_unix,omitempty"`
+	ExpiresUnix    int64  `json:"expires_unix,omitempty"`
 	CreatedUnix    int64  `json:"created_unix,omitempty"`
 	UpdatedUnix    int64  `json:"updated_unix,omitempty"`
 	// Storage/Reference appear only for a linked secret (`jit vault
@@ -1107,6 +1109,7 @@ var vaultGetCmd = &cobra.Command{
 				GroupID:        info.GroupID,
 				Origin:         info.Origin,
 				OriginSeenUnix: info.OriginSeenUnix,
+				ExpiresUnix:    info.ExpiresUnix,
 				CreatedUnix:    info.CreatedUnix,
 				UpdatedUnix:    info.UpdatedUnix,
 				Storage:        info.Storage,
@@ -1308,6 +1311,7 @@ var vaultListCmd = &cobra.Command{
 					GroupID:        info.GroupID,
 					Origin:         info.Origin,
 					OriginSeenUnix: info.OriginSeenUnix,
+					ExpiresUnix:    info.ExpiresUnix,
 					CreatedUnix:    info.CreatedUnix,
 					UpdatedUnix:    info.UpdatedUnix,
 					Storage:        info.Storage,

--- a/internal/migrate/awscreds.go
+++ b/internal/migrate/awscreds.go
@@ -140,6 +140,11 @@ func ApplyAWSProfile(v *vault.Vault, home, profileName string, dedup ...*BackupT
 	if err != nil {
 		return AWSCredentialMigration{}, err
 	}
+	// Every secret of a temporary session carries the session's end as
+	// metadata (vault.Meta.ExpiresUnix), so a listing can say whether the
+	// session is live without decrypting anything. A static key has no
+	// stamp and gets none.
+	meta.ExpiresUnix = expiryStamp(kv["aws_expiration"])
 	var varNames []string
 	for _, iniKey := range awsCredentialKeys {
 		varName := varByINIKey[iniKey]
@@ -466,6 +471,10 @@ func StoreAWSSession(v *vault.Vault, home, profileName string, s AWSSession) (AW
 	if err != nil {
 		return AWSCredentialMigration{}, err
 	}
+	// The session's end rides on every one of its secrets as metadata —
+	// what ListSessions (and so jit status and the wrapped `clisso
+	// status`) reads without an unlock.
+	meta.ExpiresUnix = expiryStamp(s.Expiration)
 	var varNames []string
 	captured := map[string]string{
 		"ACCESS_KEY_ID":     s.AccessKeyID,

--- a/internal/migrate/awscreds_test.go
+++ b/internal/migrate/awscreds_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jitpass/jit/internal/profile"
 )
@@ -196,6 +197,7 @@ func TestApplyAWSProfileWithExpirationStamp(t *testing.T) {
 	if err != nil || string(got) != "2026-07-29T19:00:11Z" {
 		t.Errorf("EXPIRATION = (%q, %v), want (2026-07-29T19:00:11Z, nil)", got, err)
 	}
+	assertSessionStamp(t, v, "aws-prod", time.Date(2026, 7, 29, 19, 0, 11, 0, time.UTC).Unix())
 	credRaw, err := os.ReadFile(AWSCredentialsPath(home)) // #nosec G304 -- test-controlled path
 	if err != nil {
 		t.Fatalf("reading rewritten credentials: %v", err)
@@ -448,6 +450,7 @@ func TestStoreAWSSessionFreshWiring(t *testing.T) {
 			t.Errorf("%s = (%q, %v), want (%q, nil)", path, got, err, want)
 		}
 	}
+	assertSessionStamp(t, v, "aws-prod", time.Date(2026, 7, 29, 19, 0, 11, 0, time.UTC).Unix())
 
 	configRaw, err := os.ReadFile(AWSConfigPath(home)) // #nosec G304 -- test-controlled path
 	if err != nil {

--- a/internal/migrate/doc.go
+++ b/internal/migrate/doc.go
@@ -140,6 +140,15 @@
 // test). A narrower named directory is unaffected: every file it discovers
 // genuinely is under cwd already.
 //
+// A profile that carries an EXPIRATION variable is a session
+// (sessions.go): temporary credentials with a known end, stamped onto every
+// one of its secrets as vault metadata by both writers — the clisso capture
+// (StoreAWSSession) and a ~/.aws/credentials migration that found an
+// aws_expiration line. ListSessions reads that metadata and never a value,
+// which is what lets `jit status` show a session row without a prompt and
+// the clisso wrap answer `clisso status` from the vault (the file clisso
+// would read is the one the wrap deliberately empties).
+//
 // A migrated .env/npmrc becomes a decoy-by-default live mount (GAPS.md #2):
 // after migrate creates it, it serves fake placeholder values to every
 // reader. Real values reach a tool only through a `jit run` grant — env

--- a/internal/migrate/sessions.go
+++ b/internal/migrate/sessions.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/jitpass/jit/internal/profile"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// A Session is a vaulted credential with a known end: the temporary AWS
+// credentials an SSO CLI mints (clisso's capture, or a ~/.aws/credentials
+// migration that found an aws_expiration stamp) — anything stored under a
+// profile that carries an EXPIRATION variable. The variable is the
+// contract, not the tool: a future capture wrap that writes EXPIRATION is
+// a session with no change here.
+//
+// This is the answer to "is the morning's login still good" that clisso's
+// own `status` can no longer give once the wrap empties
+// ~/.aws/credentials (docs/wrap/clisso.md), and the row jit status shows
+// beside grants. Both surfaces render this one query.
+type Session struct {
+	// Profile is the manifest's name — for a capture, "aws-<app>", which
+	// is also the AWS profile a caller names in --profile.
+	Profile string
+	Scope   profile.Scope
+	// Origin is the source the session's secrets were born from, as the
+	// vault recorded it ("~/.clisso.yaml", "~/.aws/credentials"): which
+	// tool minted it. Empty for secrets stored before provenance existed.
+	Origin string
+	// ExpiresUnix is when the session ends. Zero means the stamp is
+	// unknown — the secrets predate the expiry field in the vault, and
+	// the next login will stamp them — never "expired": that reading
+	// would send every script into a needless re-login.
+	ExpiresUnix int64
+}
+
+// Live reports whether the session is still usable at now. A session with
+// no known expiry is reported live: the credential_process serve is what
+// refuses a dead token (it reads the authenticated EXPIRATION value), and
+// a listing that guessed "dead" from a missing stamp would be wrong for
+// every capture that predates the stamp.
+func (s Session) Live(now time.Time) bool {
+	return s.ExpiresUnix == 0 || time.Unix(s.ExpiresUnix, 0).After(now)
+}
+
+// Remaining is the time left at now, zero once expired or when the expiry
+// is unknown.
+func (s Session) Remaining(now time.Time) time.Duration {
+	if s.ExpiresUnix == 0 {
+		return 0
+	}
+	d := time.Unix(s.ExpiresUnix, 0).Sub(now)
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// ListSessions returns every session visible from root (project manifests
+// first, then the global store — profile.ListAll's order), sorted by
+// profile name. It reads envelope METADATA only (vault.Info), never a
+// value, so it never prompts: jit status is prompt-free by design, and
+// this is what lets a session row live on it.
+//
+// The expiry is taken from the EXPIRATION secret's own stamp. A manifest
+// whose EXPIRATION secret is missing from the vault is skipped rather than
+// reported — doctor's [missing] finding already owns that story, and a
+// half-present session is not a session.
+func ListSessions(v *vault.Vault, root string, now time.Time) ([]Session, error) {
+	infos, err := profile.ListAll(root)
+	if err != nil {
+		return nil, err
+	}
+	var sessions []Session
+	for _, info := range infos {
+		p, err := profile.LoadFile(info.Path)
+		if err != nil {
+			return nil, fmt.Errorf("reading profile %s: %w", info.Path, err)
+		}
+		secretPath, ok := p["EXPIRATION"]
+		if !ok || secretPath == "" {
+			continue
+		}
+		si, err := v.Info(secretPath)
+		if err != nil {
+			continue
+		}
+		sessions = append(sessions, Session{
+			Profile:     info.Name,
+			Scope:       info.Scope,
+			Origin:      si.Origin,
+			ExpiresUnix: si.ExpiresUnix,
+		})
+	}
+	sort.Slice(sessions, func(i, j int) bool { return sessions[i].Profile < sessions[j].Profile })
+	_ = now // reserved: callers filter with Session.Live(now); listing every session is the honest default
+	return sessions, nil
+}
+
+// expiryStamp turns the RFC3339 expiry a minting tool printed into the
+// vault's metadata stamp, or 0 when it does not parse. A malformed stamp
+// deliberately stamps nothing: the EXPIRATION value itself is still
+// stored and served verbatim, so the SDK's own complaint about it wins
+// over jit guessing — the same rule buildAWSCredentialProcessOutput
+// applies on the way out.
+func expiryStamp(rfc3339 string) int64 {
+	if rfc3339 == "" {
+		return 0
+	}
+	t, err := time.Parse(time.RFC3339, rfc3339)
+	if err != nil {
+		return 0
+	}
+	return t.Unix()
+}

--- a/internal/migrate/sessions.go
+++ b/internal/migrate/sessions.go
@@ -4,7 +4,6 @@
 package migrate
 
 import (
-	"fmt"
 	"sort"
 	"time"
 
@@ -67,10 +66,14 @@ func (s Session) Remaining(now time.Time) time.Duration {
 // value, so it never prompts: jit status is prompt-free by design, and
 // this is what lets a session row live on it.
 //
-// The expiry is taken from the EXPIRATION secret's own stamp. A manifest
-// whose EXPIRATION secret is missing from the vault is skipped rather than
-// reported — doctor's [missing] finding already owns that story, and a
-// half-present session is not a session.
+// The expiry is taken from the EXPIRATION secret's own stamp. Best-effort
+// per manifest, like the secrets reconciliation beside it on the
+// dashboard: a manifest that does not parse, or whose EXPIRATION secret is
+// missing from the vault, is skipped rather than reported — the secrets
+// rollup counts the parse failure and doctor's [missing] finding owns the
+// gone secret, and a half-present session is not a session. `jit status`
+// promises to survive an unreadable profile; this listing must not be the
+// one to break that.
 func ListSessions(v *vault.Vault, root string, now time.Time) ([]Session, error) {
 	infos, err := profile.ListAll(root)
 	if err != nil {
@@ -80,7 +83,7 @@ func ListSessions(v *vault.Vault, root string, now time.Time) ([]Session, error)
 	for _, info := range infos {
 		p, err := profile.LoadFile(info.Path)
 		if err != nil {
-			return nil, fmt.Errorf("reading profile %s: %w", info.Path, err)
+			continue
 		}
 		secretPath, ok := p["EXPIRATION"]
 		if !ok || secretPath == "" {

--- a/internal/migrate/sessions_test.go
+++ b/internal/migrate/sessions_test.go
@@ -1,0 +1,143 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jitpass/jit/internal/profile"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// assertSessionStamp checks that EVERY secret of a session profile carries
+// the expiry as metadata — readable through Info, so without a prompt.
+func assertSessionStamp(t *testing.T, v *vault.Vault, vaultProfile string, want int64) {
+	t.Helper()
+	for _, varName := range []string{"ACCESS_KEY_ID", "SECRET_ACCESS_KEY", "SESSION_TOKEN", "EXPIRATION"} {
+		info, err := v.Info(vaultProfile + "/" + varName)
+		if err != nil {
+			t.Errorf("Info(%s/%s): %v", vaultProfile, varName, err)
+			continue
+		}
+		if info.ExpiresUnix != want {
+			t.Errorf("%s/%s ExpiresUnix = %d, want %d", vaultProfile, varName, info.ExpiresUnix, want)
+		}
+	}
+}
+
+func TestExpiryStamp(t *testing.T) {
+	stamp := time.Date(2026, 7, 29, 19, 0, 11, 0, time.UTC).Unix()
+	for in, want := range map[string]int64{
+		"2026-07-29T19:00:11Z":      stamp,
+		"2026-07-29T22:00:11+03:00": stamp, // same instant, as a zoned clock prints it
+		"":                          0,
+		"tomorrow-ish":              0,
+	} {
+		if got := expiryStamp(in); got != want {
+			t.Errorf("expiryStamp(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// A malformed stamp must still store and serve the value verbatim (the
+// SDK's own complaint wins) — it just carries no metadata.
+func TestStoreAWSSessionMalformedExpirationStampsNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	v := newTestVault(t)
+	if _, err := StoreAWSSession(v, home, "prod", AWSSession{
+		AccessKeyID: "ASIA1", SecretAccessKey: "secret1", SessionToken: "tok", Expiration: "soon",
+	}); err != nil {
+		t.Fatalf("StoreAWSSession: %v", err)
+	}
+	if got, err := v.Get("aws-prod/EXPIRATION"); err != nil || string(got) != "soon" {
+		t.Errorf("EXPIRATION = (%q, %v), want it stored verbatim", got, err)
+	}
+	assertSessionStamp(t, v, "aws-prod", 0)
+}
+
+func TestListSessions(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	v := newTestVault(t)
+	now := time.Date(2026, 9, 5, 12, 0, 0, 0, time.UTC)
+
+	// live: a capture from an hour ago, twelve hours long.
+	if _, err := StoreAWSSession(v, home, "stage", AWSSession{
+		AccessKeyID: "A", SecretAccessKey: "S", SessionToken: "T",
+		Expiration: now.Add(11 * time.Hour).Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("StoreAWSSession stage: %v", err)
+	}
+	// expired: yesterday's.
+	if _, err := StoreAWSSession(v, home, "prod", AWSSession{
+		AccessKeyID: "A", SecretAccessKey: "S", SessionToken: "T",
+		Expiration: now.Add(-3 * time.Hour).Format(time.RFC3339),
+	}); err != nil {
+		t.Fatalf("StoreAWSSession prod: %v", err)
+	}
+	// stampless: a capture stored before the expiry metadata existed —
+	// the manifest names EXPIRATION, the envelope carries no stamp.
+	writeManifest(t, home, "aws-dev", "ACCESS_KEY_ID: aws-dev/ACCESS_KEY_ID\nEXPIRATION: aws-dev/EXPIRATION\n")
+	for _, p := range []string{"aws-dev/ACCESS_KEY_ID", "aws-dev/EXPIRATION"} {
+		if err := v.Set(p, []byte("x")); err != nil {
+			t.Fatalf("Set %s: %v", p, err)
+		}
+	}
+	// not a session: a static key with no EXPIRATION at all.
+	writeManifest(t, home, "aws-ci", "ACCESS_KEY_ID: aws-ci/ACCESS_KEY_ID\nSECRET_ACCESS_KEY: aws-ci/SECRET_ACCESS_KEY\n")
+	// half-present: manifest says EXPIRATION, vault has no such secret.
+	writeManifest(t, home, "aws-gone", "EXPIRATION: aws-gone/EXPIRATION\n")
+
+	sessions, err := ListSessions(v, home, now)
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(sessions) != 3 {
+		t.Fatalf("ListSessions returned %d sessions, want 3 (dev, prod, stage):\n%+v", len(sessions), sessions)
+	}
+	byName := map[string]Session{}
+	for _, s := range sessions {
+		byName[s.Profile] = s
+	}
+	if got := []string{sessions[0].Profile, sessions[1].Profile, sessions[2].Profile}; got[0] != "aws-dev" || got[1] != "aws-prod" || got[2] != "aws-stage" {
+		t.Errorf("order = %v, want sorted by profile", got)
+	}
+
+	stage := byName["aws-stage"]
+	if !stage.Live(now) || stage.Remaining(now) != 11*time.Hour {
+		t.Errorf("stage: Live=%v Remaining=%s, want live with 11h", stage.Live(now), stage.Remaining(now))
+	}
+	if stage.Origin != "~/.clisso.yaml" {
+		t.Errorf("stage.Origin = %q, want ~/.clisso.yaml (which tool minted it)", stage.Origin)
+	}
+	prod := byName["aws-prod"]
+	if prod.Live(now) || prod.Remaining(now) != 0 {
+		t.Errorf("prod: Live=%v Remaining=%s, want expired", prod.Live(now), prod.Remaining(now))
+	}
+	dev := byName["aws-dev"]
+	if dev.ExpiresUnix != 0 || !dev.Live(now) {
+		t.Errorf("dev (stampless): ExpiresUnix=%d Live=%v, want unknown and reported live, never expired", dev.ExpiresUnix, dev.Live(now))
+	}
+	if _, ok := byName["aws-ci"]; ok {
+		t.Error("a static key with no EXPIRATION was listed as a session")
+	}
+	if _, ok := byName["aws-gone"]; ok {
+		t.Error("a manifest whose EXPIRATION secret is missing was listed as a session")
+	}
+}
+
+func writeManifest(t *testing.T, home, name, body string) {
+	t.Helper()
+	dir := filepath.Join(home, profile.ProfilesDir)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/migrate/sessions_test.go
+++ b/internal/migrate/sessions_test.go
@@ -92,6 +92,9 @@ func TestListSessions(t *testing.T) {
 	writeManifest(t, home, "aws-ci", "ACCESS_KEY_ID: aws-ci/ACCESS_KEY_ID\nSECRET_ACCESS_KEY: aws-ci/SECRET_ACCESS_KEY\n")
 	// half-present: manifest says EXPIRATION, vault has no such secret.
 	writeManifest(t, home, "aws-gone", "EXPIRATION: aws-gone/EXPIRATION\n")
+	// unreadable: a manifest that is not a map. jit status must survive
+	// it, so the listing skips it rather than failing the whole call.
+	writeManifest(t, home, "broken", "- not\n- a map\n")
 
 	sessions, err := ListSessions(v, home, now)
 	if err != nil {
@@ -128,6 +131,9 @@ func TestListSessions(t *testing.T) {
 	}
 	if _, ok := byName["aws-gone"]; ok {
 		t.Error("a manifest whose EXPIRATION secret is missing was listed as a session")
+	}
+	if _, ok := byName["broken"]; ok {
+		t.Error("an unparsable manifest was listed as a session")
 	}
 }
 

--- a/internal/vault/envelope.go
+++ b/internal/vault/envelope.go
@@ -49,6 +49,20 @@ type envelope struct {
 	// resolver call, and flipping the marker on disk (either direction)
 	// must fail decryption rather than change what Get does.
 	Storage string `json:"storage,omitempty"`
+	// ExpiresUnix is when the PAYLOAD stops being valid (version 5+): the
+	// stamp a temporary credential arrived with — an AWS session minted by
+	// an SSO CLI carries its own expiry — copied out of the value so a
+	// listing can answer "is this session still live" without decrypting
+	// anything (jit status is prompt-free by design, so it may read
+	// metadata and never a value). Zero means no known expiry: a
+	// long-lived key, or any secret written before version 5 — never
+	// "expired". Unlike the provenance fields it is NOT birth-immutable: a
+	// rotation replaces it, because a re-minted session has a new end, and
+	// a Set that carries no stamp clears it, because a value with no known
+	// end has none. Plaintext on disk (the SDKs receive the same stamp in
+	// the clear) but AAD-bound, so an edited stamp fails decryption rather
+	// than resurrecting a dead session or hiding a live one.
+	ExpiresUnix int64 `json:"expires_unix,omitempty"`
 	// Recipients maps a recipient ID (this device's hostname in Phase 1;
 	// Phase 2 adds real multi-recipient sharing, RFC.md §5.2) to that
 	// recipient's hex-encoded wrapped DEK.
@@ -104,9 +118,13 @@ const (
 	// class/group/origin provenance, all AAD-bound. Never written anymore
 	// (Set writes v4), readable forever, same as v1 and v2.
 	envelopeVersionProvenance = 3
-	// envelopeVersion is what Set writes today: v3's provenance plus the
-	// storage marker (see envelope.Storage), all AAD-bound.
-	envelopeVersion = 4
+	// envelopeVersionStorage is the fourth schema: v3's provenance plus
+	// the storage marker (see envelope.Storage), all AAD-bound. Never
+	// written anymore (Set writes v5), readable forever, same as v1–v3.
+	envelopeVersionStorage = 4
+	// envelopeVersion is what Set writes today: v4 plus the expiry stamp
+	// (see envelope.ExpiresUnix), AAD-bound like everything before it.
+	envelopeVersion = 5
 )
 
 // StorageOpRef marks an envelope whose payload is a 1Password secret
@@ -175,19 +193,23 @@ const (
 // admits only [A-Za-z0-9_.-] and '/', so a colon can never appear in it and
 // the encoding is unambiguous.
 //
-// The AAD is version-shaped: a v4 payload was sealed under a string that
-// appends class:group:storage:origin, a v3 payload under the shape that
-// appends class:group:origin, a v2 payload under the four-field string that
+// The AAD is version-shaped: a v5 payload was sealed under a string that
+// appends class:group:storage:expires:origin, a v4 payload under the shape
+// that appends class:group:storage:origin, a v3 payload under
+// class:group:origin, a v2 payload under the four-field string that
 // predates them all. Get MUST reconstruct whichever the stored version used,
 // so the branch here is keyed on version, NOT on whether the newer fields
-// happen to be non-empty. class, group_id, and storage never contain a colon
-// (fixed vocabulary / hex id); origin can in principle, which is why origin
-// stays the LAST field in every version's shape — v4 inserts storage BEFORE
-// origin, not after it — so everything past the final delimiter is origin
-// and the encoding stays unambiguous.
-func envelopeAAD(path string, version int, createdUnix, updatedUnix int64, class, groupID, origin, storage string) []byte {
+// happen to be non-empty. class, group_id, storage and the expiry never
+// contain a colon (fixed vocabulary / hex id / integer); origin can in
+// principle, which is why origin stays the LAST field in every version's
+// shape — v4 inserts storage and v5 inserts expires BEFORE origin, not
+// after it — so everything past the final delimiter is origin and the
+// encoding stays unambiguous.
+func envelopeAAD(path string, version int, createdUnix, updatedUnix int64, class, groupID, origin, storage string, expiresUnix int64) []byte {
 	switch {
 	case version >= envelopeVersion:
+		return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d:%s:%s:%s:%d:%s", version, path, createdUnix, updatedUnix, class, groupID, storage, expiresUnix, origin)
+	case version >= envelopeVersionStorage:
 		return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d:%s:%s:%s:%s", version, path, createdUnix, updatedUnix, class, groupID, storage, origin)
 	case version >= envelopeVersionProvenance:
 		return fmt.Appendf(nil, "jit-envelope:%d:%s:%d:%d:%s:%s:%s", version, path, createdUnix, updatedUnix, class, groupID, origin)

--- a/internal/vault/expiry_test.go
+++ b/internal/vault/expiry_test.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package vault
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// rewriteEnvelope edits one stored envelope in place through fn, the way
+// a hostile hand (or an older jit) would touch the file: parsed, changed,
+// re-encoded, never re-sealed.
+func rewriteEnvelope(t *testing.T, v *Vault, path string, fn func(*envelope)) {
+	t.Helper()
+	file := filepath.Join(v.Root, "vault", path+".enc")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("reading envelope: %v", err)
+	}
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatalf("parsing envelope: %v", err)
+	}
+	fn(&env)
+	edited, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("re-encoding envelope: %v", err)
+	}
+	if err := os.WriteFile(file, edited, 0o600); err != nil {
+		t.Fatalf("writing edited envelope: %v", err)
+	}
+}
+
+func TestExpiryRoundTripsWithoutDecrypting(t *testing.T) {
+	v := newTestVault(t)
+	const stamp = int64(1_800_000_000)
+	if err := v.SetWithMeta("aws-stage/SESSION_TOKEN", []byte("tok"), Meta{Class: ClassAWS, ExpiresUnix: stamp}); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+	// Info never touches the KeyWrapper: a listing must answer "is this
+	// session live" without a prompt.
+	info, err := v.Info("aws-stage/SESSION_TOKEN")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.ExpiresUnix != stamp {
+		t.Errorf("Info.ExpiresUnix = %d, want %d", info.ExpiresUnix, stamp)
+	}
+	if info.Version != envelopeVersion {
+		t.Errorf("Version = %d, want %d", info.Version, envelopeVersion)
+	}
+	if got, err := v.Get("aws-stage/SESSION_TOKEN"); err != nil || string(got) != "tok" {
+		t.Fatalf("Get = %q, %v; want tok, nil", got, err)
+	}
+}
+
+// A re-minted session has a new end: unlike provenance, the stamp follows
+// the value, so a rotation replaces it and a stampless Set clears it.
+func TestExpiryFollowsTheValueNotThePath(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.SetWithMeta("aws-stage/SESSION_TOKEN", []byte("old"), Meta{Class: ClassAWS, Origin: "/home/u/.clisso.yaml", ExpiresUnix: 100}); err != nil {
+		t.Fatalf("first SetWithMeta: %v", err)
+	}
+	if err := v.SetWithMeta("aws-stage/SESSION_TOKEN", []byte("new"), Meta{Class: ClassAWS, ExpiresUnix: 200}); err != nil {
+		t.Fatalf("second SetWithMeta: %v", err)
+	}
+	info, err := v.Info("aws-stage/SESSION_TOKEN")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.ExpiresUnix != 200 {
+		t.Errorf("after rotation ExpiresUnix = %d, want 200 (the new mint's end)", info.ExpiresUnix)
+	}
+	if info.Origin != "/home/u/.clisso.yaml" {
+		t.Errorf("after rotation Origin = %q, want the birth origin preserved", info.Origin)
+	}
+
+	if err := v.Set("aws-stage/SESSION_TOKEN", []byte("manual")); err != nil {
+		t.Fatalf("bare Set: %v", err)
+	}
+	info, err = v.Info("aws-stage/SESSION_TOKEN")
+	if err != nil {
+		t.Fatalf("Info: %v", err)
+	}
+	if info.ExpiresUnix != 0 {
+		t.Errorf("after a stampless Set ExpiresUnix = %d, want 0 (no known expiry)", info.ExpiresUnix)
+	}
+	if got, err := v.Get("aws-stage/SESSION_TOKEN"); err != nil || string(got) != "manual" {
+		t.Fatalf("Get after bare Set = %q, %v; want manual, nil", got, err)
+	}
+}
+
+// The stamp is plaintext on disk and must be tamper-EVIDENT: moving it
+// forward would resurrect a dead session in every listing, moving it back
+// (or clearing it) would hide a live one. Both directions fail decryption.
+func TestExpiryIsAADBound(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		edit func(*envelope)
+	}{
+		{"pushed into the future", func(e *envelope) { e.ExpiresUnix += 3600 }},
+		{"cleared", func(e *envelope) { e.ExpiresUnix = 0 }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			v := newTestVault(t)
+			if err := v.SetWithMeta("aws-stage/SESSION_TOKEN", []byte("tok"), Meta{ExpiresUnix: 1_800_000_000}); err != nil {
+				t.Fatalf("SetWithMeta: %v", err)
+			}
+			rewriteEnvelope(t, v, "aws-stage/SESSION_TOKEN", tc.edit)
+			if got, err := v.Get("aws-stage/SESSION_TOKEN"); err == nil {
+				t.Fatalf("Get = %q on an edited expiry, want AAD failure", got)
+			}
+		})
+	}
+}
+
+// A stamp added to an envelope that predates it is exactly as forged as an
+// edited one: a v4 file with expires_unix written in must not open. And a
+// v4 file left alone reads as "no known expiry", not as expired.
+func TestExpiryOnPreStampEnvelope(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.Set("aws-stage/SESSION_TOKEN", []byte("tok")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	// Downgrade the file to the shape a v4 jit wrote: same AAD minus the
+	// expiry, so the payload has to be re-sealed under v4's string.
+	file := filepath.Join(v.Root, "vault", "aws-stage/SESSION_TOKEN.enc")
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		t.Fatal(err)
+	}
+	wrappedDEK, err := hex.DecodeString(env.Recipients[v.RecipientID])
+	if err != nil {
+		t.Fatalf("decoding wrapped DEK: %v", err)
+	}
+	dek, err := v.KeyWrapper.UnwrapKey(wrappedDEK)
+	if err != nil {
+		t.Fatalf("unwrapping test DEK: %v", err)
+	}
+	sealed, err := seal(dek, []byte("tok"), envelopeAAD("aws-stage/SESSION_TOKEN", envelopeVersionStorage, env.CreatedUnix, env.UpdatedUnix, env.Class, env.GroupID, env.Origin, env.Storage, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+	env.Version = envelopeVersionStorage
+	env.ExpiresUnix = 0
+	env.Payload = hex.EncodeToString(sealed)
+	v4, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(file, v4, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := v.Info("aws-stage/SESSION_TOKEN")
+	if err != nil {
+		t.Fatalf("Info on v4: %v", err)
+	}
+	if info.ExpiresUnix != 0 {
+		t.Errorf("v4 Info.ExpiresUnix = %d, want 0 (unknown)", info.ExpiresUnix)
+	}
+	if got, err := v.Get("aws-stage/SESSION_TOKEN"); err != nil || string(got) != "tok" {
+		t.Fatalf("Get on v4 = %q, %v; want tok, nil — older envelopes must read forever", got, err)
+	}
+
+	// The v4 AAD has no expiry field, so a stamp written into a v4 file
+	// is bound by nothing — it has to be refused at the parse, for every
+	// reader, or Info would repeat the forgery while Get opened cleanly.
+	rewriteEnvelope(t, v, "aws-stage/SESSION_TOKEN", func(e *envelope) { e.ExpiresUnix = 1_800_000_000 })
+	if got, err := v.Get("aws-stage/SESSION_TOKEN"); err == nil {
+		t.Fatalf("Get = %q on a v4 file with a stamp written in, want refusal", got)
+	}
+	if info, err := v.Info("aws-stage/SESSION_TOKEN"); err == nil {
+		t.Fatalf("Info = %+v on a v4 file with a stamp written in, want refusal", info)
+	}
+}
+
+// Rekey re-encodes the whole envelope; a stamp must survive the MEK
+// rotation, and so must the AAD that binds it.
+func TestRekeyCarriesExpiry(t *testing.T) {
+	v := newTestVault(t)
+	if err := v.SetWithMeta("aws-stage/SESSION_TOKEN", []byte("tok"), Meta{ExpiresUnix: 1_800_000_000}); err != nil {
+		t.Fatalf("SetWithMeta: %v", err)
+	}
+	oldKW := v.KeyWrapper
+	newKW := newFakeKeyWrapper()
+	if _, _, err := v.RewrapAll(oldKW, newKW); err != nil {
+		t.Fatalf("RewrapAll: %v", err)
+	}
+	v.KeyWrapper = newKW
+	info, err := v.Info("aws-stage/SESSION_TOKEN")
+	if err != nil {
+		t.Fatalf("Info after rekey: %v", err)
+	}
+	if info.ExpiresUnix != 1_800_000_000 {
+		t.Errorf("ExpiresUnix after rekey = %d, want 1800000000", info.ExpiresUnix)
+	}
+	if got, err := v.Get("aws-stage/SESSION_TOKEN"); err != nil || string(got) != "tok" {
+		t.Fatalf("Get after rekey = %q, %v; want tok, nil", got, err)
+	}
+}

--- a/internal/vault/vault.go
+++ b/internal/vault/vault.go
@@ -105,6 +105,12 @@ type Meta struct {
 	Class   string
 	GroupID string
 	Origin  string
+	// ExpiresUnix is the one field honored on EVERY write, rotation
+	// included — see envelope.ExpiresUnix for why an expiry follows the
+	// value rather than the path. Zero (the default) means no known
+	// expiry, so a caller that isn't storing a temporary credential need
+	// not think about it.
+	ExpiresUnix int64
 }
 
 // NewGroupID mints a fresh surrogate group id: 128 bits of randomness, hex
@@ -184,6 +190,9 @@ func (v *Vault) setEnvelope(path string, value []byte, meta Meta, storage string
 	now := time.Now().Unix()
 	created := now
 	class, groupID, origin := meta.Class, meta.GroupID, meta.Origin
+	// The expiry is the one piece of meta a rotation does NOT preserve:
+	// it describes this value, not the path (envelope.ExpiresUnix).
+	expires := meta.ExpiresUnix
 	var originSeen int64
 	if origin != "" {
 		originSeen = now
@@ -212,7 +221,7 @@ func (v *Vault) setEnvelope(path string, value []byte, meta Meta, storage string
 	}
 	defer wipe(dek)
 
-	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, created, now, class, groupID, origin, storage))
+	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, created, now, class, groupID, origin, storage, expires))
 	if err != nil {
 		return fmt.Errorf("encrypting secret: %w", err)
 	}
@@ -244,6 +253,7 @@ func (v *Vault) setEnvelope(path string, value []byte, meta Meta, storage string
 		Origin:         origin,
 		OriginSeenUnix: originSeen,
 		Storage:        storage,
+		ExpiresUnix:    expires,
 		Recipients: map[string]string{
 			v.RecipientID: hex.EncodeToString(wrappedDEK),
 		},
@@ -287,6 +297,18 @@ func (v *Vault) readEnvelope(path string) (envelope, error) {
 	var env envelope
 	if err := json.Unmarshal(data, &env); err != nil {
 		return envelope{}, fmt.Errorf("parsing envelope %s: %w", src, err)
+	}
+	// A field the stored version cannot authenticate is a claim the file
+	// is not allowed to make. The AAD is version-shaped (envelopeAAD), so
+	// an expiry written into a v4 file — or a storage marker into a v3 one
+	// — is bound by nothing: Get would open the payload cleanly and Info
+	// would repeat the forgery. Refuse at the parse, before any reader
+	// acts on it; a genuine older envelope never carries these.
+	if env.Version < envelopeVersion && env.ExpiresUnix != 0 {
+		return envelope{}, fmt.Errorf("corrupt envelope %s: an expiry stamp on a version-%d envelope, which cannot authenticate one", src, env.Version)
+	}
+	if env.Version < envelopeVersionStorage && env.Storage != "" {
+		return envelope{}, fmt.Errorf("corrupt envelope %s: a storage marker on a version-%d envelope, which cannot authenticate one", src, env.Version)
 	}
 	return env, nil
 }
@@ -346,12 +368,12 @@ func (v *Vault) GetStored(path string) ([]byte, string, error) {
 	switch env.Version {
 	case envelopeVersionAADLess:
 		// v1: no AAD, no metadata. Readable forever.
-	case envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersion:
-		// v2, v3, and v4 all bind their metadata into the AAD; envelopeAAD
+	case envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersionStorage, envelopeVersion:
+		// v2 through v5 all bind their metadata into the AAD; envelopeAAD
 		// reconstructs the exact shape the stored version sealed under
-		// (v3 appends class/group/origin, v4 adds storage — all empty on
-		// the versions that predate them).
-		aad = envelopeAAD(path, env.Version, env.CreatedUnix, env.UpdatedUnix, env.Class, env.GroupID, env.Origin, env.Storage)
+		// (v3 appends class/group/origin, v4 adds storage, v5 adds the
+		// expiry — all empty on the versions that predate them).
+		aad = envelopeAAD(path, env.Version, env.CreatedUnix, env.UpdatedUnix, env.Class, env.GroupID, env.Origin, env.Storage, env.ExpiresUnix)
 	default:
 		return nil, "", fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
 	}
@@ -430,6 +452,11 @@ type SecretInfo struct {
 	GroupID        string
 	Origin         string
 	OriginSeenUnix int64
+	// ExpiresUnix is when the value stops being valid, 0 when unknown (a
+	// long-lived key, or a secret written before the stamp existed) — see
+	// envelope.ExpiresUnix. Render 0 as "no known expiry", never as 1970
+	// and never as "expired".
+	ExpiresUnix int64
 	// Storage is the envelope's payload-kind marker ("" for a literal
 	// value, StorageOpRef for a 1Password reference) — what lets listings
 	// tag a linked secret without decrypting anything. Like the rest of
@@ -459,7 +486,7 @@ func (v *Vault) Verify(path string) error {
 	// "corruption" that isn't corruption at all, so name it as such rather
 	// than letting it read as a damaged file.
 	switch env.Version {
-	case envelopeVersionAADLess, envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersion:
+	case envelopeVersionAADLess, envelopeVersionMetaOnly, envelopeVersionProvenance, envelopeVersionStorage, envelopeVersion:
 	default:
 		return fmt.Errorf("secret %s has envelope version %d, newer than this jit understands (max %d), upgrade jit to read it", path, env.Version, envelopeVersion)
 	}
@@ -501,6 +528,7 @@ func (v *Vault) Info(path string) (SecretInfo, error) {
 		GroupID:        env.GroupID,
 		Origin:         env.Origin,
 		OriginSeenUnix: env.OriginSeenUnix,
+		ExpiresUnix:    env.ExpiresUnix,
 		Storage:        env.Storage,
 	}, nil
 }

--- a/internal/vault/vault_test.go
+++ b/internal/vault/vault_test.go
@@ -458,7 +458,7 @@ func TestVaultOverwritePreservesCreatedUnix(t *testing.T) {
 func rewriteEnvelopeTimestamps(v *Vault, path string, value []byte, createdUnix, updatedUnix int64) error {
 	kw := v.KeyWrapper.(*fakeKeyWrapper)
 	dek := bytes.Repeat([]byte{0x0a}, dekSize)
-	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, createdUnix, updatedUnix, "", "", "", ""))
+	sealedPayload, err := seal(dek, value, envelopeAAD(path, envelopeVersion, createdUnix, updatedUnix, "", "", "", "", 0))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- **Vault (envelope v5):** a temporary credential's expiry is stored as metadata — plaintext on disk, AAD-bound like timestamps and provenance — so a listing can answer "is this session still live" through `Info()` without decrypting. The stamp follows the value (a rotation replaces it, a stampless `Set` clears it). `readEnvelope` now refuses a field the stored version cannot authenticate (an expiry on a v4 file, a storage marker on a v3 one) — a gap the new AAD test found.
- **`migrate.ListSessions`:** every profile with an `EXPIRATION` variable is a session; both writers (the clisso capture and a `~/.aws/credentials` migration that finds `aws_expiration`) stamp every secret of the session. Keyed on the variable, not the tool.
- **`jit status`** gains a last row (`sessions ● 2 live · stage expires 2026-09-05 21:11 · …`), with `→ clisso get <app>` for an expired one, and a `sessions` object in `--format json` carrying `mint`. Omitted when nothing is a session.
- **`clisso status` under the wrap** is answered from the vault in clisso's own table shape (EXPIRE AT as a date rather than an epoch), so `clisso status | grep -qw stage` keeps working. clisso's own `status` reads `~/.aws/credentials`, the file the wrap keeps empty, and denied every session the vault held — a login script that checked it re-logged in with full MFA on every call. `-r/--read-from-file` passes through; an unwrapped config passes through. Ownership comes from `~/.clisso.yaml`'s `apps:`, not origin (birth-immutable, would disown a profile first migrated from `~/.aws/credentials`).
- **`aws-credential-process`** names the exact mint command in its expired-token error — the error kubectl and the AWS CLI actually show.
- `design/sessions-and-path-repair.md` records the plan and what the investigation established, including the `jit doctor --fix` that follows in a separate PR.

## Test plan

- [x] `go test -race ./...` green (three full runs across the branch)
- [x] gofmt, vet, `go mod verify`/`tidy -diff`, `docs-gen` drift, staticcheck and govulncheck under the pinned toolchain, gosec
- [x] Vault: v5 round-trip via `Info` only; rotation replaces / bare `Set` clears; edited stamp fails decryption both directions; a v4 file reads as unknown and a stamp forged into one is refused for every reader; rekey carries the stamp
- [x] Sessions: live / expired / stampless / non-session / missing-secret / unparsable-manifest cases; malformed RFC3339 stamps nothing but stores the value verbatim
- [x] CLI: row states, JSON shape, clisso table bytes, routing of `status` / `-r` / global-flags-first, and an end-to-end `clisso status` against an envelope whose payload can never open
- [x] On a real machine: `jit status` and the wrapped `clisso status` against the live vault, prompt-free; a pre-stamp capture reads "expiry unknown until its next login"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMdQMk6nLGzuZFrvFsSbxd
