### PR TITLE
migrate: refresh a recorded jit path that has gone stale

### DIFF
--- a/design/jit-path-refresh.md
+++ b/design/jit-path-refresh.md
@@ -1,0 +1,184 @@
+# Refreshing a recorded jit path: migrate owns what migrate wrote
+
+**Status: proposed 2026-09-05. Supersedes the "PR 2 — `jit doctor --fix`"
+section of `design/sessions-and-path-repair.md`, which loses for the
+reasons in "Why not doctor --fix".**
+
+## The defect
+
+`jit doctor` reports a `~/.kube/config` whose exec command points at
+`/opt/homebrew/Caskroom/jitpass/0.84.0/jit` — written by a jit that
+predates `internal/selfpath`, deleted by the `brew upgrade` that followed —
+and prescribes `jit migrate ~/.kube/config`. On an already-migrated file
+migrate prints "Nothing to migrate: none of the path(s) you named contain
+plaintext secrets jit can move" and changes nothing. Every run of doctor
+shows the same `✗`; every run of the command it names does nothing. There
+is no repair path for a recorded jit path anywhere in jit.
+
+Doctor's prescription was right. Migrate wrote that line, backs the file up,
+and undoes it; a stale line in it is migrate's to refresh. Migrate is wrong
+because it looks for plaintext secrets and nothing else.
+
+## What the code read established
+
+- `discoverFileTarget` routes a named fixed path by exact match:
+  `~/.aws/credentials`, `~/.kube/config`, the Terraform/Docker/git
+  credential files, GCP ADC, netrc, pypirc. **`~/.aws/config` is not a
+  target**, and neither are the three helper scripts under `~/.jit/shims`.
+  So `jit migrate --only aws` — doctor's action for a stale
+  `credential_process` line — cannot reach the file it is meant to fix.
+- `applyMigrate` scopes `--only` through one `categorySlices` table keyed
+  by `migrateCategories` token, with a fail-loud guard that every token
+  has an entry; the "nothing to migrate" test is `total == 0` over that
+  table; note-only slices (`tfvarsComplexOnly`, `wrapOwnedSkipped`) render
+  as skip hints and are never counted.
+- `printMigratePlan` is the one rendering both `--dry-run` and the real
+  `[y/N]` share (`TestMigrateDryRunMatchesRealPlanExactly`); a category
+  enters the plan via `printMigratePlanCategoryAnnotated` and the subtotal
+  via the explicit slice list at its foot.
+- `resolveJitExecutable` (`selfpath.Durable`) is a package var so tests can
+  pin it; `TestEveryRecorderGoesThroughResolveJitExecutable` lists every
+  file that records jit's path and fails any that resolves it another way.
+- `BackupTracker.backupOnce` stores the pristine bytes encrypted, records
+  the undo entry with the file's mode, and dedups per run; the CLI threads
+  one tracker through every category's Apply loop.
+- Doctor's detector (`jitPathArtifacts` + `recordedJitPath`, in
+  `internal/cli/doctorsections.go`) already enumerates all five artifacts
+  with a per-artifact anchor key, so an unrelated `/usr/bin/jit` in a
+  comment is never a finding. It is the right rule; it lives in the wrong
+  package for migrate to share.
+
+## Why not `doctor --fix`
+
+1. "Scan is read-only in every mode; migrate is the guided fix path" is a
+   stated guarantee, and doctor sits on the read-only side of it. A `--fix`
+   opens a write path in a report — under a generic name every future
+   finding would have to decide whether it belongs to.
+2. Migrate already has everything the fix needs, and doctor would rebuild
+   it: encrypted backup into the undo ledger, `--dry-run`, the confirm
+   before `openVault`, `--only`, per-file targeting, and the `Durable()`
+   refusal with its message already written.
+3. Home-wide `jit migrate` heals the not-yet-broken case
+   (`[jit path: after the next upgrade]`) on any ordinary run — most of the
+   value of an auto-heal, under a command the user typed, with a plan they
+   can preview.
+4. The plan already carries rows that are not secrets (`wraps`, the guard,
+   the cache sweep). A `[recorded jit path]` row is the same shape.
+
+## Decisions
+
+**D1. The detector moves to `internal/migrate`.** `jitpathrefresh.go`:
+
+    type RecordedJitPath struct {
+        Label    string // "~/.kube/config", "the git credential helper"
+        Path     string // the artifact
+        Category string // the --only token that owns it: kube, aws, docker, git, terraform
+        Recorded string // the jit path the line carries
+    }
+    func DiscoverRecordedJitPaths(home string) []RecordedJitPath   // all five, best-effort, read-only
+    func (r RecordedJitPath) Stale() (reason string)              // "isn't there" / "version-pinned" / ""
+
+Same table, same anchor keys, same regex as doctor's today. Doctor's
+`jitPathFindings` becomes a consumer: kinds, details and action strings are
+unchanged — they were right. `selfpath` sits below `migrate`, so
+`VersionedBrew` is reachable.
+
+**D2. A refresh is a counted plan row, scoped by its owning category.**
+`discovered` gains `jitPaths []jitPathRefresh` (artifact path, category,
+recorded path, reason). It counts in `total()`, in the plan subtotal, and in
+the "nothing to migrate" test. `--only` scopes it by the artifact's
+category — `--only aws` refreshes `~/.aws/config`, `--only kube`
+`~/.kube/config` — so every action doctor already prints becomes true. No
+new `--only` token: a refresh is maintenance of a category's artifact, not a
+category.
+
+**D3. Discovery.** A named artifact (`jit migrate ~/.kube/config`,
+`~/.aws/config`, a helper under `~/.jit/shims`) checks its own recorded
+path *in addition to* its category discovery, so a kubeconfig with both a
+plaintext token and a stale exec line gets both rows. Bare `jit migrate`
+checks all five: cheap, read-only, and independent of the scan — the scan
+is about secrets and stays that way (`scan and migrate agree` is about what
+scan promises, not what migrate may additionally maintain). The
+"Nothing to protect" early return counts refresh rows.
+
+**D4. Refusal is decided at plan time.** `resolveJitExecutable()` runs
+during discovery — prompt-free, no vault — and an error turns every refresh
+row into one note-only slice rendered like `tfvarsComplexOnly`:
+
+    2 recorded jit paths can't be refreshed: this jit is running from a
+    temporary or removable location (~/Downloads/jit); …
+      ~/.kube/config, ~/.aws/config
+
+Not counted, never applied, and shown even when it is the only content.
+Today's alternative — every `Apply*` failing after the user confirmed — is
+what this replaces.
+
+**D5. Apply.** `RefreshRecordedJitPath(v, home, r, tracker)`: `backupOnce`
+(pristine bytes, mode, undo record), then a line-anchored substitution —
+only lines containing the artifact's anchor key, only the regex match equal
+to `r.Recorded` — preserving every other byte, quoting included; write with
+the file's own mode via `vault.AtomicWriteFile`. Idempotent by
+construction: a durable path is not stale, so it is never a row. A durable
+path containing whitespace or a quote is refused as a note (D4's slice):
+the writers' quoting rules differ per artifact and the case does not occur
+on a Homebrew or `/usr/local` install.
+
+**D6. Rendering.** Plan, in the machine-wide group:
+
+    [recorded jit path] 2
+      → the jit these configs run is gone or version-pinned; rewritten to
+        /opt/homebrew/bin/jit (backed up encrypted first)
+      • ~/.kube/config (was ~/../Caskroom/jitpass/0.84.0/jit)
+      • ~/.aws/config (was ~/../Caskroom/jitpass/0.84.0/jit)
+
+Result, in the mutation log:
+
+    [recorded jit paths refreshed] 2
+      • ~/.kube/config -> /opt/homebrew/bin/jit; backup: jit vault get …
+      • ~/.aws/config -> /opt/homebrew/bin/jit; backup: jit vault get …
+
+Both previewed by eye before wiring (CLAUDE.md rule).
+
+**D7. Doctor is untouched on the surface.** Its detector is swapped for
+D1's; its action strings stay: `jit migrate ~/.kube/config`,
+`jit migrate --only aws|docker|git|terraform`. Their truth is what this
+work restores.
+
+## Invariants preserved
+
+- `--dry-run` and the real confirm render one plan (D6 goes through
+  `printMigratePlan`; the parity test gains a refresh fixture).
+- The confirm precedes `openVault`; a refusal (D4) costs no prompt.
+- `jit scan` is untouched. `jit doctor` stays read-only.
+- Every recorder goes through `resolveJitExecutable`
+  (`jitPathRecorders` gains `jitpathrefresh.go`).
+- `jit migrate undo` restores the artifact byte-for-byte, mode included.
+
+## Tests
+
+- migrate: discovery over each of the five artifacts (stale-missing,
+  stale-versioned, durable → no row, unrelated path in a comment → no row,
+  absent file → no row); the substitution as a pure function on golden
+  lines (YAML `command:`, INI `credential_process`, `exec '…'` in a shell
+  helper) leaving quoting and every other byte intact; refusal note when
+  `resolveJitExecutable` fails; undo round trip with mode.
+- cli: `jit migrate ~/.kube/config` on a migrated file with a stale path
+  plans and applies one row; `--only aws` scopes to `~/.aws/config`;
+  `--only env` leaves refresh rows out; bare `jit migrate` with nothing but
+  a stale path proceeds to a plan; two `[DRY RUN]` markers on a
+  refresh-only dry run; parity; doctor's findings and actions unchanged
+  through the shared detector.
+
+## Phases
+
+1. D1 + D7: move the detector, swap doctor to it. No behaviour change;
+   doctor's tests pass unchanged.
+2. D2–D6: discovery, plan row, apply, note; preview approved first.
+3. Tests, `jit migrate --help` mention, `docs-gen`, the pinned gate.
+
+## Out of scope
+
+- Auto-heal from `jit service` at login: still deferred; this covers the
+  proactive case through bare `jit migrate`.
+- MCP configs: `mcpFindings` names the server and its own re-migration
+  path already; unchanged here.

--- a/design/jit-path-refresh.md
+++ b/design/jit-path-refresh.md
@@ -1,6 +1,6 @@
 # Refreshing a recorded jit path: migrate owns what migrate wrote
 
-**Status: proposed 2026-09-05. Supersedes the "PR 2 — `jit doctor --fix`"
+**Status: implemented 2026-09-05 (branch jit-path-refresh). Supersedes the "PR 2 — `jit doctor --fix`"
 section of `design/sessions-and-path-repair.md`, which loses for the
 reasons in "Why not doctor --fix".**
 

--- a/docs/reference/commands/jit_migrate.md
+++ b/docs/reference/commands/jit_migrate.md
@@ -45,6 +45,12 @@ plan and asks for confirmation before touching anything, and every modified
 file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`
 restores a migrated file from that backup.
 
+A machine-wide file jit already migrated is still worth naming: the line it
+carries to call back into jit records an absolute path, and if that path has
+gone stale (a version-numbered Homebrew copy the last upgrade deleted) the run
+refreshes it to the durable one — the fix `jit doctor` prescribes for a
+[jit path] finding. Bare `jit migrate` checks every such file it ever wrote.
+
 After vaulting, the run also clears verbatim copies of the newly vaulted
 credentials from AI agent caches under your home directory — files beyond
 the targets you named, each listed in the plan and backed up before it is

--- a/internal/cli/doctorsections.go
+++ b/internal/cli/doctorsections.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -312,41 +311,6 @@ func mcpFindings(cwd string) []checkFinding {
 	return findings
 }
 
-// jitPathArtifact is one thing `jit migrate` rewrote to call back into jit,
-// paired with how to find the recorded path inside it and what to re-run to
-// refresh it.
-type jitPathArtifact struct {
-	// Label names the artifact the way the user thinks of it, since the file
-	// itself is sometimes an implementation detail they never chose (the
-	// helper scripts under ~/.jit/shims).
-	Label string
-	Path  string
-	// Key is the token whose line carries the recorded path. Anchoring to it
-	// rather than scanning the whole file keeps an unrelated /usr/bin/jit
-	// mentioned in a comment from being reported as a broken artifact.
-	Key    string
-	Action string
-}
-
-// jitPathArtifacts enumerates every non-MCP artifact that records jit's
-// absolute path. MCP configs are deliberately absent: mcpFindings already
-// checks theirs, and it can say which SERVER broke, which is the more useful
-// sentence there.
-func jitPathArtifacts(home string) []jitPathArtifact {
-	return []jitPathArtifact{
-		{"~/.kube/config", migrate.KubeconfigPath(home), "command:", "`jit migrate " + shortPath(migrate.KubeconfigPath(home)) + "`"},
-		{"~/.aws/config", migrate.AWSConfigPath(home), "credential_process", "`jit migrate --only aws`"},
-		{"the docker credential helper", migrate.DockerHelperPath(home), "exec ", "`jit migrate --only docker`"},
-		{"the git credential helper", migrate.GitHelperPath(home), "exec ", "`jit migrate --only git`"},
-		{"the terraform credentials helper", migrate.TerraformHelperPath(home), "exec ", "`jit migrate --only terraform`"},
-	}
-}
-
-// recordedJitPath matches an absolute path ending in the jit binary, with the
-// surrounding quoting the writers apply (shell single quotes, YAML/JSON double
-// quotes) left outside the capture.
-var recordedJitPath = regexp.MustCompile(`(/[^\s"']*/jit)\b`)
-
 // jitPathFindings checks every recorded jit path OUTSIDE MCP configs.
 //
 // It exists because that check was written once, for MCP, and never extended
@@ -358,49 +322,44 @@ var recordedJitPath = regexp.MustCompile(`(/[^\s"']*/jit)\b`)
 // resolving a reference and being able to EXEC the binary that resolves it
 // are different questions and only the first was being asked.
 //
-// Best-effort per artifact: an unreadable or absent file yields nothing
-// rather than a failed run. A file jit never wrote has no matching line and
-// so is silently uninteresting, which is what makes it safe to probe all five
-// unconditionally.
+// The enumeration and the staleness rule live in internal/migrate
+// (DiscoverRecordedJitPaths), because migrate is what refreshes these
+// (design/jit-path-refresh.md) and the two must agree on what an artifact
+// is. What is doctor's alone is the verdict: a gone binary is a problem, a
+// version-pinned one is advice, and each names the migrate run that fixes it.
 func jitPathFindings(home string) []checkFinding {
 	var findings []checkFinding
-	for _, a := range jitPathArtifacts(home) {
-		data, err := os.ReadFile(a.Path) // #nosec G304 -- fixed, jit-owned artifact locations
-		if err != nil {
-			continue
-		}
-		seen := map[string]bool{}
-		for _, line := range strings.Split(string(data), "\n") {
-			if !strings.Contains(line, a.Key) {
-				continue
-			}
-			m := recordedJitPath.FindStringSubmatch(line)
-			if m == nil || seen[m[1]] {
-				continue
-			}
-			seen[m[1]] = true
-			recorded := m[1]
-
-			switch {
-			case !executableFile(recorded):
-				findings = append(findings, checkFinding{
-					Kind: kindJitPath,
-					Path: a.Path,
-					Detail: fmt.Sprintf("%s runs jit from %s, which isn't there",
-						a.Label, shortHome(recorded)),
-					Action: a.Action,
-				})
-			case selfpath.VersionedBrew(recorded):
-				findings = append(findings, checkFinding{
-					Kind:   kindJitPathUpgrade,
-					Path:   a.Path,
-					Detail: fmt.Sprintf("%s runs a version-pinned jit", a.Label),
-					Action: a.Action,
-				})
-			}
+	for _, r := range migrate.DiscoverRecordedJitPaths(home) {
+		switch r.Stale() {
+		case migrate.StaleMissing:
+			findings = append(findings, checkFinding{
+				Kind: kindJitPath,
+				Path: r.Path,
+				Detail: fmt.Sprintf("%s runs jit from %s, which isn't there",
+					r.Label, shortHome(r.Recorded)),
+				Action: jitPathAction(r),
+			})
+		case migrate.StaleVersioned:
+			findings = append(findings, checkFinding{
+				Kind:   kindJitPathUpgrade,
+				Path:   r.Path,
+				Detail: fmt.Sprintf("%s runs a version-pinned jit", r.Label),
+				Action: jitPathAction(r),
+			})
 		}
 	}
 	return findings
+}
+
+// jitPathAction names the migrate run that refreshes an artifact: the file
+// itself for the kubeconfig (the one a user knows by path), the owning
+// category for the rest. Both reach the artifact through migrate's own
+// discovery, so the command doctor prints is the command that works.
+func jitPathAction(r migrate.RecordedJitPath) string {
+	if r.Category == "kube" {
+		return "`jit migrate " + shortPath(r.Path) + "`"
+	}
+	return "`jit migrate --only " + r.Category + "`"
 }
 
 // executableFile reports whether path is a regular file with an execute bit.

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -148,6 +148,59 @@ type discovered struct {
 	// print time (wrapOwnerForPath) rather than stored beside the path, so
 	// dedupe() can treat this like every other []string.
 	wrapOwnedSkipped []string
+	// jitPaths are artifacts migrate wrote whose recorded jit path is stale
+	// (gone, or a version-numbered Homebrew copy the next upgrade deletes),
+	// each to be rewritten to jitPathTarget — the durable path resolved
+	// once, at plan time, so the plan and the write agree by construction
+	// (design/jit-path-refresh.md D2–D5). Counted like any category; scoped
+	// by --only through each artifact's own owning category.
+	jitPaths      []migrate.RecordedJitPath
+	jitPathTarget string
+	// jitPathRefused is note-only: the same stale artifacts when this jit
+	// has no durable path to record (jitPathRefusal says why). Rendered as
+	// a skip hint, never counted, never applied — the refusal is decided
+	// here rather than after the user confirmed.
+	jitPathRefused []string
+	jitPathRefusal string
+}
+
+// durableJitPath is the plan-time resolver, a seam for the cli tests: the
+// test binary lives under a volatile directory, so the real one correctly
+// refuses there, and both outcomes need exercising from this package.
+var durableJitPath = migrate.ResolveDurableJitPath
+
+// discoverJitPathRefresh adds every stale recorded jit path that `keep`
+// admits (nil keeps all) — as a refresh row when this jit has a durable
+// path, as a refusal note when it does not. Read-only and prompt-free:
+// the enumeration reads five fixed files, and the resolver never touches
+// the vault.
+func discoverJitPathRefresh(d *discovered, home string, keep func(migrate.RecordedJitPath) bool) {
+	for _, r := range migrate.DiscoverRecordedJitPaths(home) {
+		if r.Stale() == "" || (keep != nil && !keep(r)) {
+			continue
+		}
+		to, err := durableJitPath()
+		if err != nil {
+			d.jitPathRefused = append(d.jitPathRefused, r.Path)
+			d.jitPathRefusal = err.Error()
+			continue
+		}
+		d.jitPathTarget = to
+		d.jitPaths = append(d.jitPaths, r)
+	}
+}
+
+// printJitPathRefused renders the refusal note (design/jit-path-refresh.md
+// D4) in the shape every other skip hint uses.
+func printJitPathRefused(w io.Writer, home string, d *discovered) {
+	if len(d.jitPathRefused) == 0 {
+		return
+	}
+	// The frame reads "Skipped N finding(s) <reason>:", so the reason
+	// starts mid-sentence, as every other skip note's does.
+	printSkippedFindings(w, home, len(d.jitPathRefused),
+		"in "+countWord(len(d.jitPathRefused), "config", "configs")+" that "+pluralWord(len(d.jitPathRefused), "runs", "run")+" a jit that is gone or version-pinned, which this jit can't refresh right now",
+		d.jitPathRefused, d.jitPathRefusal)
 }
 
 // noteNamespaceMove explains a claimNamespace bump (GAPS.md #55) directly
@@ -368,6 +421,18 @@ func wrapPlanDetail(home, tool string) string {
 // token fails loud rather than being silently ignored — a typo'd category
 // name should never look like "nothing found" once the confirmation
 // prompt already fired.
+// filterJitPathsByCategory keeps the refresh rows whose owning category
+// --only selected.
+func filterJitPathsByCategory(rows []migrate.RecordedJitPath, selected map[string]bool) []migrate.RecordedJitPath {
+	var kept []migrate.RecordedJitPath
+	for _, r := range rows {
+		if selected[r.Category] {
+			kept = append(kept, r)
+		}
+	}
+	return kept
+}
+
 func filterMigrateOnly(only []string) (map[string]bool, error) {
 	valid := make(map[string]bool, len(migrateCategories))
 	for _, c := range migrateCategories {
@@ -423,6 +488,11 @@ var migrateCmd = &cobra.Command{
 		"plan and asks for confirmation before touching anything, and every modified\n" +
 		"file is backed up (encrypted, into the vault) first, `jit migrate undo <path>`\n" +
 		"restores a migrated file from that backup.\n\n" +
+		"A machine-wide file jit already migrated is still worth naming: the line it\n" +
+		"carries to call back into jit records an absolute path, and if that path has\n" +
+		"gone stale (a version-numbered Homebrew copy the last upgrade deleted) the run\n" +
+		"refreshes it to the durable one — the fix `jit doctor` prescribes for a\n" +
+		"[jit path] finding. Bare `jit migrate` checks every such file it ever wrote.\n\n" +
 		"After vaulting, the run also clears verbatim copies of the newly vaulted\n" +
 		"credentials from AI agent caches under your home directory — files beyond\n" +
 		"the targets you named, each listed in the plan and backed up before it is\n" +
@@ -523,6 +593,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	looseEmbeddedSkipped := d.looseEmbeddedSkipped
 	historyKeyOnly := d.historyKeyOnly
 	wrapOwnedSkipped := d.wrapOwnedSkipped
+	jitPaths := d.jitPaths
+	jitPathRefused := d.jitPathRefused
 
 	// --only scopes a run to just the named categories (GAPS.md #21) —
 	// validated against migrateCategories BEFORE anything else, including
@@ -589,9 +661,24 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		if !selected["k8s-secret"] {
 			k8sManifestsComplexOnly = nil // note-only companion, scoped with its category
 		}
+		// A recorded-path refresh is scoped by the category whose migration
+		// wrote the artifact: `--only aws` refreshes ~/.aws/config exactly
+		// as it migrates ~/.aws/credentials. Not a token of its own.
+		jitPaths = filterJitPathsByCategory(jitPaths, selected)
+		if len(jitPathRefused) > 0 {
+			var kept []string
+			for _, r := range migrate.DiscoverRecordedJitPaths(home) {
+				for _, p := range jitPathRefused {
+					if r.Path == p && selected[r.Category] {
+						kept = append(kept, p)
+					}
+				}
+			}
+			jitPathRefused = kept
+		}
 	}
 
-	total := 0
+	total := len(jitPaths)
 	for _, items := range categorySlices {
 		total += len(*items)
 	}
@@ -613,6 +700,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		printSkippedFindings(cmd.OutOrStdout(), home, len(historyKeyOnly), "in "+pluralWord(len(historyKeyOnly), "a history file", "history files")+" holding private key material", historyKeyOnly,
 			"jit only matched the -----BEGIN line; the key body is on the lines around it, so redacting would leave the key behind and make the file look clean. Regenerate the key, then delete those lines by hand.")
 		printSkippedWrapOwned(cmd.OutOrStdout(), home, wrapOwnedSkipped)
+		printJitPathRefused(cmd.OutOrStdout(), home, &discovered{jitPathRefused: jitPathRefused, jitPathRefusal: d.jitPathRefusal})
 		return false, nil
 	}
 
@@ -657,6 +745,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		netrcFiles:       netrcFiles,
 		pypircFiles:      pypircFiles,
 		looseSecretFiles: looseSecretFiles,
+		jitPaths:         jitPaths,
+		jitPathTarget:    d.jitPathTarget,
 	}
 	// The cache-sweep preview joins the plan HERE, after the --only
 	// filter: its needles are the plaintext values of exactly the files
@@ -686,6 +776,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	printSkippedFindings(cmd.OutOrStdout(), home, len(historyKeyOnly), "in "+pluralWord(len(historyKeyOnly), "a history file", "history files")+" holding private key material", historyKeyOnly,
 		"jit only matched the -----BEGIN line; the key body is on the lines around it, so redacting would leave the key behind and make the file look clean. Regenerate the key, then delete those lines by hand.")
 	printSkippedWrapOwned(cmd.OutOrStdout(), home, wrapOwnedSkipped)
+	printJitPathRefused(cmd.OutOrStdout(), home, &discovered{jitPathRefused: jitPathRefused, jitPathRefusal: d.jitPathRefusal})
 
 	// The 1Password announcement is part of the plan the user confirms
 	// against (and --dry-run's, same rendering), but the plan never
@@ -816,6 +907,23 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	// a run that migrates none of the disclosing categories never pays the
 	// full-vault read.
 	dupIdx := &dupIndexOnce{v: v}
+
+	// Recorded jit paths first: a category migration later in this run
+	// (a kubeconfig user, an AWS profile) rewrites the same artifact with
+	// the same durable path, and the tracker's first backup of the file is
+	// the pristine one either way.
+	if len(jitPaths) > 0 {
+		printMigrateResultCategory(out, pluralWord(len(jitPaths), "recorded jit path refreshed", "recorded jit paths refreshed"), len(jitPaths))
+		for _, r := range jitPaths {
+			res, err := migrate.RefreshRecordedJitPath(v, r, d.jitPathTarget, backups)
+			if err != nil {
+				return false, fmt.Errorf("jit migrate: %w", err)
+			}
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> %s; backup: `jit vault get %s`\n",
+				displayPath(home, res.Path), res.To, res.Backup)))
+		}
+		fmt.Fprintln(out)
+	}
 
 	// Each migrated category gets the same "[Label] (N)" header + bullet
 	// shape the plan itself already uses (printMigratePlan/
@@ -1476,13 +1584,19 @@ func runMigrateAll(cmd *cobra.Command) error {
 		offerGuard = false
 	}
 
-	if len(files) == 0 && len(tools) == 0 && !offerGuard {
+	// The artifacts migrate itself wrote are checked on every bare run —
+	// independent of the scan, which is about secrets — so a recorded jit
+	// path heals before the upgrade that would break it, under a plan the
+	// user previews (design/jit-path-refresh.md D3).
+	d := &discovered{}
+	discoverJitPathRefresh(d, home, nil)
+
+	if len(files) == 0 && len(tools) == 0 && !offerGuard && d.total() == 0 && len(d.jitPathRefused) == 0 {
 		fmt.Fprintln(cmd.OutOrStdout(), hlCmds("Nothing to protect — the scan found no secrets jit can act on. Run `jit scan` for the full picture."))
 		return nil
 	}
 	sort.Strings(files)
 
-	d := &discovered{}
 	for _, path := range files {
 		if err := discoverFileTarget(d, home, path); err != nil {
 			// One unreadable file must not sink the whole protect run; say
@@ -1504,6 +1618,10 @@ func runMigrateAll(cmd *cobra.Command) error {
 		// hard-linked, or changed under us), so preventing the NEXT one is the
 		// only protection left to give. Returning here would have offered it
 		// in the plan and then silently not installed it.
+		if len(d.jitPathRefused) > 0 {
+			printJitPathRefused(out, home, d)
+			return nil
+		}
 		fmt.Fprintln(out, hlCmds("Nothing bare `jit migrate` can protect right now: the flagged file(s) mix secrets with other content or need to be named explicitly. `jit scan` has the details."))
 		return nil
 	}
@@ -1792,6 +1910,14 @@ func discoverFileTarget(d *discovered, home, path string) error {
 			return nil
 		}
 	}
+	// An artifact migrate itself wrote (~/.kube/config, ~/.aws/config, a
+	// credential helper) is also checked for the jit path it records —
+	// before the switch, which returns early for the kubeconfig, and in
+	// addition to it: a kubeconfig with a plaintext token AND a stale exec
+	// line gets both rows (design/jit-path-refresh.md D3). This is what
+	// makes doctor's `jit migrate ~/.kube/config` do what it says on a
+	// file that has already been migrated.
+	discoverJitPathRefresh(d, home, func(r migrate.RecordedJitPath) bool { return r.Path == path })
 	// The remaining fixed files each live at exactly one path. The name-keyed
 	// categories (aws/kube/terraform/docker/git) migrate every profile/user/
 	// host/registry the one file holds, so there's nothing to narrow; the
@@ -1994,10 +2120,19 @@ func (d *discovered) dedupe() {
 		&d.historyFiles, &d.mcpConfigs, &d.awsProfiles, &d.k8sUsers, &d.terraformHosts,
 		&d.dockerRegistries, &d.gitHosts, &d.gcpADCFiles, &d.sopsAgeFiles,
 		&d.npmrcFiles, &d.netrcFiles, &d.pypircFiles, &d.looseSecretFiles, &d.looseEmbeddedSkipped,
-		&d.historyKeyOnly, &d.wrapOwnedSkipped,
+		&d.historyKeyOnly, &d.wrapOwnedSkipped, &d.jitPathRefused,
 	} {
 		dedupeStrings(s)
 	}
+	seen := map[string]bool{}
+	kept := d.jitPaths[:0]
+	for _, r := range d.jitPaths {
+		if k := r.Path + "\x00" + r.Recorded; !seen[k] {
+			seen[k] = true
+			kept = append(kept, r)
+		}
+	}
+	d.jitPaths = kept
 }
 
 // total counts everything discovered across every category, so
@@ -2014,7 +2149,7 @@ func (d *discovered) total() int {
 	} {
 		n += len(s)
 	}
-	return n
+	return n + len(d.jitPaths)
 }
 
 // dedupeStrings drops repeated entries in place, keeping first-seen order.

--- a/internal/cli/migratejitpath_test.go
+++ b/internal/cli/migratejitpath_test.go
@@ -1,0 +1,137 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/migrate"
+)
+
+// stubDurableJitPath pins the plan-time resolver: the test binary is
+// volatile, so the real one refuses — the refusal path is the default here
+// and needs no stub.
+func stubDurableJitPath(t *testing.T, path string, err error) {
+	t.Helper()
+	orig := durableJitPath
+	durableJitPath = func() (string, error) { return path, err }
+	t.Cleanup(func() { durableJitPath = orig })
+}
+
+const staleKubeconfig = `apiVersion: v1
+users:
+- name: docker-desktop
+  user:
+    exec:
+      apiVersion: client.authentication.k8s.io/v1
+      command: /opt/homebrew/Caskroom/jitpass/0.84.0/jit
+      args: ["k8s-exec-credential", "--profile", "k8s-docker-desktop"]
+      interactiveMode: Never
+`
+
+// Doctor prescribes `jit migrate ~/.kube/config` for a stale exec line; on
+// an already-migrated file that used to print "Nothing to migrate" and
+// change nothing. It now plans the refresh — the same row --dry-run shows.
+func TestMigrateNamedKubeconfigPlansAJitPathRefresh(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	stubDurableJitPath(t, "/opt/homebrew/bin/jit", nil)
+	kube := migrate.KubeconfigPath(home)
+	writeArtifact(t, kube, staleKubeconfig)
+
+	out, err := execMigrate(t, kube, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate ~/.kube/config --dry-run: %v\n%s", err, out)
+	}
+	for _, want := range []string{
+		"[recorded jit path] 1",
+		"rewritten to /opt/homebrew/bin/jit",
+		"~/.kube/config (was /opt/homebrew/Caskroom/jitpass/0.84.0/jit)",
+		"1 change planned across 1 category",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plan missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Nothing to migrate") {
+		t.Errorf("a stale recorded path is something to migrate:\n%s", out)
+	}
+	if got := strings.Count(out, "[DRY RUN]"); got != 2 {
+		t.Errorf("expected exactly 2 [DRY RUN] markers on a refresh-only dry run, got %d:\n%s", got, out)
+	}
+}
+
+// --only scopes a refresh through the artifact's owning category: `aws`
+// reaches ~/.aws/config, `env` leaves every artifact alone.
+func TestMigrateOnlyScopesJitPathRefreshByCategory(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	stubDurableJitPath(t, "/opt/homebrew/bin/jit", nil)
+	writeArtifact(t, migrate.KubeconfigPath(home), staleKubeconfig)
+	writeArtifact(t, migrate.AWSConfigPath(home), "[profile work]\ncredential_process = /nowhere/jit aws-credential-process --profile aws-work\n")
+
+	out, err := execMigrate(t, migrate.KubeconfigPath(home), migrate.AWSConfigPath(home), "--only", "aws", "--dry-run")
+	if err != nil {
+		t.Fatalf("--only aws: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "~/.aws/config (was /nowhere/jit)") || strings.Contains(out, "~/.kube/config") {
+		t.Errorf("--only aws must plan the AWS config and nothing else:\n%s", out)
+	}
+
+	out, err = execMigrate(t, migrate.KubeconfigPath(home), "--only", "env", "--dry-run")
+	if err != nil {
+		t.Fatalf("--only env: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "Nothing to migrate in the selected --only") {
+		t.Errorf("--only env must leave the kubeconfig refresh out:\n%s", out)
+	}
+}
+
+// A jit with no durable path — the real answer inside `go test` — turns
+// the refresh into a note at plan time, never a failure after [y/N].
+func TestMigrateJitPathRefusalIsANoteNotAFailure(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	stubDurableJitPath(t, "", errors.New("this jit is running from a temporary or removable location (~/Downloads/jit)"))
+	kube := migrate.KubeconfigPath(home)
+	writeArtifact(t, kube, staleKubeconfig)
+
+	out, err := execMigrate(t, kube, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate ~/.kube/config --dry-run: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "can't refresh right now") || !strings.Contains(out, "~/Downloads/jit") {
+		t.Errorf("expected the refusal note with its reason:\n%s", out)
+	}
+	if strings.Contains(out, "[recorded jit path]") {
+		t.Errorf("a refused refresh must not be a plan row:\n%s", out)
+	}
+}
+
+// A durable path is not stale: the common healthy install plans nothing.
+func TestMigrateNamedArtifactWithDurablePathIsQuiet(t *testing.T) {
+	home := withFixtureHome(t)
+	withFixtureCwd(t)
+	stubDurableJitPath(t, "/opt/homebrew/bin/jit", nil)
+	prefix, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable := installFakeJit(t, filepath.Join(prefix, "bin", "jit"))
+	helper := migrate.GitHelperPath(home)
+	writeArtifact(t, helper, "#!/bin/sh\nexec '"+stable+"' git-credential \"$@\"\n")
+
+	out, err := execMigrate(t, helper, "--dry-run")
+	if err != nil {
+		t.Fatalf("jit migrate <helper> --dry-run: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "[recorded jit path]") {
+		t.Errorf("a durable path was planned for refresh:\n%s", out)
+	}
+}

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -126,7 +126,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 	}
 
 	hasScoped := len(d.envFiles) > 0 || len(d.tfvarsFiles) > 0 || len(d.k8sManifests) > 0 || len(mcpScoped) > 0 || len(npmrcScoped) > 0 || len(d.looseSecretFiles) > 0
-	hasFixed := len(d.shellConfigs) > 0 || len(d.historyFiles) > 0 || len(mcpFixed) > 0 || len(d.awsProfiles) > 0 || len(d.k8sUsers) > 0 || len(d.terraformHosts) > 0 || len(d.dockerRegistries) > 0 || len(d.gitHosts) > 0 || len(d.gcpADCFiles) > 0 || len(d.sopsAgeFiles) > 0 || len(npmrcFixed) > 0 || len(d.netrcFiles) > 0 || len(d.pypircFiles) > 0
+	hasFixed := len(d.shellConfigs) > 0 || len(d.historyFiles) > 0 || len(mcpFixed) > 0 || len(d.awsProfiles) > 0 || len(d.k8sUsers) > 0 || len(d.terraformHosts) > 0 || len(d.dockerRegistries) > 0 || len(d.gitHosts) > 0 || len(d.gcpADCFiles) > 0 || len(d.sopsAgeFiles) > 0 || len(npmrcFixed) > 0 || len(d.netrcFiles) > 0 || len(d.pypircFiles) > 0 || len(d.jitPaths) > 0
 
 	if hasScoped {
 		// The annotation callback below is handed the display-shortened path,
@@ -255,6 +255,24 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 				}
 				return "also rewrites " + strings.Join(short, ", ")
 			})
+		// A recorded jit path: the artifact stays what it is, only the
+		// binary it calls back into changes (design/jit-path-refresh.md D6).
+		if len(d.jitPaths) > 0 {
+			items := make([]string, 0, len(d.jitPaths))
+			was := make(map[string]string, len(d.jitPaths))
+			for _, r := range d.jitPaths {
+				item := displayPath(home, r.Path)
+				items = append(items, item)
+				note := "was " + displayPath(home, r.Recorded)
+				if r.Stale() == migrate.StaleVersioned {
+					note += ", still there until the next brew upgrade"
+				}
+				was[item] = note
+			}
+			printMigratePlanCategoryAnnotated(w,
+				"recorded jit path "+glyphAction+" the jit "+pluralWord(len(d.jitPaths), "this config runs", "these configs run")+" is gone or version-pinned; rewritten to "+d.jitPathTarget+" (backed up encrypted first)",
+				items, func(item string) string { return was[item] })
+		}
 		// AWS/kubeconfig/Terraform/Docker items are profile/user/host/
 		// registry NAMES, not paths — nothing to shorten.
 		printMigratePlanCategory(w,
@@ -322,6 +340,10 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 			categories++
 		}
 		total += len(items)
+	}
+	if len(d.jitPaths) > 0 {
+		categories++
+		total += len(d.jitPaths)
 	}
 	extraItems, extraCategories := extras.counts()
 	total += extraItems

--- a/internal/migrate/jitpath_test.go
+++ b/internal/migrate/jitpath_test.go
@@ -23,6 +23,7 @@ var jitPathRecorders = []string{
 	"dockercreds.go",
 	"gitcreds.go",
 	"terraform.go",
+	"jitpathrefresh.go",
 }
 
 // TestEveryRecorderGoesThroughResolveJitExecutable is a source-level guard, in

--- a/internal/migrate/jitpathrefresh.go
+++ b/internal/migrate/jitpathrefresh.go
@@ -1,0 +1,120 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/jitpass/jit/internal/selfpath"
+)
+
+// A RecordedJitPath is one artifact `jit migrate` rewrote to call back into
+// jit by absolute path — a kubeconfig exec, an AWS credential_process line,
+// the docker/git/terraform helper scripts — and the path it currently
+// carries (design/jit-path-refresh.md). The path was right when written;
+// nothing revalidates it afterwards, and on a Homebrew install a copy
+// written before internal/selfpath names the version-numbered Caskroom
+// file the next `brew upgrade` deletes. jit doctor reports these; jit
+// migrate refreshes them, because migrate wrote them and owns their backup
+// and undo. Both go through this one enumeration so they cannot disagree
+// about what an artifact is.
+type RecordedJitPath struct {
+	// Label names the artifact the way the user thinks of it — the helper
+	// scripts under ~/.jit/shims are an implementation detail nobody chose.
+	Label string
+	Path  string
+	// Category is the --only token whose migration wrote the artifact:
+	// `--only aws` refreshes ~/.aws/config the way it migrates
+	// ~/.aws/credentials. A refresh is maintenance of a category's
+	// artifact, not a category of its own.
+	Category string
+	// Key is the token whose line carries the recorded path. Anchoring to
+	// it is what keeps an unrelated /usr/bin/jit mentioned in a comment
+	// from being reported as a broken artifact.
+	Key string
+	// Recorded is the jit path the artifact carries.
+	Recorded string
+}
+
+// jitPathArtifacts is the table: every non-MCP artifact that records jit's
+// absolute path. MCP configs are deliberately absent — doctor's mcpFindings
+// checks theirs and can say which SERVER broke, the more useful sentence,
+// and each server's re-migration is its own path.
+func jitPathArtifacts(home string) []RecordedJitPath {
+	return []RecordedJitPath{
+		{Label: "~/.kube/config", Path: KubeconfigPath(home), Category: "kube", Key: "command:"},
+		{Label: "~/.aws/config", Path: AWSConfigPath(home), Category: "aws", Key: "credential_process"},
+		{Label: "the docker credential helper", Path: DockerHelperPath(home), Category: "docker", Key: "exec "},
+		{Label: "the git credential helper", Path: GitHelperPath(home), Category: "git", Key: "exec "},
+		{Label: "the terraform credentials helper", Path: TerraformHelperPath(home), Category: "terraform", Key: "exec "},
+	}
+}
+
+// recordedJitPath matches an absolute path ending in the jit binary, with
+// the surrounding quoting the writers apply (shell single quotes, YAML/JSON
+// double quotes) left outside the capture.
+var recordedJitPath = regexp.MustCompile(`(/[^\s"']*/jit)\b`)
+
+// DiscoverRecordedJitPaths reads every artifact and returns one entry per
+// distinct jit path each records. Best-effort and read-only: an absent or
+// unreadable artifact yields nothing, and a file jit never wrote has no
+// matching line and is silently uninteresting — which is what makes it
+// safe to probe all five unconditionally.
+func DiscoverRecordedJitPaths(home string) []RecordedJitPath {
+	var out []RecordedJitPath
+	for _, a := range jitPathArtifacts(home) {
+		data, err := os.ReadFile(a.Path) // #nosec G304 -- fixed, jit-owned artifact locations
+		if err != nil {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, line := range strings.Split(string(data), "\n") {
+			if !strings.Contains(line, a.Key) {
+				continue
+			}
+			m := recordedJitPath.FindStringSubmatch(line)
+			if m == nil || seen[m[1]] {
+				continue
+			}
+			seen[m[1]] = true
+			r := a
+			r.Recorded = m[1]
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// The two ways a recorded path is stale, in the order they are tested: a
+// path that is gone is broken now; a version-numbered Homebrew path works
+// today and stops existing at the next upgrade.
+const (
+	StaleMissing   = "isn't there"
+	StaleVersioned = "version-pinned"
+)
+
+// Stale reports why the recorded path needs refreshing, "" when it does
+// not. Every durable path — the common healthy install — answers "".
+func (r RecordedJitPath) Stale() string {
+	switch {
+	case !executableFile(r.Recorded):
+		return StaleMissing
+	case selfpath.VersionedBrew(r.Recorded):
+		return StaleVersioned
+	}
+	return ""
+}
+
+// executableFile reports whether path is a regular file with an execute
+// bit. Both halves matter: a directory at the path and a non-executable
+// file both fail exec with errors the host renders as one opaque failure.
+func executableFile(path string) bool {
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path) // #nosec G703 -- stat-only probe; no content is read
+	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}

--- a/internal/migrate/jitpathrefresh.go
+++ b/internal/migrate/jitpathrefresh.go
@@ -4,11 +4,13 @@
 package migrate
 
 import (
+	"fmt"
 	"os"
 	"regexp"
 	"strings"
 
 	"github.com/jitpass/jit/internal/selfpath"
+	"github.com/jitpass/jit/internal/vault"
 )
 
 // A RecordedJitPath is one artifact `jit migrate` rewrote to call back into
@@ -117,4 +119,87 @@ func executableFile(path string) bool {
 	}
 	info, err := os.Stat(path) // #nosec G703 -- stat-only probe; no content is read
 	return err == nil && info.Mode().IsRegular() && info.Mode().Perm()&0o111 != 0
+}
+
+// ResolveDurableJitPath is the path a refresh records — resolveJitExecutable
+// (selfpath.Durable) for callers outside the package — or the refusal
+// naming why this jit has none (a build directory, ~/Downloads, an
+// unmatched Caskroom copy). Prompt-free and cheap, so a plan can ask
+// before anything is confirmed and turn a refusal into a note rather than
+// a failure after [y/N] (design/jit-path-refresh.md D4).
+func ResolveDurableJitPath() (string, error) {
+	return resolveJitExecutable()
+}
+
+// JitPathRefresh is one refreshed artifact, for the mutation log.
+type JitPathRefresh struct {
+	Path   string
+	From   string
+	To     string
+	Backup string // the vault path holding the pristine bytes; `jit migrate undo` restores it
+}
+
+// RefreshRecordedJitPath rewrites the jit path r records to `to`, the
+// durable path the plan resolved and showed the user — passed in rather
+// than re-resolved here so the line the user confirmed is the line that
+// gets written. Line-anchored: only lines carrying r.Key, only the regex
+// match equal to r.Recorded; every other byte, quoting included, is
+// preserved, and the file keeps its own mode (the helpers are 0755
+// scripts). Backed up first through the run's tracker, so undo restores
+// the pristine artifact even when a category migration rewrites the same
+// file later in the run.
+func RefreshRecordedJitPath(v *vault.Vault, r RecordedJitPath, to string, tracker *BackupTracker) (JitPathRefresh, error) {
+	// The writers quote per artifact (single quotes in a shell helper,
+	// nothing in INI/YAML); a substitution inside their quoting is right
+	// only for a path that needs none. Homebrew and /usr/local never do.
+	if strings.ContainsAny(to, " \t'\"") {
+		return JitPathRefresh{}, fmt.Errorf("refusing to record %q: a jit path with whitespace or quotes cannot be substituted into every artifact's own quoting", to)
+	}
+	data, err := os.ReadFile(r.Path) // #nosec G304 -- fixed, jit-owned artifact location
+	if err != nil {
+		return JitPathRefresh{}, fmt.Errorf("reading %s: %w", r.Path, err)
+	}
+	info, err := os.Stat(r.Path)
+	if err != nil {
+		return JitPathRefresh{}, err
+	}
+	rewritten, changed := refreshRecordedLines(string(data), r.Key, r.Recorded, to)
+	if !changed {
+		return JitPathRefresh{}, fmt.Errorf("%s no longer carries %s; nothing to refresh", r.Path, r.Recorded)
+	}
+	backup, err := tracker.backupOnce(v, r.Path)
+	if err != nil {
+		return JitPathRefresh{}, fmt.Errorf("backing up %s: %w", r.Path, err)
+	}
+	if err := vault.AtomicWriteFile(r.Path, []byte(rewritten)); err != nil {
+		return JitPathRefresh{}, fmt.Errorf("writing %s: %w", r.Path, err)
+	}
+	// AtomicWriteFile lands at the vault's own 0600; a helper script has
+	// to stay executable or the tool it serves fails on its next call.
+	if err := os.Chmod(r.Path, info.Mode().Perm()); err != nil {
+		return JitPathRefresh{}, fmt.Errorf("restoring mode of %s: %w", r.Path, err)
+	}
+	return JitPathRefresh{Path: r.Path, From: r.Recorded, To: to, Backup: backup}, nil
+}
+
+// refreshRecordedLines is the pure substitution: on every line containing
+// key, each recorded-path match equal to from becomes to. Splitting and
+// joining on "\n" keeps a trailing newline (or its absence) exactly as
+// the file had it.
+func refreshRecordedLines(content, key, from, to string) (string, bool) {
+	lines := strings.Split(content, "\n")
+	changed := false
+	for i, line := range lines {
+		if !strings.Contains(line, key) {
+			continue
+		}
+		lines[i] = recordedJitPath.ReplaceAllStringFunc(line, func(m string) string {
+			if m != from {
+				return m
+			}
+			changed = true
+			return to
+		})
+	}
+	return strings.Join(lines, "\n"), changed
 }

--- a/internal/migrate/jitpathrefresh_test.go
+++ b/internal/migrate/jitpathrefresh_test.go
@@ -72,3 +72,121 @@ func TestDiscoverRecordedJitPathsIsQuietOnAnEmptyHome(t *testing.T) {
 		t.Errorf("an empty home produced %d entries, want none: %+v", len(got), got)
 	}
 }
+
+func TestRefreshRecordedLinesIsLineAnchoredAndByteExact(t *testing.T) {
+	const from, to = "/opt/homebrew/Caskroom/jitpass/0.84.0/jit", "/opt/homebrew/bin/jit"
+	for _, tc := range []struct {
+		name, key, in, want string
+	}{
+		{"yaml exec command", "command:",
+			"users:\n- name: u\n  user:\n    exec:\n      command: " + from + "\n      args: [\"k8s-exec-credential\"]\n",
+			"users:\n- name: u\n  user:\n    exec:\n      command: " + to + "\n      args: [\"k8s-exec-credential\"]\n"},
+		{"ini credential_process", "credential_process",
+			"[profile work]\nregion = us-east-1\ncredential_process = " + from + " aws-credential-process --profile aws-work\n",
+			"[profile work]\nregion = us-east-1\ncredential_process = " + to + " aws-credential-process --profile aws-work\n"},
+		{"single-quoted shell exec, comment untouched", "exec ",
+			"#!/bin/sh\n# was " + from + " once\nexec '" + from + "' git-credential \"$@\"\n",
+			"#!/bin/sh\n# was " + from + " once\nexec '" + to + "' git-credential \"$@\"\n"},
+		{"no trailing newline stays that way", "exec ",
+			"exec '" + from + "' docker-credential \"$@\"",
+			"exec '" + to + "' docker-credential \"$@\""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, changed := refreshRecordedLines(tc.in, tc.key, from, to)
+			if !changed || got != tc.want {
+				t.Errorf("changed=%v\n got: %q\nwant: %q", changed, got, tc.want)
+			}
+			// A second pass finds nothing to change: idempotent.
+			if _, again := refreshRecordedLines(got, tc.key, from, to); again {
+				t.Error("a refreshed file was changed again")
+			}
+		})
+	}
+	// A different recorded path on the anchored line is not touched: the
+	// substitution is for the exact path the plan showed.
+	if got, changed := refreshRecordedLines("exec '/usr/local/bin/jit' x\n", "exec ", from, to); changed || got != "exec '/usr/local/bin/jit' x\n" {
+		t.Errorf("a non-matching path was rewritten: %q", got)
+	}
+}
+
+func TestRefreshRecordedJitPathBacksUpAndKeepsMode(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	v := newTestVault(t)
+	helper := GitHelperPath(home)
+	stale := "/nowhere/at/all/jit"
+	writeArtifactFile(t, helper, "#!/bin/sh\nexec '"+stale+"' git-credential \"$@\"\n", 0o755)
+
+	var r RecordedJitPath
+	for _, c := range DiscoverRecordedJitPaths(home) {
+		if c.Path == helper {
+			r = c
+		}
+	}
+	if r.Recorded != stale || r.Stale() != StaleMissing {
+		t.Fatalf("discovery = %+v, want the stale helper", r)
+	}
+	tracker := NewBackupTracker()
+	res, err := RefreshRecordedJitPath(v, r, "/usr/local/bin/jit", tracker)
+	if err != nil {
+		t.Fatalf("RefreshRecordedJitPath: %v", err)
+	}
+	got, err := os.ReadFile(helper) // #nosec G304 -- test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "#!/bin/sh\nexec '/usr/local/bin/jit' git-credential \"$@\"\n" {
+		t.Errorf("helper after refresh:\n%s", got)
+	}
+	info, err := os.Stat(helper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("mode after refresh = %o, want 0755 — a helper that lost its execute bit fails the tool it serves", info.Mode().Perm())
+	}
+	if res.From != stale || res.To != "/usr/local/bin/jit" || res.Backup == "" {
+		t.Errorf("result = %+v", res)
+	}
+	// The pristine bytes are in the vault, indexed for undo.
+	backup, err := v.Get(res.Backup)
+	if err != nil || string(backup) != "#!/bin/sh\nexec '"+stale+"' git-credential \"$@\"\n" {
+		t.Errorf("backup = %q, %v; want the pre-refresh bytes", backup, err)
+	}
+	records, err := LoadBackupRecords(v.Root)
+	if err != nil {
+		t.Fatalf("LoadBackupRecords: %v", err)
+	}
+	var rec *BackupRecord
+	for i := range records {
+		if records[i].OriginalPath == helper {
+			rec = &records[i]
+		}
+	}
+	if rec == nil || rec.VaultPath != res.Backup || rec.Mode != "755" {
+		t.Errorf("undo record for %s = %+v, want vault path %s with mode 755", helper, rec, res.Backup)
+	}
+	// And undo puts the stale line back, mode included.
+	if err := RestoreFromBackup(v, *rec); err != nil {
+		t.Fatalf("RestoreFromBackup: %v", err)
+	}
+	restored, err := os.ReadFile(helper) // #nosec G304 -- test fixture
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(restored) != "#!/bin/sh\nexec '"+stale+"' git-credential \"$@\"\n" {
+		t.Errorf("undo did not restore the pristine helper:\n%s", restored)
+	}
+	// A second refresh in the same run (a category migration rewriting the
+	// same file) must not re-back-up the already-modified file.
+	if again, err := tracker.backupOnce(v, helper); err != nil || again != res.Backup {
+		t.Errorf("second backupOnce = %q, %v; want the first backup reused", again, err)
+	}
+}
+
+func TestRefreshRecordedJitPathRefusesAQuotedTarget(t *testing.T) {
+	v := newTestVault(t)
+	if _, err := RefreshRecordedJitPath(v, RecordedJitPath{Path: "/x", Key: "exec ", Recorded: "/a/jit"}, "/Applications/My Tools/jit", nil); err == nil {
+		t.Error("a target with whitespace must be refused, not substituted into a helper's quoting")
+	}
+}

