### PR TITLE
design: mark the sessions note shipped and point PR 2 at its successor

### DIFF
--- a/design/sessions-and-path-repair.md
+++ b/design/sessions-and-path-repair.md
@@ -1,6 +1,8 @@
 # Sessions, and repairing a recorded jit path
 
-**Status: PR 1 in progress (2026-09-05); PR 2 and the runbook edit proposed.**
+**Status: PR 1 shipped as #87 (2026-09-05). The "PR 2 — `jit doctor --fix`"
+section below was superseded before it was built — `design/jit-path-refresh.md`
+says why, and shipped as #88. The runbook edit is pending.**
 
 ## What prompted this
 


### PR DESCRIPTION
Doc only. The sessions design note still said "PR 1 in progress; PR 2 proposed" after both #87 and #88 merged; its PR 2 section was superseded by `design/jit-path-refresh.md` before it was built, and the status line now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMdQMk6nLGzuZFrvFsSbxd