--- a/internal/migrate/jitpathrefresh_test.go
+++ b/internal/migrate/jitpathrefresh_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeArtifactFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil { // #nosec G306 -- test fixture
+		t.Fatalf("WriteFile %s: %v", path, err)
+	}
+}
+
+// installFakeJit lays out a runnable binary at path and returns it.
+func installFakeJit(t *testing.T, path string) string {
+	t.Helper()
+	writeArtifactFile(t, path, "#!/bin/sh\n", 0o755)
+	return path
+}
+
+func TestDiscoverRecordedJitPathsEveryArtifact(t *testing.T) {
+	home := t.TempDir()
+	prefix, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stable := installFakeJit(t, filepath.Join(prefix, "bin", "jit"))
+	versioned := installFakeJit(t, filepath.Join(prefix, "brew", "Caskroom", "jitpass", "0.84.0", "jit"))
+	gone := "/nowhere/at/all/jit"
+
+	writeArtifactFile(t, KubeconfigPath(home), "users:\n- name: u\n  user:\n    exec:\n      command: "+gone+"\n      args: [k8s-exec-credential]\n", 0o600)
+	writeArtifactFile(t, AWSConfigPath(home), "[profile work]\ncredential_process = "+versioned+" aws-credential-process --profile aws-work\n", 0o600)
+	writeArtifactFile(t, DockerHelperPath(home), "#!/bin/sh\n# this used to be /old/place/jit before the rewrite\nexec '"+stable+"' docker-credential \"$@\"\n", 0o755)
+	writeArtifactFile(t, GitHelperPath(home), "#!/bin/sh\nexec '"+stable+"' git-credential \"$@\"\n", 0o755)
+	// terraform helper absent on purpose: an artifact the user never
+	// migrated must stay quiet.
+
+	got := DiscoverRecordedJitPaths(home)
+	want := map[string]struct {
+		category, recorded, stale string
+	}{
+		KubeconfigPath(home):   {"kube", gone, StaleMissing},
+		AWSConfigPath(home):    {"aws", versioned, StaleVersioned},
+		DockerHelperPath(home): {"docker", stable, ""}, // the comment's /old/place/jit is not on the exec line
+		GitHelperPath(home):    {"git", stable, ""},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d recorded paths, want %d:\n%+v", len(got), len(want), got)
+	}
+	for _, r := range got {
+		w, ok := want[r.Path]
+		if !ok {
+			t.Errorf("unexpected artifact %s", r.Path)
+			continue
+		}
+		if r.Category != w.category || r.Recorded != w.recorded || r.Stale() != w.stale {
+			t.Errorf("%s = category %q recorded %q stale %q; want %q %q %q", r.Label, r.Category, r.Recorded, r.Stale(), w.category, w.recorded, w.stale)
+		}
+	}
+}
+
+func TestDiscoverRecordedJitPathsIsQuietOnAnEmptyHome(t *testing.T) {
+	if got := DiscoverRecordedJitPaths(t.TempDir()); len(got) != 0 {
+		t.Errorf("an empty home produced %d entries, want none: %+v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Summary

`jit doctor` reports a `~/.kube/config` whose exec line names `/opt/homebrew/Caskroom/jitpass/0.84.0/jit` — written before `internal/selfpath`, deleted by the `brew upgrade` that followed — and prescribes `jit migrate ~/.kube/config`. On an already-migrated file, migrate printed "Nothing to migrate" and changed nothing. There was no repair path for a recorded jit path anywhere in jit.

Doctor's prescription was right; migrate was wrong, because it looked for plaintext secrets and nothing else. This teaches migrate that **a stale jit path it recorded is its own finding** — it wrote the line, backs the file up, and undoes it.

- **Detector moves to `internal/migrate`** (`DiscoverRecordedJitPaths`, `Stale()`); doctor consumes it. Doctor's kinds, details and action strings are unchanged.
- **A refresh is a counted plan row**, in the machine-wide group, scoped by the artifact's owning `--only` category — `--only aws` refreshes `~/.aws/config`, `--only kube` `~/.kube/config` — so every action doctor already prints becomes true. No new `--only` token.
- **Naming an artifact** (`~/.kube/config`, `~/.aws/config`, a helper under `~/.jit/shims`) checks its recorded path in addition to its category discovery. **Bare `jit migrate`** checks all five, independent of the scan, so the not-yet-broken version-pinned case heals before the upgrade breaks it — under a plan the user previews.
- **Refusal is decided at plan time**: a jit with no durable path (`/tmp`, `~/Downloads`, an unmatched Caskroom copy) becomes a skip note, never a failure after `[y/N]`.
- **Apply**: the durable path is resolved once at plan time and passed into the write, so the plan row and the rewritten line agree by construction; line-anchored substitution on the artifact's anchor key only, every other byte and the file's quoting preserved; backed up through the run's `BackupTracker` (pristine bytes, mode, undo record); mode restored after the atomic write so a 0755 helper stays executable.
- `design/jit-path-refresh.md` records the plan, what the code read established, and why `jit doctor --fix` lost.

## Test plan

- [x] `go test -race ./...` green
- [x] gofmt, vet, `go mod verify`/`tidy -diff`, `docs-gen` drift, staticcheck and govulncheck under the pinned toolchain, gosec
- [x] migrate: discovery over each artifact (missing / version-pinned / durable / comment-only path / absent file); the substitution as a pure function on YAML, INI and single-quoted shell lines, byte-exact and idempotent; backup + undo record + mode; undo restores the pristine helper; a target with whitespace is refused
- [x] cli: a named stale kubeconfig plans one row (two `[DRY RUN]` markers); `--only aws` scopes to `~/.aws/config`, `--only env` leaves refreshes out; the refusal is a note, not a row; a durable path plans nothing; doctor's tests pass unchanged against the shared detector
- [x] On the real machine: `jit migrate ~/.kube/config --dry-run` plans the refresh of the actual stale exec line from a durable location, and renders the refusal note from a volatile one; file untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMdQMk6nLGzuZFrvFsSbxd
