### PR TITLE
migrate: make the 1Password enumeration lazy, scoped, streamed and visible

### DIFF
--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -178,10 +178,25 @@ type RefResolver interface {
   in a fresh session can cost two prompts back to back (jit's Touch
   ID, then 1Password's); both sides session-cache, so steady state is
   zero or one. Dogfood this before shipping — it is the UX risk.
-- **Multi-account**: the URI does not name an account. v1 defers to
-  op's own selection (`OP_ACCOUNT`, app-integration chooser) and
-  records this as an open question rather than inventing per-link
-  account storage speculatively.
+- **Multi-account**: the URI does not name an account, and op resolves
+  every reference against ONE — `--account`, else `OP_ACCOUNT`, else
+  its most recent sign-in. v1 deferred this as speculative; a Mac with
+  a personal and an employer account then showed the failure live
+  (2026-09-05): a link made under one account fails with "isn't a
+  vault in this account" once op's default flips to the other. So a
+  link jit creates is **pinned**: the stored reference carries
+  `?account=<account uuid>` (the query slot op itself uses for
+  `?attribute=otp`; op ignores the parameter, verified), the resolver
+  strips it and passes `--account`, and every other consumer of the
+  stored string — export, doctor's sweep, `vault get`'s JSON — carries
+  it along. Migrate's enumeration covers every signed-in account
+  unless `OP_ACCOUNT` names one, pinning each match to its account;
+  `jit vault link` tries each account until the reference resolves and
+  pins that one (`--no-verify` stores it unpinned, following op's
+  default as before). An unpinned link that fails to resolve on a
+  multi-account machine says so in its error. The pin is the ACCOUNT
+  uuid, not the user's: it names what the vault ids inside the
+  reference belong to.
 
 ## Command surface
 
@@ -439,7 +454,8 @@ Each gets a one-clause error plus the one command to type:
 - Batch resolution (one `op inject` exec for a whole profile) — only
   if per-reference exec latency proves annoying in practice.
 - Secure Note linking (PEM keys stored in note bodies).
-- Per-link account pinning for multi-account users.
+- ~~Per-link account pinning for multi-account users.~~ Shipped
+  2026-09-05, see Multi-account above.
 - Other backends (the scheme-dispatched resolver leaves the door
   open; nothing else is built).
 - `jit scan` awareness of `op://` references already sitting in

--- a/design/1password-adapter.md
+++ b/design/1password-adapter.md
@@ -323,10 +323,37 @@ resolving. `jit scan` already treats `op://` values as non-secrets
 - **The index holds hashes, not values**: SHA-256 of each concealed
   field → its reference, built from one
   `op item list --format json | op item get - --format json`
-  enumeration (one authorization, values in memory only, raw JSON
-  wiped after parsing). Stored references are built in ID form from
-  the item JSON's own vault/item/field ids; the mutation log
-  displays the name form, which is what the user recognizes.
+  enumeration (one authorization; the item stream is decoded one
+  object at a time, so at most one item's plaintext is resident).
+  Stored references are built in ID form from the item JSON's own
+  vault/item/field ids; the mutation log displays the name form,
+  which is what the user recognizes.
+- **The enumeration is lazy and scoped** (2026-09-05, after the first
+  real post-1.0 migrate spent minutes in it for one kubeconfig line).
+  It runs on the FIRST value that could link — 8 bytes or more, not
+  already an `op://` string — so a run with no such value never
+  contacts op; `item list` is filtered client-side on `category`
+  before piping, dropping Credit Card, Bank Account, Identity and the
+  other document/finance categories (their CONCEALED fields are CVVs
+  and PINs, which must not pass through jit to be hashed, and each
+  fetch is an activity-log event in a Business account) — a
+  deny-list, so a category 1Password adds is enumerated by default;
+  and the two op calls carry different bounds: the list waits on the
+  unlock dialog under the resolve timeout, the get is bounded by an
+  idle watchdog per item, so a large account is never cut off for
+  being large while a hung op is still killed. Items that arrived
+  before op stopped early stay indexed; the shortfall is stated.
+- **The user sees it run.** A stderr spinner counts items as they
+  stream ("37/174 items"); the `[1Password]` block in the mutation
+  log prints whenever the check ran — including "0 of 12 linked" with
+  the item count — so a user who waited through the enumeration and
+  answered its prompt is never left guessing whether it happened.
+  Silence is reserved for a run that never consulted op.
+- **Nothing else in migrate resolves through op.** The duplicate
+  disclosure index keys a linked entry by its stored reference
+  (`GetStored`), never by resolving it: before this, every linked
+  secret in the vault cost one `op read` exec per env/MCP migration,
+  each able to block on the unlock dialog, for a note.
 
 This closes the loop the issue is really about: a 1Password user's
 `.env` is usually a hand-made plaintext cache of things 1Password

--- a/docs/reference/commands/jit_vault_link.md
+++ b/docs/reference/commands/jit_vault_link.md
@@ -15,7 +15,10 @@ Reference). Item and vault IDs also work in place of names and survive
 renames.
 
 The link is test-resolved through `op` first, so a typo or a signed-out
-CLI fails here, not at first use; --no-verify skips that (offline setup).
+CLI fails here, not at first use, and the reference is pinned to the
+1Password account it resolved in, so a Mac signed in to several keeps
+resolving it there whichever account op last used. --no-verify skips
+both (offline setup): the link then follows op's default account.
 Requires the 1Password CLI (`brew install 1password-cli`) with the
 desktop app integration on.
 

--- a/internal/cli/agentclient.go
+++ b/internal/cli/agentclient.go
@@ -8,6 +8,7 @@ package cli
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"sync"
 	"time"
@@ -191,9 +192,32 @@ var agentHealOnce sync.Once
 // their Mac — the same silent-prompt confusion internal/keychainwrap already
 // documents. stderr, so it never corrupts a --format json payload on stdout;
 // json/status commands don't challenge, so it won't fire for them anyway.
+//
+// Once per process. The client's timer is per RPC, and a command like
+// migrate issues several slow RPCs after its one real unlock (a mount
+// refresh that re-serves every registered mount, a store behind the
+// service's own housekeeping), each of which crossed the 400ms line and
+// printed the notice again — three or four "Touch ID required" lines for
+// one prompt (seen live 2026-09-05, the audit log showing a single
+// unlock). The line's job is to explain the first hang; the audit log,
+// not this notice, is the record of prompts.
 func announceTouchIDWait() {
-	fmt.Fprintln(os.Stderr, glyphLock+" Touch ID required: approve the prompt on your Mac to continue...")
+	touchIDNotice.mu.Lock()
+	defer touchIDNotice.mu.Unlock()
+	if touchIDNotice.shown {
+		return
+	}
+	touchIDNotice.shown = true
+	fmt.Fprintln(touchIDNotice.out, glyphLock+" Touch ID required: approve the prompt on your Mac to continue...")
 }
+
+// touchIDNotice is announceTouchIDWait's once-per-process state; the
+// writer is a field so tests can capture the line and reset the guard.
+var touchIDNotice = struct {
+	mu    sync.Mutex
+	shown bool
+	out   io.Writer
+}{out: os.Stderr}
 
 // installedNotRunningParts is the SINGLE source of the "installed but not
 // running" guidance, shared by `jit status`, `jit service status`, doctor,

--- a/internal/cli/agentclient_test.go
+++ b/internal/cli/agentclient_test.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// The wait notice explains ONE hang per process: a migrate's several slow
+// RPCs after its single unlock must not print it three or four times.
+func TestTouchIDNoticePrintsOncePerProcess(t *testing.T) {
+	touchIDNotice.mu.Lock()
+	prevOut, prevShown := touchIDNotice.out, touchIDNotice.shown
+	var buf bytes.Buffer
+	touchIDNotice.out, touchIDNotice.shown = &buf, false
+	touchIDNotice.mu.Unlock()
+	t.Cleanup(func() {
+		touchIDNotice.mu.Lock()
+		touchIDNotice.out, touchIDNotice.shown = prevOut, prevShown
+		touchIDNotice.mu.Unlock()
+	})
+	for i := 0; i < 4; i++ {
+		announceTouchIDWait()
+	}
+	if n := strings.Count(buf.String(), "Touch ID required"); n != 1 {
+		t.Errorf("notice printed %d times across 4 slow RPCs, want 1:\n%s", n, buf.String())
+	}
+}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -22,8 +22,8 @@ import (
 	"github.com/jitpass/jit/internal/guard"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/mount"
-	"github.com/jitpass/jit/internal/onepassword"
 	"github.com/jitpass/jit/internal/termtext"
+	"github.com/jitpass/jit/internal/ui"
 	"github.com/jitpass/jit/internal/vault"
 	"github.com/jitpass/jit/internal/wrap"
 )
@@ -39,55 +39,6 @@ var (
 	// this flag restores plain copies. Opt-out, not opt-in — installing
 	// and signing in to `op` was the opt-in.
 	migrateNo1Password bool
-)
-
-// opInventory is what the dedupe needs from onepassword.Index, as an
-// interface so tests can pin a fake index without a real `op`.
-type opInventory interface {
-	RefFor(value []byte) (onepassword.IndexEntry, bool)
-	Items() int
-}
-
-// newOpLinkHook builds the vault.LinkOnSet migrate installs for the
-// 1Password dedupe: a value that already IS an op:// reference links as
-// itself (a .env kept for `op run` needs no index, and vaulting the
-// literal would hand `jit run` an unresolvable string); anything else
-// links iff its bytes match a concealed 1Password field. ix may be nil —
-// the enumeration failed — and verbatim links still work. The stored
-// reference is the rename-proof ID form; the recorded row carries the
-// name form for the mutation log.
-func newOpLinkHook(ix opInventory, linked *[]opLinkedRow, offered *int) func(path string, value []byte, meta vault.Meta) (string, bool) {
-	return func(path string, value []byte, _ vault.Meta) (string, bool) {
-		*offered++
-		if s := string(value); onepassword.ValidateRef(s) == nil {
-			*linked = append(*linked, opLinkedRow{path: path, ref: s})
-			return s, true
-		}
-		if ix == nil {
-			return "", false
-		}
-		e, ok := ix.RefFor(value)
-		if !ok {
-			return "", false
-		}
-		*linked = append(*linked, opLinkedRow{path: path, ref: e.NameRef})
-		return e.IDRef, true
-	}
-}
-
-// migrateOpInstalled/migrateOpInventory are the 1Password seams: the
-// plan's announcement line keys off the cheap PATH probe, the post-confirm
-// dedupe off the real enumeration. Vars so tests pin both — the plan must
-// render identically on machines with and without op installed.
-var (
-	migrateOpInstalled = onepassword.Installed
-	migrateOpInventory = func() (opInventory, error) {
-		ix, err := onepassword.New().Inventory()
-		if err != nil {
-			return nil, err
-		}
-		return ix, nil
-	}
 )
 
 // migrateCategories are the --only tokens real (non---dry-run) migrate
@@ -849,29 +800,20 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	}
 	registryPath := mount.RegistryPath(root)
 
-	// 1Password dedupe (design/1password-adapter.md): one authenticated
-	// enumeration up front, then every value about to be vaulted is offered
-	// to the vault's LinkOnSet hook — a byte-exact match, or a value that
-	// already IS an op:// reference (a .env kept for `op run`), stores the
-	// reference instead of a copy. Fails open on purpose: a signed-out CLI
+	// 1Password dedupe (design/1password-adapter.md, migrate1password.go):
+	// every value about to be vaulted is offered to the vault's LinkOnSet
+	// hook — a byte-exact match against 1Password's concealed fields, or a
+	// value that already IS an op:// reference (a .env kept for `op run`),
+	// stores the reference instead of a copy. The enumeration behind the
+	// match runs lazily on the first value that could link, after [y/N]
+	// and Touch ID, never at plan time — the plan's announcement line
+	// above is a PATH probe only. Fails open on purpose: a signed-out CLI
 	// or a locked app degrades to today's literal copies, reported once in
-	// the mutation log. Runs after [y/N] and Touch ID, never at plan time —
-	// the plan's announcement line above is a PATH probe only.
-	var opLinked []opLinkedRow
-	var opOffered, opItemsChecked int
-	var opSkipNote string
+	// the mutation log.
+	var opLinks *opDedupe
 	if vaultsValues && migrateOpInstalled() && !migrateNo1Password {
-		fmt.Fprintln(cmd.ErrOrStderr(), "checking 1Password for already-stored values (its prompt may appear)...")
-		ix, invErr := migrateOpInventory()
-		if invErr != nil {
-			opSkipNote = invErr.Error()
-		} else {
-			opItemsChecked = ix.Items()
-		}
-		// The hook stays installed even when the enumeration failed:
-		// verbatim op:// values need no index, and vaulting one as a
-		// literal would hand `jit run` an unresolvable string.
-		v.LinkOnSet = newOpLinkHook(ix, &opLinked, &opOffered)
+		opLinks = newOpDedupe(func() *ui.Tracker { return newProgress(cmd, false) })
+		v.LinkOnSet = opLinks.hook
 	}
 
 	// producedMount records whether this run registered ANY live mount, so the
@@ -1438,7 +1380,7 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		fmt.Fprintln(out)
 	}
 
-	printOpLinkResult(out, opLinked, opOffered, opItemsChecked, opSkipNote)
+	opLinks.print(out)
 
 	// Best-effort: an unreadable marker means no nudge, never a failed
 	// migrate — everything above already succeeded. Only when this run

--- a/internal/cli/migrate1password.go
+++ b/internal/cli/migrate1password.go
@@ -153,9 +153,9 @@ func (d *opDedupe) print(w io.Writer) {
 
 // printOpLinkResult renders the 1Password dedupe outcome. Four cases: the
 // check failed (one amber note — the run continued with copies, fail
-// open); op was never consulted (silence: every value was under the
-// floor or a verbatim reference, and there is no 1Password outcome to
-// report); the check ran and nothing matched (the header with its
+// open); op was never consulted and nothing linked (silence: every value
+// was under the floor, and there is no 1Password outcome to report); the
+// check ran and nothing matched (the header with its
 // counts, so a user who just waited through the enumeration — and
 // possibly answered 1Password's prompt — sees that it ran, what it
 // covered, and that copies were the honest result); or N linked (the
@@ -170,12 +170,17 @@ func printOpLinkResult(w io.Writer, linked []opLinkedRow, offered int, stats opC
 		fmt.Fprintln(w)
 		return
 	}
-	if !stats.ran {
+	if !stats.ran && len(linked) == 0 {
 		return
 	}
-	items := countWord(stats.read, "item", "items") + " checked"
-	if stats.read < stats.listed {
+	// Verbatim op:// values link without an enumeration; the header must
+	// not claim items were checked when none were.
+	items := "1Password not consulted"
+	switch {
+	case stats.ran && stats.read < stats.listed:
 		items = fmt.Sprintf("%d of %d items read", stats.read, stats.listed)
+	case stats.ran:
+		items = countWord(stats.read, "item", "items") + " checked"
 	}
 	printMigrateResultCategoryLabel(w, fmt.Sprintf("%d of %d linked, not copied · %s", len(linked), offered, items))
 	if stats.incomplete != "" {

--- a/internal/cli/migrate1password.go
+++ b/internal/cli/migrate1password.go
@@ -1,0 +1,209 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/termtext"
+	"github.com/jitpass/jit/internal/ui"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// This file is migrate's 1Password dedupe (design/1password-adapter.md):
+// a value about to be vaulted that already lives in 1Password is stored
+// as a reference to it, not a copy. The enumeration behind it is the
+// expensive part — one authorization prompt and one `op item get` per
+// credential item in the account — so it runs LAZILY, on the first value
+// that could possibly link: a run whose every value is under the match
+// floor, or already an op:// reference, never contacts op at all. The
+// plan's announcement line stays a PATH probe (a plan must never prompt),
+// and the result prints as a `[1Password]` block in the mutation log.
+
+// opInventory is what the dedupe needs from onepassword.Index, as an
+// interface so tests can pin a fake index without a real `op`.
+type opInventory interface {
+	RefFor(value []byte) (onepassword.IndexEntry, bool)
+	Items() int
+	Listed() int
+	Incomplete() string
+}
+
+// migrateOpInstalled/migrateOpInventory are the 1Password seams: the
+// plan's announcement line keys off the cheap PATH probe, the post-confirm
+// dedupe off the real enumeration. Vars so tests pin both — the plan must
+// render identically on machines with and without op installed.
+var (
+	migrateOpInstalled = onepassword.Installed
+	migrateOpInventory = func(progress func(read, listed int)) (opInventory, error) {
+		ix, err := onepassword.New().Inventory(progress)
+		if err != nil {
+			return nil, err
+		}
+		return ix, nil
+	}
+)
+
+type opLinkedRow struct{ path, ref string }
+
+// opCheckStats is what the mutation log says about the enumeration once
+// it has run: how many items op was asked for, how many it answered, and
+// its own error line if it stopped early.
+type opCheckStats struct {
+	ran          bool
+	read, listed int
+	incomplete   string
+}
+
+// opDedupe owns one migrate run's 1Password state: the lazily built
+// index, the rows it linked, and the tally the mutation log reports. Its
+// hook is the vault.LinkOnSet migrate installs.
+type opDedupe struct {
+	newTracker func() *ui.Tracker
+
+	once     bool
+	ix       opInventory
+	skipNote string
+	stats    opCheckStats
+	linked   []opLinkedRow
+	offered  int
+}
+
+// newOpDedupe builds the dedupe for a run that vaults values with op on
+// PATH and --no-1password unset. newTracker supplies the stderr progress
+// line the enumeration animates while it waits (nil for none).
+func newOpDedupe(newTracker func() *ui.Tracker) *opDedupe {
+	if newTracker == nil {
+		newTracker = func() *ui.Tracker { return ui.New(io.Discard, false, false) }
+	}
+	return &opDedupe{newTracker: newTracker}
+}
+
+// hook is the vault.LinkOnSet: a value that already IS an op:// reference
+// links as itself (a .env kept for `op run` needs no index, and vaulting
+// the literal would hand `jit run` an unresolvable string); a value under
+// the match floor can never link and costs nothing; anything else builds
+// the index on first use and links iff its bytes match a concealed
+// 1Password field. The stored reference is the rename-proof ID form; the
+// recorded row carries the name form for the mutation log.
+func (d *opDedupe) hook(path string, value []byte, _ vault.Meta) (string, bool) {
+	d.offered++
+	if s := string(value); onepassword.ValidateRef(s) == nil {
+		d.linked = append(d.linked, opLinkedRow{path: path, ref: s})
+		return s, true
+	}
+	if len(value) < onepassword.MinLinkableValueLen {
+		return "", false
+	}
+	d.ensure()
+	if d.ix == nil {
+		return "", false
+	}
+	e, ok := d.ix.RefFor(value)
+	if !ok {
+		return "", false
+	}
+	d.linked = append(d.linked, opLinkedRow{path: path, ref: e.NameRef})
+	return e.IDRef, true
+}
+
+// ensure runs the enumeration once, behind a spinner that counts items as
+// they stream in, so minutes of `op item get` never look like a hang. A
+// failed enumeration (signed-out CLI, locked app, a fake op the signature
+// gate rejected) fails open: the run continues on copies and the mutation
+// log says so once. The hook stays installed either way — verbatim op://
+// values need no index.
+func (d *opDedupe) ensure() {
+	if d.once {
+		return
+	}
+	d.once = true
+	d.stats.ran = true
+
+	tr := d.newTracker()
+	tr.Collapse()
+	tr.Step("checking 1Password for already-stored values (its prompt may appear)", "")
+	ix, err := migrateOpInventory(func(read, listed int) {
+		tr.Update(fmt.Sprintf("%d/%d items", read, listed))
+	})
+	if err != nil {
+		tr.Stop()
+		d.skipNote = err.Error()
+		return
+	}
+	d.ix = ix
+	d.stats.read, d.stats.listed, d.stats.incomplete = ix.Items(), ix.Listed(), ix.Incomplete()
+	tr.StopCollapsed("checked 1Password: " + countWord(ix.Items(), "item", "items"))
+}
+
+// print renders the run's 1Password outcome after the per-category
+// results. Nil-safe: a run that never installed the dedupe prints
+// nothing.
+func (d *opDedupe) print(w io.Writer) {
+	if d == nil {
+		return
+	}
+	printOpLinkResult(w, d.linked, d.offered, d.stats, d.skipNote)
+}
+
+// printOpLinkResult renders the 1Password dedupe outcome. Four cases: the
+// check failed (one amber note — the run continued with copies, fail
+// open); op was never consulted (silence: every value was under the
+// floor or a verbatim reference, and there is no 1Password outcome to
+// report); the check ran and nothing matched (the header with its
+// counts, so a user who just waited through the enumeration — and
+// possibly answered 1Password's prompt — sees that it ran, what it
+// covered, and that copies were the honest result); or N linked (the
+// block naming each path → reference, so the user knows exactly which
+// secrets now follow 1Password rotation). A shortfall — op stopped
+// answering before every listed item — is stated on the header and
+// explained with op's own line, never hidden inside a rounder number.
+func printOpLinkResult(w io.Writer, linked []opLinkedRow, offered int, stats opCheckStats, skipNote string) {
+	if skipNote != "" {
+		_, _ = cWarn.Fprint(w, glyphWarn)
+		wrapBody(w, 1, "  ", " 1Password check skipped: "+skipNote+"; values were copied, not linked")
+		fmt.Fprintln(w)
+		return
+	}
+	if !stats.ran {
+		return
+	}
+	items := countWord(stats.read, "item", "items") + " checked"
+	if stats.read < stats.listed {
+		items = fmt.Sprintf("%d of %d items read", stats.read, stats.listed)
+	}
+	printMigrateResultCategoryLabel(w, fmt.Sprintf("%d of %d linked, not copied · %s", len(linked), offered, items))
+	if stats.incomplete != "" {
+		fmt.Fprintln(w, truncateEnd("  op stopped early: "+stats.incomplete, termtext.Width()))
+	}
+	if len(linked) == 0 {
+		fmt.Fprintln(w, "  No migrated value matched a concealed 1Password field.")
+		fmt.Fprintln(w)
+		return
+	}
+	widest := 0
+	for _, r := range linked {
+		if len(r.path) > widest {
+			widest = len(r.path)
+		}
+	}
+	for _, r := range linked {
+		// Truncate the variable tail rather than wrap: one row per secret.
+		row := fmt.Sprintf("  %-*s %s %s", widest, r.path, glyphAction, r.ref)
+		fmt.Fprintln(w, truncateEnd(row, termtext.Width()))
+	}
+	fmt.Fprintln(w, "  Rotate these in 1Password; jit follows. The vault holds the")
+	fmt.Fprintln(w, "  reference, never a copy.")
+	fmt.Fprintln(w)
+}
+
+// printMigrateResultCategoryLabel is printMigrateResultCategory for a
+// header whose tail is richer than a bare count.
+func printMigrateResultCategoryLabel(w io.Writer, tail string) {
+	fmt.Fprintf(w, "[1Password] %s\n", tail)
+}

--- a/internal/cli/migrate1password_test.go
+++ b/internal/cli/migrate1password_test.go
@@ -266,13 +266,30 @@ func TestPrintOpLinkResultSkipNote(t *testing.T) {
 	}
 }
 
-// op never consulted (every value under the floor, or verbatim): there is
-// no 1Password outcome, so nothing prints.
+// op never consulted (every value under the floor) and nothing linked:
+// there is no 1Password outcome, so nothing prints.
 func TestPrintOpLinkResultSilentWhenNeverConsulted(t *testing.T) {
 	var buf bytes.Buffer
 	printOpLinkResult(&buf, nil, 12, opCheckStats{}, "")
 	if buf.Len() != 0 {
 		t.Errorf("a run that never consulted op must print nothing, got:\n%s", buf.String())
+	}
+}
+
+// A verbatim op:// value links with no enumeration at all (found live:
+// the lazy path skipped op, and the block that names the link went with
+// it). The block prints, and its header must not claim items checked.
+func TestPrintOpLinkResultVerbatimLinksWithoutEnumeration(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, []opLinkedRow{{path: "app/REF", ref: "op://Personal/X/field"}}, 3, opCheckStats{}, "")
+	out := buf.String()
+	for _, want := range []string{"[1Password] 1 of 3 linked, not copied · 1Password not consulted", "app/REF", "Rotate these"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "items checked") {
+		t.Errorf("header claims items were checked with no enumeration:\n%s", out)
 	}
 }
 

--- a/internal/cli/migrate1password_test.go
+++ b/internal/cli/migrate1password_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/jitpass/jit/internal/onepassword"
+	"github.com/jitpass/jit/internal/ui"
 	"github.com/jitpass/jit/internal/vault"
 )
 
@@ -23,7 +24,7 @@ import (
 // vars themselves and restore them.
 func TestMain(m *testing.M) {
 	migrateOpInstalled = func() bool { return false }
-	migrateOpInventory = func() (opInventory, error) {
+	migrateOpInventory = func(func(read, listed int)) (opInventory, error) {
 		return nil, errors.New("1Password inventory pinned off in tests")
 	}
 	doctorOpVerified = func() (string, error) { return "", errors.New("op pinned off in tests") }
@@ -103,10 +104,32 @@ func (f *fakeOpIndex) RefFor(value []byte) (onepassword.IndexEntry, bool) {
 	e, ok := f.entries[string(value)]
 	return e, ok
 }
-func (f *fakeOpIndex) Items() int { return f.items }
+func (f *fakeOpIndex) Items() int         { return f.items }
+func (f *fakeOpIndex) Listed() int        { return f.items }
+func (f *fakeOpIndex) Incomplete() string { return "" }
+
+// withOpInventory pins the enumeration for one test to return ix (or err),
+// and counts how many times it ran — the laziness assertions live on that
+// count. progressTicks, when non-nil, receives what a real enumeration
+// would report so the tracker wiring can be observed.
+func withOpInventory(t *testing.T, ix opInventory, err error) *int {
+	t.Helper()
+	runs := 0
+	prev := migrateOpInventory
+	migrateOpInventory = func(progress func(read, listed int)) (opInventory, error) {
+		runs++
+		if progress != nil && ix != nil {
+			progress(ix.Items(), ix.Listed())
+		}
+		return ix, err
+	}
+	t.Cleanup(func() { migrateOpInventory = prev })
+	return &runs
+}
 
 func TestOpLinkHookMatchesAndRecords(t *testing.T) {
 	ix := &fakeOpIndex{
+		items: 14,
 		entries: map[string]onepassword.IndexEntry{
 			"sk_live_matching_value": {
 				IDRef:   "op://vault-1/item-a/f1",
@@ -114,49 +137,98 @@ func TestOpLinkHookMatchesAndRecords(t *testing.T) {
 			},
 		},
 	}
-	var linked []opLinkedRow
-	var offered int
-	hook := newOpLinkHook(ix, &linked, &offered)
+	runs := withOpInventory(t, ix, nil)
+	d := newOpDedupe(nil)
 
 	// A matching value links to the ID form and records the name form.
-	ref, ok := hook("myapp/STRIPE_KEY", []byte("sk_live_matching_value"), vault.Meta{})
+	ref, ok := d.hook("myapp/STRIPE_KEY", []byte("sk_live_matching_value"), vault.Meta{})
 	if !ok || ref != "op://vault-1/item-a/f1" {
 		t.Errorf("match returned (%q, %v), want the ID-form reference", ref, ok)
 	}
 
 	// A non-matching value declines.
-	if _, ok := hook("myapp/OTHER", []byte("no-match-here"), vault.Meta{}); ok {
+	if _, ok := d.hook("myapp/OTHER", []byte("no-match-here"), vault.Meta{}); ok {
 		t.Error("hook linked a value the index does not hold")
 	}
 
 	// A verbatim op:// value links as itself, no index consulted.
-	ref, ok = hook("myapp/FROM_OP_RUN", []byte("op://Personal/GitHub/token"), vault.Meta{})
+	ref, ok = d.hook("myapp/FROM_OP_RUN", []byte("op://Personal/GitHub/token"), vault.Meta{})
 	if !ok || ref != "op://Personal/GitHub/token" {
 		t.Errorf("verbatim reference returned (%q, %v), want itself", ref, ok)
 	}
 
-	if offered != 3 {
-		t.Errorf("offered = %d, want every SetWithMeta counted", offered)
+	if d.offered != 3 {
+		t.Errorf("offered = %d, want every SetWithMeta counted", d.offered)
 	}
-	if len(linked) != 2 {
-		t.Fatalf("linked rows = %d, want 2", len(linked))
+	if len(d.linked) != 2 {
+		t.Fatalf("linked rows = %d, want 2", len(d.linked))
 	}
-	if linked[0].ref != "op://Personal/Stripe/credential" {
-		t.Errorf("recorded row ref = %q, want the NAME form for display", linked[0].ref)
+	if d.linked[0].ref != "op://Personal/Stripe/credential" {
+		t.Errorf("recorded row ref = %q, want the NAME form for display", d.linked[0].ref)
+	}
+	if *runs != 1 {
+		t.Errorf("enumeration ran %d times, want exactly once for the whole run", *runs)
+	}
+	if !d.stats.ran || d.stats.read != 14 {
+		t.Errorf("stats = %+v, want ran with 14 items read", d.stats)
 	}
 }
 
-func TestOpLinkHookNilIndexStillLinksVerbatimRefs(t *testing.T) {
-	var linked []opLinkedRow
-	var offered int
-	hook := newOpLinkHook(nil, &linked, &offered)
+// The enumeration is the expensive part — a prompt and one op call per
+// item — so it must not run for a value that could never link: one under
+// the match floor, or one that already is a reference.
+func TestOpLinkHookIsLazy(t *testing.T) {
+	runs := withOpInventory(t, &fakeOpIndex{items: 3}, nil)
+	d := newOpDedupe(nil)
 
-	if _, ok := hook("myapp/PLAIN", []byte("some-ordinary-value"), vault.Meta{}); ok {
-		t.Error("nil index must never match a plain value")
+	if _, ok := d.hook("myapp/PIN", []byte("admin"), vault.Meta{}); ok {
+		t.Error("a value under the floor linked")
 	}
-	ref, ok := hook("myapp/REF", []byte("op://Personal/X/field"), vault.Meta{})
+	ref, ok := d.hook("myapp/REF", []byte("op://Personal/X/field"), vault.Meta{})
 	if !ok || ref != "op://Personal/X/field" {
-		t.Errorf("verbatim link with nil index returned (%q, %v), want itself", ref, ok)
+		t.Errorf("verbatim link returned (%q, %v), want itself", ref, ok)
+	}
+	if *runs != 0 {
+		t.Fatalf("enumeration ran %d times for values that could never match, want 0", *runs)
+	}
+	if d.stats.ran {
+		t.Error("stats claim the check ran; the mutation log would report a check that never happened")
+	}
+
+	// The first linkable candidate triggers it, once.
+	d.hook("myapp/A", []byte("long-enough-candidate"), vault.Meta{})
+	d.hook("myapp/B", []byte("another-long-candidate"), vault.Meta{})
+	if *runs != 1 {
+		t.Errorf("enumeration ran %d times, want once", *runs)
+	}
+}
+
+func TestOpLinkHookFailedEnumerationStillLinksVerbatimRefs(t *testing.T) {
+	withOpInventory(t, nil, errors.New("op item list failed: account is not signed in"))
+	d := newOpDedupe(nil)
+
+	if _, ok := d.hook("myapp/PLAIN", []byte("some-ordinary-value"), vault.Meta{}); ok {
+		t.Error("a failed enumeration must never match a plain value")
+	}
+	if d.skipNote == "" || !strings.Contains(d.skipNote, "not signed in") {
+		t.Errorf("skipNote = %q, want op's own error for the mutation log", d.skipNote)
+	}
+	ref, ok := d.hook("myapp/REF", []byte("op://Personal/X/field"), vault.Meta{})
+	if !ok || ref != "op://Personal/X/field" {
+		t.Errorf("verbatim link after a failed enumeration returned (%q, %v), want itself", ref, ok)
+	}
+}
+
+// The tracker step is what stands between the user and a minutes-long
+// silence: it must start before the enumeration and be stopped (settled,
+// so nothing can interleave with stdout) before the hook returns.
+func TestOpLinkHookAnimatesTheEnumeration(t *testing.T) {
+	withOpInventory(t, &fakeOpIndex{items: 174}, nil)
+	var trail bytes.Buffer
+	d := newOpDedupe(func() *ui.Tracker { return ui.New(&trail, true, false) })
+	d.hook("myapp/A", []byte("long-enough-candidate"), vault.Meta{})
+	if !strings.Contains(trail.String(), "checking 1Password") {
+		t.Errorf("no progress line while enumerating, got:\n%s", trail.String())
 	}
 }
 
@@ -165,7 +237,7 @@ func TestPrintOpLinkResultBlock(t *testing.T) {
 	printOpLinkResult(&buf, []opLinkedRow{
 		{path: "myapp/DB_PASSWORD", ref: "op://Personal/Postgres/password"},
 		{path: "myapp/STRIPE_KEY", ref: "op://Personal/Stripe/credential"},
-	}, 12, 14, "")
+	}, 12, opCheckStats{ran: true, read: 14, listed: 14}, "")
 	out := buf.String()
 	for _, want := range []string{
 		"[1Password] 2 of 12 linked, not copied · 14 items checked",
@@ -177,11 +249,14 @@ func TestPrintOpLinkResultBlock(t *testing.T) {
 			t.Errorf("expected %q in the block, got:\n%s", want, out)
 		}
 	}
+	if strings.Contains(out, "stopped early") || strings.Contains(out, "No migrated value") {
+		t.Errorf("a complete, matching run printed a shortfall or no-match line:\n%s", out)
+	}
 }
 
 func TestPrintOpLinkResultSkipNote(t *testing.T) {
 	var buf bytes.Buffer
-	printOpLinkResult(&buf, nil, 5, 0, "op item list failed: account is not signed in")
+	printOpLinkResult(&buf, nil, 5, opCheckStats{ran: true}, "op item list failed: account is not signed in")
 	out := buf.String()
 	if !strings.Contains(out, "1Password check skipped") || !strings.Contains(out, "not signed in") {
 		t.Errorf("expected the skip note carrying op's error, got:\n%s", out)
@@ -191,10 +266,47 @@ func TestPrintOpLinkResultSkipNote(t *testing.T) {
 	}
 }
 
-func TestPrintOpLinkResultSilentWhenNothingLinked(t *testing.T) {
+// op never consulted (every value under the floor, or verbatim): there is
+// no 1Password outcome, so nothing prints.
+func TestPrintOpLinkResultSilentWhenNeverConsulted(t *testing.T) {
 	var buf bytes.Buffer
-	printOpLinkResult(&buf, nil, 12, 14, "")
+	printOpLinkResult(&buf, nil, 12, opCheckStats{}, "")
 	if buf.Len() != 0 {
-		t.Errorf("a run with no links must print nothing, got:\n%s", buf.String())
+		t.Errorf("a run that never consulted op must print nothing, got:\n%s", buf.String())
+	}
+}
+
+// The check ran — the user waited through it, maybe answered a prompt —
+// and nothing matched: say so, with the counts, instead of silence.
+func TestPrintOpLinkResultNothingMatchedSaysSo(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, nil, 12, opCheckStats{ran: true, read: 174, listed: 174}, "")
+	out := buf.String()
+	for _, want := range []string{
+		"[1Password] 0 of 12 linked, not copied · 174 items checked",
+		"No migrated value matched a concealed 1Password field.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Rotate these") {
+		t.Errorf("the rotate advice printed with nothing linked:\n%s", out)
+	}
+}
+
+func TestPrintOpLinkResultShortfallIsStated(t *testing.T) {
+	var buf bytes.Buffer
+	printOpLinkResult(&buf, []opLinkedRow{{path: "myapp/DB_PASSWORD", ref: "op://Personal/Postgres/password"}},
+		12, opCheckStats{ran: true, read: 150, listed: 174, incomplete: "[ERROR] 2026/09/05 rate limit exceeded"}, "")
+	out := buf.String()
+	for _, want := range []string{
+		"1 of 12 linked, not copied · 150 of 174 items read",
+		"op stopped early: [ERROR] 2026/09/05 rate limit exceeded",
+		"myapp/DB_PASSWORD",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q, got:\n%s", want, out)
+		}
 	}
 }

--- a/internal/cli/migrateduplicates.go
+++ b/internal/cli/migrateduplicates.go
@@ -28,6 +28,13 @@ import (
 // failure) simply disables the notes — disclosure must never fail a
 // migration.
 //
+// It reads what is STORED, never what a linked secret resolves to: a
+// 1Password-linked entry is keyed by its reference, so two links to the
+// same field read as duplicates of each other and a link never equals a
+// literal copy of the same value. Resolving would cost one `op read` exec
+// per linked secret on every migrate run — and, with the app locked, one
+// unlock dialog each — for a disclosure note.
+//
 // It maps a digest to EVERY path holding it, not just the first. The index
 // is built lazily, which means it is built AFTER the run's first file has
 // already been stored, so a value's own freshly-written path is in here
@@ -45,15 +52,29 @@ func buildVaultValueIndex(v *vault.Vault) map[string][]string {
 	secrets, _ := splitBackupPaths(paths)
 	idx := make(map[string][]string, len(secrets))
 	for _, p := range secrets {
-		value, err := v.Get(p)
-		if err != nil {
+		key, _, ok := storedDigest(v, p)
+		if !ok {
 			continue
 		}
-		sum := sha256.Sum256(value)
-		key := fmt.Sprintf("%x", sum)
 		idx[key] = append(idx[key], p)
 	}
 	return idx
+}
+
+// storedDigest keys one vault entry for the duplicate index: the digest of
+// its stored bytes, prefixed by storage kind so a reference and a literal
+// can never collide. Returns the stored length too, for the floor below.
+func storedDigest(v *vault.Vault, path string) (key string, n int, ok bool) {
+	payload, storage, err := v.GetStored(path)
+	if err != nil {
+		return "", 0, false
+	}
+	sum := sha256.Sum256(payload)
+	key = fmt.Sprintf("%x", sum)
+	if storage != "" {
+		key = storage + ":" + key
+	}
+	return key, len(payload), true
 }
 
 // minDuplicateValueLen keeps trivially-coincidental values ("true", a port
@@ -76,13 +97,12 @@ func noteDuplicateValues(out io.Writer, v *vault.Vault, idx map[string][]string,
 		if looksLikeConfig(name) {
 			continue
 		}
-		value, err := v.Get(profileName + "/" + name)
-		if err != nil || len(value) < minDuplicateValueLen {
+		key, n, ok := storedDigest(v, profileName+"/"+name)
+		if !ok || n < minDuplicateValueLen {
 			continue
 		}
-		sum := sha256.Sum256(value)
 		counted := false
-		for _, existing := range idx[fmt.Sprintf("%x", sum)] {
+		for _, existing := range idx[key] {
 			// Skip the value's own group, including the copy this very
 			// migration just wrote (the index is built after the store).
 			g := groupPrefix(existing)

--- a/internal/cli/migrateduplicates_test.go
+++ b/internal/cli/migrateduplicates_test.go
@@ -7,6 +7,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -100,5 +101,48 @@ func TestNoteDuplicateValuesIndexBuiltAfterTheWrite(t *testing.T) {
 	}
 	if strings.Contains(out, "ws-copy") {
 		t.Errorf("the migrating profile must never name itself, got:\n%s", out)
+	}
+}
+
+// countingResolver fails every resolve and counts the attempts: the
+// duplicate index must key linked entries by their stored reference, never
+// by resolving them — one `op read` per linked secret per migrate run, each
+// able to block on an unlock dialog, for a disclosure note.
+type countingResolver struct{ calls int }
+
+func (c *countingResolver) ResolveRef(string) ([]byte, error) {
+	c.calls++
+	return nil, errors.New("must not resolve")
+}
+
+func TestDuplicateIndexNeverResolvesLinkedSecrets(t *testing.T) {
+	withFixtureHome(t)
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	resolver := &countingResolver{}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device", RefResolver: resolver}
+	link := func(path, ref string) {
+		t.Helper()
+		if err := v.SetReference(path, ref, vault.Meta{}); err != nil {
+			t.Fatalf("SetReference(%s): %v", path, err)
+		}
+	}
+	link("svc-a/DB_PASSWORD", "op://vault-1/item-a/password")
+	if err := v.Set("svc-a/API_KEY", []byte("literal-value-here")); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	idx := buildVaultValueIndex(v)
+	link("svc-b/DB_PASSWORD", "op://vault-1/item-a/password") // same field linked twice
+	link("svc-b/OTHER", "op://vault-1/item-b/password")
+
+	var buf bytes.Buffer
+	noteDuplicateValues(&buf, v, idx, "svc-b", []string{"DB_PASSWORD", "OTHER"})
+	if out := buf.String(); !strings.Contains(out, "1 value is already stored under svc-a") {
+		t.Errorf("two links to the same 1Password field must read as a duplicate, got:\n%s", out)
+	}
+	if resolver.calls != 0 {
+		t.Errorf("the duplicate index resolved through 1Password %d times, want 0", resolver.calls)
 	}
 }

--- a/internal/cli/migratesummary.go
+++ b/internal/cli/migratesummary.go
@@ -12,7 +12,6 @@ import (
 	"github.com/jitpass/jit/internal/agent"
 	"github.com/jitpass/jit/internal/migrate"
 	"github.com/jitpass/jit/internal/profile"
-	"github.com/jitpass/jit/internal/termtext"
 )
 
 // This file is real migrate's MUTATION LOG rendering — the per-category
@@ -37,48 +36,6 @@ func printMigrateResultCategory(w io.Writer, label string, n int) {
 // mutation-log block: the vault path, and the reference in its
 // human-readable name form (the stored one is rename-proof ID form; the
 // name form is what the user recognizes from the 1Password app).
-type opLinkedRow struct{ path, ref string }
-
-// printOpLinkResult renders the 1Password dedupe outcome after the
-// per-category results (design/1password-adapter.md). Three cases: the
-// check failed (one amber note — the run continued with copies, fail
-// open), nothing matched (silence; an empty block would be noise on every
-// run op is merely installed for), or N linked (the block naming each
-// path → reference, so the user knows exactly which secrets now follow
-// 1Password rotation).
-func printOpLinkResult(w io.Writer, linked []opLinkedRow, offered, itemsChecked int, skipNote string) {
-	if skipNote != "" {
-		_, _ = cWarn.Fprint(w, glyphWarn)
-		wrapBody(w, 1, "  ", " 1Password check skipped: "+skipNote+"; values were copied, not linked")
-		fmt.Fprintln(w)
-		return
-	}
-	if len(linked) == 0 {
-		return
-	}
-	widest := 0
-	for _, r := range linked {
-		if len(r.path) > widest {
-			widest = len(r.path)
-		}
-	}
-	printMigrateResultCategoryLabel(w, fmt.Sprintf("%d of %d linked, not copied · %s checked", len(linked), offered, countWord(itemsChecked, "item", "items")))
-	for _, r := range linked {
-		// Truncate the variable tail rather than wrap: one row per secret.
-		row := fmt.Sprintf("  %-*s %s %s", widest, r.path, glyphAction, r.ref)
-		fmt.Fprintln(w, truncateEnd(row, termtext.Width()))
-	}
-	fmt.Fprintln(w, "  Rotate these in 1Password; jit follows. The vault holds the")
-	fmt.Fprintln(w, "  reference, never a copy.")
-	fmt.Fprintln(w)
-}
-
-// printMigrateResultCategoryLabel is printMigrateResultCategory for a
-// header whose tail is richer than a bare count.
-func printMigrateResultCategoryLabel(w io.Writer, tail string) {
-	fmt.Fprintf(w, "[1Password] %s\n", tail)
-}
-
 // migrateSummary collects everything that used to print inline, once per
 // file, during a real migrate run's mutation loop — git-history warnings,
 // pointer-file confirmations, and reveal-hook results — so it can be

--- a/internal/cli/vaultlink.go
+++ b/internal/cli/vaultlink.go
@@ -24,6 +24,18 @@ var (
 	vaultLinkNoVerify bool
 )
 
+// vaultLinkPin is the trial resolve: it proves the reference resolves and
+// returns it pinned to the account it resolved in (onepassword.Pin), so
+// the link keeps resolving there whatever account op defaults to later.
+// A var so tests can drive the command past it without a real op; the
+// vault opener is a var for the same reason (no Touch ID in tests).
+var (
+	vaultLinkPin = func(ref string) (string, error) {
+		return onepassword.New().Pin(ref)
+	}
+	vaultLinkOpen = openVaultFreshAuth
+)
+
 var vaultLinkCmd = &cobra.Command{
 	Use:   "link <path> <op://vault/item/field>",
 	Short: "Store a 1Password reference instead of a value",
@@ -36,7 +48,10 @@ var vaultLinkCmd = &cobra.Command{
 		"Reference). Item and vault IDs also work in place of names and survive\n" +
 		"renames.\n\n" +
 		"The link is test-resolved through `op` first, so a typo or a signed-out\n" +
-		"CLI fails here, not at first use; --no-verify skips that (offline setup).\n" +
+		"CLI fails here, not at first use, and the reference is pinned to the\n" +
+		"1Password account it resolved in, so a Mac signed in to several keeps\n" +
+		"resolving it there whichever account op last used. --no-verify skips\n" +
+		"both (offline setup): the link then follows op's default account.\n" +
 		"Requires the 1Password CLI (`brew install 1password-cli`) with the\n" +
 		"desktop app integration on.\n\n" +
 		"First use in a terminal session may show two prompts: jit's Touch ID\n" +
@@ -71,16 +86,18 @@ var vaultLinkCmd = &cobra.Command{
 			// and nothing on screen says which prompt belongs to whom.
 			// stderr, so stdout stays byte-clean for pipes.
 			fmt.Fprintln(cmd.ErrOrStderr(), "checking with 1Password (its prompt may appear)...")
-			if _, err := onepassword.New().ResolveRef(ref); err != nil {
+			pinned, err := vaultLinkPin(ref)
+			if err != nil {
 				return fmt.Errorf("jit vault link: %w (use --no-verify to link anyway)", err)
 			}
+			ref = pinned
 		}
 
 		// Fresh auth on every sensitive vault command, never the cached
 		// agent session — writing a pointer is writing a secret: whoever
 		// controls the reference controls what every consumer of this path
 		// receives.
-		v, err := openVaultFreshAuth()
+		v, err := vaultLinkOpen()
 		if err != nil {
 			return fmt.Errorf("jit vault link: %w", err)
 		}

--- a/internal/cli/vaultlink_test.go
+++ b/internal/cli/vaultlink_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jitpass/jit/internal/vault"
 )
 
 // TestVaultLinkRejectsBadReferenceBeforeAnythingElse confirms a malformed
@@ -58,5 +60,43 @@ func TestVaultLinkTrialResolveFailsClosedOnAnUnsignedOp(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "--no-verify") {
 		t.Errorf("error does not offer --no-verify: %v", err)
+	}
+}
+
+// TestVaultLinkStoresThePinnedReference: the trial resolve hands back the
+// reference pinned to the account it resolved in, and THAT is what gets
+// stored — not the bare reference the user typed.
+func TestVaultLinkStoresThePinnedReference(t *testing.T) {
+	prevPin, prevOpen := vaultLinkPin, vaultLinkOpen
+	t.Cleanup(func() { vaultLinkPin, vaultLinkOpen = prevPin, prevOpen })
+	var pinnedWith string
+	vaultLinkPin = func(ref string) (string, error) {
+		pinnedWith = ref
+		return ref + "?account=ACC1", nil
+	}
+	withFixtureHome(t)
+	root, err := vaultRootDir()
+	if err != nil {
+		t.Fatalf("vaultRootDir: %v", err)
+	}
+	v := &vault.Vault{Root: root, KeyWrapper: newFakeKeyWrapper(), RecipientID: "test-device"}
+	vaultLinkOpen = func() (*vault.Vault, error) { return v, nil }
+
+	vaultLinkYes, vaultLinkNoVerify = true, false
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetArgs([]string{"vault", "link", "svc/TOKEN", "op://vaultid/itemid/fieldid"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("vault link: %v", err)
+	}
+	if pinnedWith != "op://vaultid/itemid/fieldid" {
+		t.Errorf("trial resolve got %q, want the reference as typed", pinnedWith)
+	}
+	stored, storage, err := v.GetStored("svc/TOKEN")
+	if err != nil {
+		t.Fatalf("GetStored: %v", err)
+	}
+	if storage != vault.StorageOpRef || string(stored) != "op://vaultid/itemid/fieldid?account=ACC1" {
+		t.Errorf("stored (%q, %q), want the pinned reference as a link", stored, storage)
 	}
 }

--- a/internal/onepassword/account.go
+++ b/internal/onepassword/account.go
@@ -1,0 +1,184 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+// Account pinning. An op:// reference names a vault, an item and a field
+// but NOT an account, and op resolves every reference against ONE
+// account — `--account`, else OP_ACCOUNT, else whichever it signed in to
+// most recently. On a Mac with two accounts (a personal one and an
+// employer's) that default flips with ordinary use, and a link made
+// under one account then fails with "isn't a vault in this account"
+// under the other. Found live 2026-09-05 with exactly that pair.
+//
+// So a link jit creates carries the account it was made against, as a
+// query parameter on the stored reference — `op://v/i/f?account=<id>`,
+// the same slot op itself uses for `?attribute=otp`. op ignores the
+// parameter (verified: identical behavior with and without it), the
+// resolver strips it and passes `--account` instead, and every other
+// consumer of the stored string (export, doctor's sweep, `vault get`'s
+// JSON) carries it along untouched. The id is the ACCOUNT uuid, not the
+// user's: it names the account itself, which is what the vault ids
+// inside the reference belong to.
+
+// accountParam is the query key carrying the pin.
+const accountParam = "account"
+
+// Account is one signed-in 1Password account as `op account list` reports
+// it. ID is the account uuid (the pin); the rest identify it to a person
+// and match OP_ACCOUNT.
+type Account struct {
+	ID        string `json:"account_uuid"`
+	UserID    string `json:"user_uuid"`
+	URL       string `json:"url"`
+	Shorthand string `json:"shorthand"`
+	Email     string `json:"email"`
+}
+
+// Accounts lists the accounts op knows on this machine. Reads op's own
+// config through the app integration — no authorization prompt, no
+// secret — and is bounded short because a health probe must never hang.
+func (r *Resolver) Accounts() ([]Account, error) {
+	bin, err := r.bin()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	out, err := runOp(ctx, bin, nil, "account", "list", "--format", "json")
+	if err != nil {
+		return nil, fmt.Errorf("op account list failed: %w", err)
+	}
+	var accounts []Account
+	if err := json.Unmarshal(out, &accounts); err != nil {
+		return nil, fmt.Errorf("op account list output not understood: %v", err)
+	}
+	return accounts, nil
+}
+
+// enumerationAccounts is the account set one enumeration covers: every
+// signed-in account, unless OP_ACCOUNT names one — op's own scoping
+// variable, honored here so a user with a large employer account beside
+// a personal one can keep migrate to the one they mean. An OP_ACCOUNT
+// that matches nothing, or a failed listing, yields nil: one unpinned
+// pass under op's own default, today's behavior.
+func (r *Resolver) enumerationAccounts() []Account {
+	accounts, err := r.Accounts()
+	if err != nil {
+		return nil
+	}
+	return selectAccounts(accounts, os.Getenv("OP_ACCOUNT"))
+}
+
+// selectAccounts filters by OP_ACCOUNT the way op's --account matches:
+// shorthand, sign-in address (with or without scheme), account id, user
+// id — plus the email, which people also reach for.
+func selectAccounts(all []Account, opAccount string) []Account {
+	want := strings.TrimSpace(opAccount)
+	if want == "" {
+		return all
+	}
+	want = strings.ToLower(want)
+	for _, a := range all {
+		host := a.URL
+		if u, err := url.Parse(a.URL); err == nil && u.Host != "" {
+			host = u.Host
+		}
+		for _, cand := range []string{a.Shorthand, a.URL, host, a.ID, a.UserID, a.Email} {
+			if cand != "" && strings.ToLower(cand) == want {
+				return []Account{a}
+			}
+		}
+	}
+	return nil
+}
+
+// PinAccount returns ref carrying accountID as its account parameter,
+// replacing any pin already present. An empty accountID returns ref
+// unchanged.
+func PinAccount(ref, accountID string) string {
+	if accountID == "" {
+		return ref
+	}
+	bare, _ := SplitAccount(ref)
+	sep := "?"
+	if strings.Contains(bare, "?") {
+		sep = "&"
+	}
+	return bare + sep + accountParam + "=" + url.QueryEscape(accountID)
+}
+
+// SplitAccount separates the account pin from a reference: bare is the
+// reference op receives (every other query parameter kept, in op's own
+// order of no significance), accountID the pin or "". The path is never
+// re-encoded — a name-form reference may carry spaces op accepts raw and
+// url.URL.String would percent-escape.
+func SplitAccount(ref string) (bare, accountID string) {
+	i := strings.IndexByte(ref, '?')
+	if i < 0 {
+		return ref, ""
+	}
+	q, err := url.ParseQuery(ref[i+1:])
+	if err != nil {
+		return ref, ""
+	}
+	accountID = q.Get(accountParam)
+	if accountID == "" {
+		return ref, ""
+	}
+	q.Del(accountParam)
+	if len(q) == 0 {
+		return ref[:i], accountID
+	}
+	return ref[:i] + "?" + q.Encode(), accountID
+}
+
+// Pin resolves ref once and returns it pinned to the account it resolved
+// in — `jit vault link`'s trial resolve, made account-aware. A ref
+// already pinned is only test-resolved. Otherwise, with one account
+// signed in the pin is that account; with several, each is tried in
+// turn (op's own listing order) and the first that resolves wins, so a
+// reference copied from either app window links correctly without the
+// user knowing the account uuid. No accounts listed at all (op not
+// configured) means one unpinned resolve and an unpinned link, as
+// before. Every attempt can pop that account's authorization dialog.
+func (r *Resolver) Pin(ref string) (string, error) {
+	if _, pinned := SplitAccount(ref); pinned != "" {
+		if _, err := r.ResolveRef(ref); err != nil {
+			return "", err
+		}
+		return ref, nil
+	}
+	accounts, err := r.Accounts()
+	if err != nil || len(accounts) == 0 {
+		if _, err := r.ResolveRef(ref); err != nil {
+			return "", err
+		}
+		return ref, nil
+	}
+	var firstErr error
+	for _, a := range accounts {
+		pinned := PinAccount(ref, a.ID)
+		if _, err := r.ResolveRef(pinned); err != nil {
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		return pinned, nil
+	}
+	if len(accounts) > 1 {
+		return "", fmt.Errorf("%w (tried all %d signed-in accounts)", firstErr, len(accounts))
+	}
+	return "", firstErr
+}

--- a/internal/onepassword/account_test.go
+++ b/internal/onepassword/account_test.go
@@ -1,0 +1,251 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package onepassword
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestSplitAndPinAccount(t *testing.T) {
+	cases := []struct {
+		in, bare, account string
+	}{
+		{"op://v/i/f", "op://v/i/f", ""},
+		{"op://v/i/f?account=ACC1", "op://v/i/f", "ACC1"},
+		{"op://v/i/f?attribute=otp", "op://v/i/f?attribute=otp", ""},
+		{"op://v/i/f?attribute=otp&account=ACC1", "op://v/i/f?attribute=otp", "ACC1"},
+		{"op://app-prod/ssh/private key?ssh-format=openssh&account=ACC1", "op://app-prod/ssh/private key?ssh-format=openssh", "ACC1"},
+	}
+	for _, c := range cases {
+		bare, account := SplitAccount(c.in)
+		if bare != c.bare || account != c.account {
+			t.Errorf("SplitAccount(%q) = (%q, %q), want (%q, %q)", c.in, bare, account, c.bare, c.account)
+		}
+	}
+	if got := PinAccount("op://v/i/f", "ACC1"); got != "op://v/i/f?account=ACC1" {
+		t.Errorf("PinAccount = %q", got)
+	}
+	if got := PinAccount("op://v/i/f?attribute=otp", "ACC1"); got != "op://v/i/f?attribute=otp&account=ACC1" {
+		t.Errorf("PinAccount with a query = %q", got)
+	}
+	if got := PinAccount("op://v/i/f?account=OLD", "NEW"); got != "op://v/i/f?account=NEW" {
+		t.Errorf("PinAccount over an existing pin = %q", got)
+	}
+	if got := PinAccount("op://v/i/f", ""); got != "op://v/i/f" {
+		t.Errorf("PinAccount with no account = %q, want unchanged", got)
+	}
+	// A pinned reference is still a valid reference shape.
+	if err := ValidateRef("op://v/i/f?account=ACC1"); err != nil {
+		t.Errorf("ValidateRef rejects a pinned reference: %v", err)
+	}
+}
+
+func TestSelectAccountsMatchesLikeOpAccount(t *testing.T) {
+	all := []Account{
+		{ID: "ACC1", UserID: "USER1", URL: "https://my.1password.com", Email: "me@example.com"},
+		{ID: "ACC2", UserID: "USER2", URL: "https://corp.1password.com", Shorthand: "corp"},
+	}
+	for want, key := range map[string]string{
+		"ACC1": "my.1password.com",
+		"ACC2": "corp",
+		"":     "nobody.1password.com",
+	} {
+		got := selectAccounts(all, key)
+		switch {
+		case want == "" && got != nil:
+			t.Errorf("selectAccounts(%q) = %v, want nil (no match → op's default)", key, got)
+		case want != "" && (len(got) != 1 || got[0].ID != want):
+			t.Errorf("selectAccounts(%q) = %v, want %s", key, got, want)
+		}
+	}
+	for _, key := range []string{"https://my.1password.com", "USER2", "acc2", "ME@EXAMPLE.COM"} {
+		if got := selectAccounts(all, key); len(got) != 1 {
+			t.Errorf("selectAccounts(%q) = %v, want one account", key, got)
+		}
+	}
+	if got := selectAccounts(all, ""); len(got) != 2 {
+		t.Errorf("selectAccounts(\"\") = %v, want every account", got)
+	}
+}
+
+const twoAccountsJSON = `[{"url":"https://my.1password.com","email":"me@example.com","user_uuid":"USER1","account_uuid":"ACC1"},` +
+	`{"url":"https://corp.1password.com","email":"me@corp.example","user_uuid":"USER2","account_uuid":"ACC2","shorthand":"corp"}]`
+
+// fakeOpAccounts builds a fake op that answers `account list` with
+// accountsJSON, and `item list` / `item get -` / `read` per --account
+// from the per-account bodies, failing for an account with no entry.
+// Every invocation appends its full argument line to callLog.
+func fakeOpAccounts(t *testing.T, accountsJSON string, perAccount map[string][2]string) (path, callLog string) {
+	t.Helper()
+	callLog = t.TempDir() + "/calls"
+	script := `echo "$*" >> ` + callLog + `
+ACC=""
+if [ "$1" = "--account" ]; then ACC="$2"; shift 2; fi
+case "$1 $2" in
+"account list")
+cat <<'JSONEOF'
+` + accountsJSON + `
+JSONEOF
+exit 0 ;;
+"read -n")
+case "$ACC" in
+`
+	for id := range perAccount {
+		script += id + `) printf 'value-in-` + id + `'; exit 0 ;;
+`
+	}
+	script += `*) echo "[ERROR] isn't a vault in this account" >&2; exit 1 ;;
+esac ;;
+esac
+case "$ACC" in
+`
+	for id, bodies := range perAccount {
+		script += id + `)
+case "$1 $2" in
+"item list") cat <<'JSONEOF'
+` + bodies[0] + `
+JSONEOF
+;;
+"item get") cat >/dev/null; cat <<'JSONEOF'
+` + bodies[1] + `
+JSONEOF
+;;
+esac ;;
+`
+	}
+	script += `*) echo "[ERROR] account $ACC is not signed in" >&2; exit 1 ;;
+esac
+`
+	return fakeOp(t, script), callLog
+}
+
+func TestInventoryCoversEveryAccountAndPinsEachLink(t *testing.T) {
+	bin, calls := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{
+		"ACC1": {`[{"id":"p1","category":"LOGIN"}]`, fmt.Sprintf(inventoryItemTemplate, "p1", "personal")},
+		"ACC2": {`[{"id":"c1","category":"LOGIN"},{"id":"c2","category":"CREDIT_CARD"}]`, fmt.Sprintf(inventoryItemTemplate, "c1", "corp")},
+	})
+	t.Setenv("OP_ACCOUNT", "")
+	var ticks []string
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(func(read, listed int) {
+		ticks = append(ticks, fmt.Sprintf("%d/%d", read, listed))
+	})
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Listed() != 2 || ix.Items() != 2 || ix.Incomplete() != "" {
+		t.Errorf("Listed/Items/Incomplete = %d/%d/%q, want 2/2 (the card filtered) and complete", ix.Listed(), ix.Items(), ix.Incomplete())
+	}
+	e, ok := ix.RefFor([]byte("value-of-personal"))
+	if !ok || e.IDRef != "op://v/p1/f?account=ACC1" {
+		t.Errorf("personal link = (%q, %v), want pinned to ACC1", e.IDRef, ok)
+	}
+	e, ok = ix.RefFor([]byte("value-of-corp"))
+	if !ok || e.IDRef != "op://v/c1/f?account=ACC2" {
+		t.Errorf("corp link = (%q, %v), want pinned to ACC2", e.IDRef, ok)
+	}
+	if got := strings.Join(ticks, " "); got != "0/2 1/2 2/2" {
+		t.Errorf("progress = %q, want cumulative across accounts", got)
+	}
+	log, _ := os.ReadFile(calls) // #nosec G304 -- test temp file
+	for _, want := range []string{"--account ACC1 item list", "--account ACC2 item list", "--account ACC1 item get -", "--account ACC2 item get -"} {
+		if !strings.Contains(string(log), want) {
+			t.Errorf("op was never invoked as %q:\n%s", want, log)
+		}
+	}
+}
+
+func TestInventoryHonorsOPAccount(t *testing.T) {
+	bin, calls := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{
+		"ACC1": {`[{"id":"p1","category":"LOGIN"}]`, fmt.Sprintf(inventoryItemTemplate, "p1", "personal")},
+		"ACC2": {`[{"id":"c1","category":"LOGIN"}]`, fmt.Sprintf(inventoryItemTemplate, "c1", "corp")},
+	})
+	t.Setenv("OP_ACCOUNT", "my.1password.com")
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Listed() != 1 {
+		t.Errorf("Listed() = %d, want the one account OP_ACCOUNT names", ix.Listed())
+	}
+	if _, ok := ix.RefFor([]byte("value-of-corp")); ok {
+		t.Error("the account OP_ACCOUNT excluded was enumerated")
+	}
+	if log, _ := os.ReadFile(calls); strings.Contains(string(log), "--account ACC2") { // #nosec G304 -- test temp file
+		t.Errorf("op was invoked for the excluded account:\n%s", log)
+	}
+}
+
+func TestInventoryOneFailingAccountIsAShortfallNotAFailure(t *testing.T) {
+	// ACC2 is listed but has no fake body: every call for it fails.
+	bin, _ := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{
+		"ACC1": {`[{"id":"p1","category":"LOGIN"}]`, fmt.Sprintf(inventoryItemTemplate, "p1", "personal")},
+	})
+	t.Setenv("OP_ACCOUNT", "")
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if _, ok := ix.RefFor([]byte("value-of-personal")); !ok {
+		t.Error("the working account was not indexed")
+	}
+	if !strings.Contains(ix.Incomplete(), "corp.1password.com") || !strings.Contains(ix.Incomplete(), "not signed in") {
+		t.Errorf("Incomplete() = %q, want the failing account named with op's line", ix.Incomplete())
+	}
+}
+
+func TestInventoryEveryAccountFailingIsAnError(t *testing.T) {
+	bin, _ := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{})
+	t.Setenv("OP_ACCOUNT", "")
+	if _, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil); err == nil {
+		t.Fatal("Inventory succeeded with every account failing")
+	}
+}
+
+func TestResolveRefPassesThePinAsAccount(t *testing.T) {
+	bin, calls := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{"ACC2": {}})
+	r := &Resolver{path: bin, verify: noVerify}
+	got, err := r.ResolveRef("op://v/i/f?account=ACC2")
+	if err != nil || string(got) != "value-in-ACC2" {
+		t.Fatalf("ResolveRef = (%q, %v), want the pinned account's value", got, err)
+	}
+	log, _ := os.ReadFile(calls) // #nosec G304 -- test temp file
+	if !strings.Contains(string(log), "--account ACC2 read -n op://v/i/f\n") {
+		t.Errorf("op read was not invoked with --account and the bare reference:\n%s", log)
+	}
+	// Unpinned on a two-account machine: the failure names the likely cause.
+	_, err = r.ResolveRef("op://v/i/f")
+	if err == nil || !strings.Contains(err.Error(), "signed in to 2 accounts") {
+		t.Errorf("unpinned failure = %v, want the multi-account hint", err)
+	}
+}
+
+func TestPinFindsTheAccountAReferenceResolvesIn(t *testing.T) {
+	bin, _ := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{"ACC2": {}})
+	r := &Resolver{path: bin, verify: noVerify}
+	pinned, err := r.Pin("op://v/i/f")
+	if err != nil || pinned != "op://v/i/f?account=ACC2" {
+		t.Errorf("Pin = (%q, %v), want the second account, the one it resolves in", pinned, err)
+	}
+	// Already pinned: kept as is.
+	if pinned, err := r.Pin("op://v/i/f?account=ACC2"); err != nil || pinned != "op://v/i/f?account=ACC2" {
+		t.Errorf("Pin of a pinned ref = (%q, %v)", pinned, err)
+	}
+	// Resolves nowhere: the error says every account was tried.
+	bin2, _ := fakeOpAccounts(t, twoAccountsJSON, map[string][2]string{})
+	if _, err := (&Resolver{path: bin2, verify: noVerify}).Pin("op://v/i/f"); err == nil || !strings.Contains(err.Error(), "tried all 2") {
+		t.Errorf("Pin with no resolving account = %v, want the tried-all error", err)
+	}
+}
+
+func TestPinWithOneAccountPinsIt(t *testing.T) {
+	one := `[{"url":"https://my.1password.com","user_uuid":"USER1","account_uuid":"ACC1"}]`
+	bin, _ := fakeOpAccounts(t, one, map[string][2]string{"ACC1": {}})
+	pinned, err := (&Resolver{path: bin, verify: noVerify}).Pin("op://v/i/f")
+	if err != nil || pinned != "op://v/i/f?account=ACC1" {
+		t.Errorf("Pin = (%q, %v), want pinned to the only account", pinned, err)
+	}
+}

--- a/internal/onepassword/inventory.go
+++ b/internal/onepassword/inventory.go
@@ -4,30 +4,73 @@
 package onepassword
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os/exec"
-	"sort"
+	"sync/atomic"
 	"time"
 )
 
-// minLinkableValueLen is the floor under which a 1Password field value is
+// MinLinkableValueLen is the floor under which a 1Password field value is
 // never indexed for matching: a `PASSWORD=admin` line must not silently
 // link to whichever item also says "admin". Byte-exact matching plus this
 // floor is the whole anti-collision story — no fuzz, no normalization.
-const minLinkableValueLen = 8
+// Exported so migrate can tell a linkable candidate from a value that
+// could never match, and skip the enumeration for a run that has none.
+const MinLinkableValueLen = 8
+
+// skipCategories are the 1Password item categories the enumeration never
+// fetches. None of them holds a developer credential; what they do hold
+// behind CONCEALED fields is a card's CVV and PIN, a bank account's phone
+// PIN, and identity-document details — bytes that must not pass through
+// jit's memory to be hashed, and fetches that in a Business account each
+// land an "item accessed" event in the activity log for nothing. A
+// deny-list, not an allow-list, so a category 1Password adds tomorrow is
+// enumerated until someone decides otherwise. Values are the `category`
+// key `op item list --format json` carries (op's own template names in
+// upper snake case).
+var skipCategories = map[string]bool{
+	"BANK_ACCOUNT":           true,
+	"CREDIT_CARD":            true,
+	"DRIVER_LICENSE":         true,
+	"IDENTITY":               true,
+	"MEDICAL_RECORD":         true,
+	"MEMBERSHIP":             true,
+	"OUTDOOR_LICENSE":        true,
+	"PASSPORT":               true,
+	"REWARD_PROGRAM":         true,
+	"SOCIAL_SECURITY_NUMBER": true,
+}
 
 // Index maps the SHA-256 of each concealed 1Password field value to the
-// reference naming that field. It holds hashes, never the values: the
-// enumeration's plaintext lives only inside Inventory's call frame, and
-// what migrate keeps around for the duration of a run is unlinkable
-// digests plus op:// strings.
+// reference naming that field. It holds hashes, never the values: each
+// item's plaintext lives only as long as its decode, and what migrate
+// keeps around for the duration of a run is unlinkable digests plus
+// op:// strings.
 type Index struct {
-	byHash map[[sha256.Size]byte]IndexEntry
-	items  int
+	byHash map[[sha256.Size]byte]indexed
+	// listed is how many items survived the category filter — what
+	// `op item get -` was asked for; read is how many it answered with.
+	listed, read int
+	// incomplete carries op's own first stderr line when it stopped
+	// answering before every listed item arrived (a rate limit, a vault
+	// that went away mid-run). The items that did arrive are indexed —
+	// a partial index links what it can — and the caller reports the
+	// shortfall rather than hiding it.
+	incomplete string
+}
+
+// indexed is an IndexEntry plus the (vault id, item id) it came from, so
+// a value present in several fields settles on the same one every run.
+type indexed struct {
+	IndexEntry
+	vaultID, itemID string
 }
 
 // IndexEntry is one linkable 1Password field. IDRef is the rename-proof
@@ -42,20 +85,45 @@ type IndexEntry struct {
 
 // RefFor returns the entry for a value, matching byte-exact via hash.
 func (ix *Index) RefFor(value []byte) (IndexEntry, bool) {
-	if ix == nil || len(value) < minLinkableValueLen {
+	if ix == nil || len(value) < MinLinkableValueLen {
 		return IndexEntry{}, false
 	}
 	e, ok := ix.byHash[sha256.Sum256(value)]
-	return e, ok
+	return e.IndexEntry, ok
 }
 
-// Items reports how many 1Password items the enumeration covered — the
-// honest "checked N items" number for the mutation log.
+// Items reports how many 1Password items the enumeration actually read —
+// the honest "checked N items" number for the mutation log.
 func (ix *Index) Items() int {
 	if ix == nil {
 		return 0
 	}
-	return ix.items
+	return ix.read
+}
+
+// Listed reports how many items the enumeration asked op for after the
+// category filter. Equal to Items unless op stopped early.
+func (ix *Index) Listed() int {
+	if ix == nil {
+		return 0
+	}
+	return ix.listed
+}
+
+// Incomplete is op's own error line when the enumeration ended before
+// every listed item was read, or "" when it read them all.
+func (ix *Index) Incomplete() string {
+	if ix == nil {
+		return ""
+	}
+	return ix.incomplete
+}
+
+// opListed is the slice of one `op item list --format json` object this
+// package reads: the category, to filter on, and nothing else — the
+// object itself is handed back to `op item get -` verbatim.
+type opListed struct {
+	Category string `json:"category"`
 }
 
 // opItem is the slice of `op item get --format json` output this package
@@ -77,20 +145,28 @@ type opItem struct {
 	} `json:"fields"`
 }
 
-// Inventory enumerates every item the signed-in account can read and
-// returns an Index of its concealed field values, for migrate's
-// link-instead-of-copy dedupe (design/1password-adapter.md). One
-// authenticated enumeration — `op item list` piped into `op item get -`,
-// the CLI's own documented bulk pattern — so the user answers at most one
-// 1Password authorization prompt per run. Only fields op marks CONCEALED
-// are indexed: that is 1Password's own "this is a secret" bit, and it
-// naturally excludes usernames, URLs, and Secure Note bodies.
+// Inventory enumerates the credential-bearing items the signed-in account
+// can read and returns an Index of their concealed field values, for
+// migrate's link-instead-of-copy dedupe (design/1password-adapter.md).
+// One authenticated enumeration — `op item list` piped into
+// `op item get -`, the CLI's own documented bulk pattern — so the user
+// answers at most one 1Password authorization prompt per run. Only fields
+// op marks CONCEALED are indexed: that is 1Password's own "this is a
+// secret" bit, and it naturally excludes usernames, URLs, and Secure Note
+// bodies. (SSH Key items never match either: their private key is type
+// SSHKEY, not CONCEALED, and on-disk key bytes rarely equal op's rendering
+// anyway.)
 //
-// The raw JSON (which carries the values) is wiped before returning;
-// Go strings parsed out of it are unwipable, so this is best-effort
-// hygiene on the same terms as migrate's own file parsing, not a
-// guarantee.
-func (r *Resolver) Inventory() (*Index, error) {
+// The item stream is decoded one object at a time as op emits it, so at
+// most one item's plaintext is resident, and progress (when non-nil) is
+// told after each — (read, listed) — so a long enumeration can show a
+// counter instead of looking hung. The two op calls carry different
+// bounds: the list waits on 1Password's unlock dialog, the same class of
+// wait as jit's own Touch ID, and gets the resolve timeout; the get is
+// bounded per item — an idle watchdog that trips when no item has arrived
+// for that long, so a large account is never cut off for merely being
+// large while a hung op is still killed.
+func (r *Resolver) Inventory(progress func(read, listed int)) (*Index, error) {
 	bin, err := r.bin()
 	if err != nil {
 		return nil, err
@@ -100,96 +176,203 @@ func (r *Resolver) Inventory() (*Index, error) {
 	if timeout <= 0 {
 		timeout = resolveTimeout
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
+	listCtx, cancelList := context.WithTimeout(context.Background(), timeout)
+	defer cancelList()
 
-	list, err := runOp(ctx, bin, nil, "item", "list", "--format", "json")
+	list, err := runOp(listCtx, bin, nil, "item", "list", "--format", "json")
 	if err != nil {
 		return nil, fmt.Errorf("op item list failed: %w", err)
 	}
-	defer wipeBytes(list)
-
-	// An account with zero items lists `[]`; don't hand `op item get -`
-	// an empty worklist to choke on.
-	var listed []json.RawMessage
-	if err := json.Unmarshal(bytes.TrimSpace(list), &listed); err != nil {
-		return nil, fmt.Errorf("op item list output not understood: %v", err)
-	}
-	if len(listed) == 0 {
-		return &Index{byHash: map[[sha256.Size]byte]IndexEntry{}}, nil
-	}
-
-	raw, err := runOp(ctx, bin, list, "item", "get", "-", "--format", "json")
-	if err != nil {
-		return nil, fmt.Errorf("op item get failed: %w", err)
-	}
-	defer wipeBytes(raw)
-
-	items, err := parseItems(raw)
+	worklist, listed, err := filterListed(list)
 	if err != nil {
 		return nil, err
 	}
+	// An account with zero (kept) items: don't hand `op item get -` an
+	// empty worklist to choke on.
+	ix := &Index{byHash: map[[sha256.Size]byte]indexed{}, listed: listed}
+	if listed == 0 {
+		return ix, nil
+	}
+	if progress != nil {
+		progress(0, listed)
+	}
 
-	// Deterministic first-wins for a value present in several fields: the
-	// choice is cosmetic (same value, same secret), but it must not change
-	// between runs of the same vault state.
-	sort.Slice(items, func(i, j int) bool {
-		if items[i].Vault.ID != items[j].Vault.ID {
-			return items[i].Vault.ID < items[j].Vault.ID
-		}
-		return items[i].ID < items[j].ID
-	})
-
-	ix := &Index{byHash: map[[sha256.Size]byte]IndexEntry{}, items: len(items)}
-	for _, it := range items {
-		for _, f := range it.Fields {
-			if f.Type != "CONCEALED" || len(f.Value) < minLinkableValueLen {
-				continue
-			}
-			if it.Vault.ID == "" || it.ID == "" || f.ID == "" {
-				continue // no rename-proof reference to build; skip rather than store a fragile one
-			}
-			sum := sha256.Sum256([]byte(f.Value))
-			if _, taken := ix.byHash[sum]; taken {
-				continue
-			}
-			name := f.Reference
-			if name == "" {
-				name = fmt.Sprintf("op://%s/%s/%s", it.Vault.Name, it.Title, f.Label)
-			}
-			ix.byHash[sum] = IndexEntry{
-				IDRef:   fmt.Sprintf("op://%s/%s/%s", it.Vault.ID, it.ID, f.ID),
-				NameRef: name,
-			}
-		}
+	if err := r.streamItems(bin, worklist, timeout, ix, progress); err != nil {
+		return nil, err
 	}
 	return ix, nil
 }
 
-// parseItems accepts both shapes `op item get - --format json` emits: a
-// JSON array, or a concatenated stream of objects (one per piped item).
-func parseItems(raw []byte) ([]opItem, error) {
-	trimmed := bytes.TrimSpace(raw)
-	if len(trimmed) == 0 {
-		return nil, nil
+// filterListed parses `op item list` output, drops skipCategories, and
+// returns the kept objects re-encoded as the JSON array `op item get -`
+// accepts (each object verbatim, so op keeps the vault it already knows
+// the item lives in), plus how many were kept. An object with no
+// category key is kept: the filter only ever removes what it can name.
+func filterListed(list []byte) ([]byte, int, error) {
+	var listed []json.RawMessage
+	if err := json.Unmarshal(bytes.TrimSpace(list), &listed); err != nil {
+		return nil, 0, fmt.Errorf("op item list output not understood: %v", err)
 	}
-	if trimmed[0] == '[' {
-		var items []opItem
-		if err := json.Unmarshal(trimmed, &items); err != nil {
-			return nil, fmt.Errorf("op item get output not understood: %v", err)
+	kept := make([]json.RawMessage, 0, len(listed))
+	for _, raw := range listed {
+		var l opListed
+		if err := json.Unmarshal(raw, &l); err == nil && skipCategories[l.Category] {
+			continue
 		}
-		return items, nil
+		kept = append(kept, raw)
 	}
-	var items []opItem
-	dec := json.NewDecoder(bytes.NewReader(trimmed))
+	if len(kept) == 0 {
+		return nil, 0, nil
+	}
+	worklist, err := json.Marshal(kept)
+	if err != nil {
+		return nil, 0, fmt.Errorf("op item list output not understood: %v", err)
+	}
+	return worklist, len(kept), nil
+}
+
+// streamItems runs `op item get -` over worklist and indexes each item as
+// it arrives. The idle watchdog restarts on every decoded item; when it
+// trips, or op exits non-zero, whatever was read stays indexed and the
+// shortfall is recorded on ix — unless nothing at all was read, which is
+// a failed enumeration and returns the error.
+func (r *Resolver) streamItems(bin string, worklist []byte, idle time.Duration, ix *Index, progress func(read, listed int)) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var stalled atomic.Bool
+	watchdog := time.AfterFunc(idle, func() { stalled.Store(true); cancel() })
+	defer watchdog.Stop()
+
+	var stderr bytes.Buffer
+	cmd := exec.CommandContext(ctx, bin, "item", "get", "-", "--format", "json") // #nosec G204 -- bin is signature-verified by bin(); args are fixed literals
+	cmd.Stdin = bytes.NewReader(worklist)
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = time.Second
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("op item get failed: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("op item get failed: %v", err)
+	}
+
+	decodeErr := decodeItems(stdout, func(it opItem) {
+		watchdog.Reset(idle)
+		ix.add(it)
+		if progress != nil {
+			progress(ix.read, ix.listed)
+		}
+	})
+	// Drain so op never blocks on a full pipe after a decode error, then
+	// let Wait collect the exit status (and, past WaitDelay, the pipe).
+	_, _ = io.Copy(io.Discard, stdout)
+	waitErr := cmd.Wait()
+
+	if waitErr == nil && decodeErr == nil {
+		return nil
+	}
+	var detail string
+	switch {
+	case stalled.Load():
+		detail = fmt.Sprintf("stalled: no item arrived for %s (waiting for a 1Password unlock that never came?)", idle)
+	case decodeErr != nil && waitErr == nil:
+		detail = fmt.Sprintf("op item get output not understood: %v", decodeErr)
+	default:
+		detail = firstLine(stderr.String())
+		if detail == "" {
+			detail = waitErr.Error()
+		}
+	}
+	if ix.read == 0 {
+		return fmt.Errorf("op item get failed: %s", detail)
+	}
+	ix.incomplete = detail
+	return nil
+}
+
+// decodeItems accepts both shapes `op item get - --format json` emits — a
+// JSON array, or a concatenated stream of objects (one per piped item) —
+// and calls each for every item as soon as it is complete.
+func decodeItems(r io.Reader, each func(opItem)) error {
+	br := bufio.NewReader(r)
+	first, err := peekNonSpace(br)
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil // nothing at all: op said so on stderr
+		}
+		return err
+	}
+	dec := json.NewDecoder(br)
+	if first == '[' {
+		if _, err := dec.Token(); err != nil {
+			return err
+		}
+	}
 	for dec.More() {
 		var it opItem
 		if err := dec.Decode(&it); err != nil {
-			return nil, fmt.Errorf("op item get output not understood: %v", err)
+			return err
 		}
-		items = append(items, it)
+		each(it)
 	}
-	return items, nil
+	return nil
+}
+
+// peekNonSpace returns the first non-whitespace byte without consuming it.
+func peekNonSpace(br *bufio.Reader) (byte, error) {
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			return 0, err
+		}
+		switch b {
+		case ' ', '\n', '\r', '\t':
+			continue
+		}
+		return b, br.UnreadByte()
+	}
+}
+
+// add indexes one item's concealed fields. A value present in several
+// fields settles on the lowest (vault id, item id, first field) — the
+// choice is cosmetic (same value, same secret), but it must not change
+// between runs of the same vault state, and the stream's own order is
+// op's to change.
+func (ix *Index) add(it opItem) {
+	ix.read++
+	for _, f := range it.Fields {
+		if f.Type != "CONCEALED" || len(f.Value) < MinLinkableValueLen {
+			continue
+		}
+		if it.Vault.ID == "" || it.ID == "" || f.ID == "" {
+			continue // no rename-proof reference to build; skip rather than store a fragile one
+		}
+		sum := sha256.Sum256([]byte(f.Value))
+		if held, taken := ix.byHash[sum]; taken && !earlier(it, held) {
+			continue
+		}
+		name := f.Reference
+		if name == "" {
+			name = fmt.Sprintf("op://%s/%s/%s", it.Vault.Name, it.Title, f.Label)
+		}
+		ix.byHash[sum] = indexed{
+			IndexEntry: IndexEntry{
+				IDRef:   fmt.Sprintf("op://%s/%s/%s", it.Vault.ID, it.ID, f.ID),
+				NameRef: name,
+			},
+			vaultID: it.Vault.ID,
+			itemID:  it.ID,
+		}
+	}
+}
+
+// earlier reports whether it sorts before the item held holds — strictly,
+// so a second field of the same item never displaces the first.
+func earlier(it opItem, held indexed) bool {
+	if it.Vault.ID != held.vaultID {
+		return it.Vault.ID < held.vaultID
+	}
+	return it.ID < held.itemID
 }
 
 // runOp executes one op invocation under ctx with stdin (nil for none),
@@ -208,7 +391,6 @@ func runOp(ctx context.Context, bin string, stdin []byte, args ...string) ([]byt
 	// bounding.
 	cmd.WaitDelay = time.Second
 	if err := cmd.Run(); err != nil {
-		wipeBytes(stdout.Bytes())
 		if ctx.Err() == context.DeadlineExceeded {
 			return nil, fmt.Errorf("timed out (waiting for a 1Password unlock that never came?)")
 		}
@@ -218,12 +400,4 @@ func runOp(ctx context.Context, bin string, stdin []byte, args ...string) ([]byt
 		return nil, err
 	}
 	return stdout.Bytes(), nil
-}
-
-// wipeBytes zeroes b — best-effort plaintext hygiene for buffers that
-// carried field values.
-func wipeBytes(b []byte) {
-	for i := range b {
-		b[i] = 0
-	}
 }

--- a/internal/onepassword/inventory.go
+++ b/internal/onepassword/inventory.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"strings"
 	"sync/atomic"
 	"time"
 )
@@ -145,27 +146,33 @@ type opItem struct {
 	} `json:"fields"`
 }
 
-// Inventory enumerates the credential-bearing items the signed-in account
-// can read and returns an Index of their concealed field values, for
-// migrate's link-instead-of-copy dedupe (design/1password-adapter.md).
-// One authenticated enumeration — `op item list` piped into
+// Inventory enumerates the credential-bearing items the signed-in
+// accounts can read and returns an Index of their concealed field values,
+// for migrate's link-instead-of-copy dedupe (design/1password-adapter.md).
+// Per account, one authenticated enumeration — `op item list` piped into
 // `op item get -`, the CLI's own documented bulk pattern — so the user
-// answers at most one 1Password authorization prompt per run. Only fields
-// op marks CONCEALED are indexed: that is 1Password's own "this is a
-// secret" bit, and it naturally excludes usernames, URLs, and Secure Note
-// bodies. (SSH Key items never match either: their private key is type
-// SSHKEY, not CONCEALED, and on-disk key bytes rarely equal op's rendering
-// anyway.)
+// answers at most one 1Password authorization prompt per account per
+// run. Every signed-in account is covered unless OP_ACCOUNT names one
+// (enumerationAccounts), and each indexed reference is pinned to the
+// account it came from (account.go), so the link resolves there whatever
+// op's default account is later. Only fields op marks CONCEALED are
+// indexed: that is 1Password's own "this is a secret" bit, and it
+// naturally excludes usernames, URLs, and Secure Note bodies. (SSH Key
+// items never match either: their private key is type SSHKEY, not
+// CONCEALED, and on-disk key bytes rarely equal op's rendering anyway.)
 //
 // The item stream is decoded one object at a time as op emits it, so at
 // most one item's plaintext is resident, and progress (when non-nil) is
-// told after each — (read, listed) — so a long enumeration can show a
-// counter instead of looking hung. The two op calls carry different
-// bounds: the list waits on 1Password's unlock dialog, the same class of
-// wait as jit's own Touch ID, and gets the resolve timeout; the get is
-// bounded per item — an idle watchdog that trips when no item has arrived
-// for that long, so a large account is never cut off for merely being
-// large while a hung op is still killed.
+// told after each — (read, listed), cumulative across accounts — so a
+// long enumeration can show a counter instead of looking hung. The two
+// op calls carry different bounds: the list waits on 1Password's unlock
+// dialog, the same class of wait as jit's own Touch ID, and gets the
+// resolve timeout; the get is bounded per item — an idle watchdog that
+// trips when no item has arrived for that long, so a large account is
+// never cut off for merely being large while a hung op is still killed.
+// With several accounts, one that fails (not authorized, gone) is
+// reported on the index and the others still count; only every account
+// failing is a failed enumeration.
 func (r *Resolver) Inventory(progress func(read, listed int)) (*Index, error) {
 	bin, err := r.bin()
 	if err != nil {
@@ -176,31 +183,119 @@ func (r *Resolver) Inventory(progress func(read, listed int)) (*Index, error) {
 	if timeout <= 0 {
 		timeout = resolveTimeout
 	}
-	listCtx, cancelList := context.WithTimeout(context.Background(), timeout)
-	defer cancelList()
 
-	list, err := runOp(listCtx, bin, nil, "item", "list", "--format", "json")
-	if err != nil {
-		return nil, fmt.Errorf("op item list failed: %w", err)
+	// One pass per account; a nil account set is one unpinned pass under
+	// op's own default (no accounts listed, or OP_ACCOUNT matched none).
+	passes := []Account{{}}
+	if accounts := r.enumerationAccounts(); len(accounts) > 0 {
+		passes = accounts
 	}
-	worklist, listed, err := filterListed(list)
-	if err != nil {
-		return nil, err
+
+	type pass struct {
+		account  Account
+		worklist []byte
+		listed   int
+	}
+	var work []pass
+	var shortfalls []string
+	var firstErr error
+	for _, a := range passes {
+		listCtx, cancelList := context.WithTimeout(context.Background(), timeout)
+		list, err := runOp(listCtx, bin, nil, accountArgs(a, "item", "list", "--format", "json")...)
+		cancelList()
+		if err != nil {
+			err = fmt.Errorf("op item list failed: %w", err)
+			if len(passes) == 1 {
+				return nil, err
+			}
+			shortfalls = append(shortfalls, accountLabel(a)+": "+err.Error())
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		worklist, listed, err := filterListed(list)
+		if err != nil {
+			if len(passes) == 1 {
+				return nil, err
+			}
+			shortfalls = append(shortfalls, accountLabel(a)+": "+err.Error())
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		work = append(work, pass{account: a, worklist: worklist, listed: listed})
+	}
+	if len(work) == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+
+	ix := &Index{byHash: map[[sha256.Size]byte]indexed{}}
+	for _, p := range work {
+		ix.listed += p.listed
 	}
 	// An account with zero (kept) items: don't hand `op item get -` an
 	// empty worklist to choke on.
-	ix := &Index{byHash: map[[sha256.Size]byte]indexed{}, listed: listed}
-	if listed == 0 {
+	if ix.listed == 0 {
+		ix.incomplete = strings.Join(shortfalls, "; ")
 		return ix, nil
 	}
 	if progress != nil {
-		progress(0, listed)
+		progress(0, ix.listed)
 	}
 
-	if err := r.streamItems(bin, worklist, timeout, ix, progress); err != nil {
-		return nil, err
+	streamed := 0
+	for _, p := range work {
+		if p.listed == 0 {
+			continue
+		}
+		if err := r.streamItems(bin, p.account, p.worklist, timeout, ix, progress); err != nil {
+			if len(work) == 1 {
+				return nil, err
+			}
+			shortfalls = append(shortfalls, accountLabel(p.account)+": "+err.Error())
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		streamed++
+	}
+	if streamed == 0 && firstErr != nil {
+		return nil, firstErr
+	}
+	// Whole-account shortfalls first, then what the streams recorded.
+	if len(shortfalls) > 0 {
+		if ix.incomplete != "" {
+			shortfalls = append(shortfalls, ix.incomplete)
+		}
+		ix.incomplete = strings.Join(shortfalls, "; ")
 	}
 	return ix, nil
+}
+
+// accountArgs prefixes op arguments with --account for a real account and
+// leaves them alone for the zero Account (op's own default).
+func accountArgs(a Account, args ...string) []string {
+	if a.ID == "" {
+		return args
+	}
+	return append([]string{"--account", a.ID}, args...)
+}
+
+// accountLabel names an account in a shortfall note the way the user
+// knows it — the sign-in address — never by uuid alone.
+func accountLabel(a Account) string {
+	switch {
+	case a.URL != "":
+		return a.URL
+	case a.Shorthand != "":
+		return a.Shorthand
+	case a.ID != "":
+		return a.ID
+	}
+	return "default account"
 }
 
 // filterListed parses `op item list` output, drops skipCategories, and
@@ -236,7 +331,7 @@ func filterListed(list []byte) ([]byte, int, error) {
 // trips, or op exits non-zero, whatever was read stays indexed and the
 // shortfall is recorded on ix — unless nothing at all was read, which is
 // a failed enumeration and returns the error.
-func (r *Resolver) streamItems(bin string, worklist []byte, idle time.Duration, ix *Index, progress func(read, listed int)) error {
+func (r *Resolver) streamItems(bin string, account Account, worklist []byte, idle time.Duration, ix *Index, progress func(read, listed int)) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var stalled atomic.Bool
@@ -244,7 +339,7 @@ func (r *Resolver) streamItems(bin string, worklist []byte, idle time.Duration, 
 	defer watchdog.Stop()
 
 	var stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, bin, "item", "get", "-", "--format", "json") // #nosec G204 -- bin is signature-verified by bin(); args are fixed literals
+	cmd := exec.CommandContext(ctx, bin, accountArgs(account, "item", "get", "-", "--format", "json")...) // #nosec G204 -- bin is signature-verified by bin(); args are fixed literals plus op's own account id
 	cmd.Stdin = bytes.NewReader(worklist)
 	cmd.Stderr = &stderr
 	cmd.WaitDelay = time.Second
@@ -256,9 +351,11 @@ func (r *Resolver) streamItems(bin string, worklist []byte, idle time.Duration, 
 		return fmt.Errorf("op item get failed: %v", err)
 	}
 
+	read := 0
 	decodeErr := decodeItems(stdout, func(it opItem) {
 		watchdog.Reset(idle)
-		ix.add(it)
+		read++
+		ix.add(it, account.ID)
 		if progress != nil {
 			progress(ix.read, ix.listed)
 		}
@@ -283,10 +380,16 @@ func (r *Resolver) streamItems(bin string, worklist []byte, idle time.Duration, 
 			detail = waitErr.Error()
 		}
 	}
-	if ix.read == 0 {
+	if read == 0 {
 		return fmt.Errorf("op item get failed: %s", detail)
 	}
-	ix.incomplete = detail
+	if ix.incomplete != "" {
+		ix.incomplete += "; "
+	}
+	if account.ID != "" {
+		detail = accountLabel(account) + ": " + detail
+	}
+	ix.incomplete += detail
 	return nil
 }
 
@@ -333,12 +436,13 @@ func peekNonSpace(br *bufio.Reader) (byte, error) {
 	}
 }
 
-// add indexes one item's concealed fields. A value present in several
-// fields settles on the lowest (vault id, item id, first field) — the
-// choice is cosmetic (same value, same secret), but it must not change
-// between runs of the same vault state, and the stream's own order is
-// op's to change.
-func (ix *Index) add(it opItem) {
+// add indexes one item's concealed fields, pinning each reference to
+// accountID ("" for an unpinned pass). A value present in several fields
+// settles on the lowest (vault id, item id, first field) — the choice is
+// cosmetic (same value, same secret), but it must not change between
+// runs of the same vault state, and the stream's own order is op's to
+// change.
+func (ix *Index) add(it opItem, accountID string) {
 	ix.read++
 	for _, f := range it.Fields {
 		if f.Type != "CONCEALED" || len(f.Value) < MinLinkableValueLen {
@@ -357,7 +461,7 @@ func (ix *Index) add(it opItem) {
 		}
 		ix.byHash[sum] = indexed{
 			IndexEntry: IndexEntry{
-				IDRef:   fmt.Sprintf("op://%s/%s/%s", it.Vault.ID, it.ID, f.ID),
+				IDRef:   PinAccount(fmt.Sprintf("op://%s/%s/%s", it.Vault.ID, it.ID, f.ID), accountID),
 				NameRef: name,
 			},
 			vaultID: it.Vault.ID,

--- a/internal/onepassword/inventory_test.go
+++ b/internal/onepassword/inventory_test.go
@@ -5,20 +5,30 @@ package onepassword
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeOpInventory builds a fake op that answers `item list` with listJSON
-// and `item get -` with getJSON, failing loudly on anything else. When
-// getJSON is empty, an `item get` invocation drops a marker file so the
-// test can assert it never ran.
+// and `item get -` with getJSON, failing loudly on anything else. What
+// `item get -` received on stdin is written to getStdin, so a test can
+// assert which items were asked for. When getJSON is empty, an `item get`
+// invocation drops a marker file instead so the test can assert it never
+// ran.
 func fakeOpInventory(t *testing.T, listJSON, getJSON string) (path, getMarker string) {
+	path, getMarker, _ = fakeOpInventoryStdin(t, listJSON, getJSON)
+	return path, getMarker
+}
+
+func fakeOpInventoryStdin(t *testing.T, listJSON, getJSON string) (path, getMarker, getStdin string) {
 	t.Helper()
 	dir := t.TempDir()
 	getMarker = filepath.Join(dir, "get-ran")
+	getStdin = filepath.Join(dir, "get-stdin")
 	script := `
 case "$1 $2" in
 "item list")
@@ -34,7 +44,7 @@ echo "item get must not run" >&2
 exit 3
 `
 	} else {
-		script += `cat >/dev/null
+		script += `cat >` + getStdin + `
 cat <<'JSONEOF'
 ` + getJSON + `
 JSONEOF
@@ -47,7 +57,7 @@ exit 2
 ;;
 esac
 `
-	return fakeOp(t, script), getMarker
+	return fakeOp(t, script), getMarker, getStdin
 }
 
 const inventoryListTwo = `[{"id":"item-b"},{"id":"item-a"}]`
@@ -78,7 +88,7 @@ const inventoryGetStream = `{
 
 func TestInventoryIndexesConcealedFieldsOnly(t *testing.T) {
 	bin, _ := fakeOpInventory(t, inventoryListTwo, inventoryGetStream)
-	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
 	if err != nil {
 		t.Fatalf("Inventory: %v", err)
 	}
@@ -130,7 +140,7 @@ func TestInventoryFirstWinsIsDeterministic(t *testing.T) {
   "fields": [{"id": "f1", "type": "CONCEALED", "label": "token", "value": "shared-value-12345"}]
 }`
 	bin, _ := fakeOpInventory(t, `[{"id":"item-z"},{"id":"item-a"}]`, get)
-	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
 	if err != nil {
 		t.Fatalf("Inventory: %v", err)
 	}
@@ -151,7 +161,7 @@ func TestInventoryAcceptsArrayOutput(t *testing.T) {
   "fields": [{"id": "f1", "type": "CONCEALED", "label": "token", "value": "ghp_abcdefgh"}]
 }]`
 	bin, _ := fakeOpInventory(t, `[{"id":"item-a"}]`, get)
-	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
 	if err != nil {
 		t.Fatalf("Inventory: %v", err)
 	}
@@ -162,7 +172,7 @@ func TestInventoryAcceptsArrayOutput(t *testing.T) {
 
 func TestInventoryEmptyVaultSkipsItemGet(t *testing.T) {
 	bin, marker := fakeOpInventory(t, `[]`, "")
-	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
 	if err != nil {
 		t.Fatalf("Inventory on empty vault: %v", err)
 	}
@@ -179,7 +189,7 @@ func TestInventorySurfacesSignedOutError(t *testing.T) {
 echo '[ERROR] 2026/08/17 account is not signed in' >&2
 exit 1
 `)
-	_, err := (&Resolver{path: bin, verify: noVerify}).Inventory()
+	_, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
 	if err == nil {
 		t.Fatal("Inventory succeeded against a signed-out op")
 	}
@@ -191,11 +201,169 @@ exit 1
 func TestInventoryVerifyFailureIsClosedBeforeExec(t *testing.T) {
 	bin := fakeOp(t, `touch "$0.ran"; exit 0`)
 	failVerify := func(string) error { return errors.New("signature rejected") }
-	_, err := (&Resolver{path: bin, verify: failVerify}).Inventory()
+	_, err := (&Resolver{path: bin, verify: failVerify}).Inventory(nil)
 	if err == nil || !strings.Contains(err.Error(), "signature rejected") {
 		t.Fatalf("err = %v, want the verification failure", err)
 	}
 	if _, statErr := os.Stat(bin + ".ran"); statErr == nil {
 		t.Error("unverified binary was executed")
+	}
+}
+
+func TestInventorySkipsPIICategoriesBeforeFetching(t *testing.T) {
+	list := `[{"id":"card","category":"CREDIT_CARD"},{"id":"login","category":"LOGIN"},` +
+		`{"id":"bank","category":"BANK_ACCOUNT"},{"id":"nocat"},{"id":"api","category":"API_CREDENTIAL"}]`
+	get := `{"id":"login","title":"L","vault":{"id":"v","name":"P"},"fields":[{"id":"f","type":"CONCEALED","label":"password","value":"long-enough-value"}]}`
+	bin, _, stdin := fakeOpInventoryStdin(t, list, get)
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	got, err := os.ReadFile(stdin) // #nosec G304 -- test temp file
+	if err != nil {
+		t.Fatalf("item get received no stdin: %v", err)
+	}
+	for _, id := range []string{"card", "bank"} {
+		if strings.Contains(string(got), `"`+id+`"`) {
+			t.Errorf("PII item %q was handed to op item get:\n%s", id, got)
+		}
+	}
+	for _, id := range []string{"login", "nocat", "api"} {
+		if !strings.Contains(string(got), `"`+id+`"`) {
+			t.Errorf("credential item %q was filtered out:\n%s", id, got)
+		}
+	}
+	if ix.Listed() != 3 {
+		t.Errorf("Listed() = %d, want 3 (the kept items)", ix.Listed())
+	}
+}
+
+func TestInventoryAllPIIAccountSkipsItemGet(t *testing.T) {
+	bin, marker := fakeOpInventory(t, `[{"id":"card","category":"CREDIT_CARD"}]`, "")
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Listed() != 0 || ix.Items() != 0 {
+		t.Errorf("Listed/Items = %d/%d, want 0/0", ix.Listed(), ix.Items())
+	}
+	if _, err := os.Stat(marker); err == nil {
+		t.Error("op item get ran for a worklist the filter emptied")
+	}
+}
+
+func TestInventoryReportsProgressPerItem(t *testing.T) {
+	bin, _ := fakeOpInventory(t, inventoryListTwo, inventoryGetStream)
+	var seen []string
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(func(read, listed int) {
+		seen = append(seen, fmt.Sprintf("%d/%d", read, listed))
+	})
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	want := "0/2 1/2 2/2"
+	if got := strings.Join(seen, " "); got != want {
+		t.Errorf("progress = %q, want %q", got, want)
+	}
+	if ix.Items() != 2 || ix.Listed() != 2 || ix.Incomplete() != "" {
+		t.Errorf("Items/Listed/Incomplete = %d/%d/%q, want 2/2/\"\"", ix.Items(), ix.Listed(), ix.Incomplete())
+	}
+}
+
+const inventoryItemTemplate = `{"id":"%s","title":"T","vault":{"id":"v","name":"P"},"fields":[{"id":"f","type":"CONCEALED","label":"password","value":"value-of-%s"}]}`
+
+// A stream that keeps delivering must never trip the bound, however long
+// it runs in total: four items 400ms apart under a 1s idle watchdog
+// (1.6s total) all arrive.
+func TestInventoryIdleWatchdogIsPerItemNotTotal(t *testing.T) {
+	get := ""
+	for _, id := range []string{"a", "b", "c", "d"} {
+		get += fmt.Sprintf(inventoryItemTemplate, id, id) + "\n"
+	}
+	bin := fakeOp(t, `
+case "$1 $2" in
+"item list") echo '[{"id":"a"},{"id":"b"},{"id":"c"},{"id":"d"}]' ;;
+"item get")
+cat >/dev/null
+while IFS= read -r line; do printf '%s\n' "$line"; sleep 0.4; done <<'JSONEOF'
+`+get+`JSONEOF
+;;
+esac
+`)
+	ix, err := (&Resolver{path: bin, verify: noVerify, timeout: time.Second}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Items() != 4 || ix.Incomplete() != "" {
+		t.Errorf("Items/Incomplete = %d/%q, want 4 read with nothing incomplete", ix.Items(), ix.Incomplete())
+	}
+}
+
+// One item, then silence: the watchdog kills op, the item that arrived
+// stays indexed, and the shortfall is on the index — not an error.
+func TestInventoryStallKeepsPartialIndex(t *testing.T) {
+	bin := fakeOp(t, `
+case "$1 $2" in
+"item list") echo '[{"id":"a"},{"id":"b"}]' ;;
+"item get")
+cat >/dev/null
+echo '`+fmt.Sprintf(inventoryItemTemplate, "a", "a")+`'
+sleep 30
+;;
+esac
+`)
+	start := time.Now()
+	ix, err := (&Resolver{path: bin, verify: noVerify, timeout: time.Second}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed > 10*time.Second {
+		t.Errorf("Inventory took %s; the watchdog did not bound the stall", elapsed)
+	}
+	if _, ok := ix.RefFor([]byte("value-of-a")); !ok {
+		t.Error("the item that arrived before the stall was not indexed")
+	}
+	if ix.Items() != 1 || ix.Listed() != 2 {
+		t.Errorf("Items/Listed = %d/%d, want 1/2", ix.Items(), ix.Listed())
+	}
+	if !strings.Contains(ix.Incomplete(), "stalled") {
+		t.Errorf("Incomplete() = %q, want the stall named", ix.Incomplete())
+	}
+}
+
+// op answering some items then exiting non-zero (a rate limit, a vault
+// gone mid-run): partial index, op's own line as the shortfall.
+func TestInventoryEarlyExitKeepsPartialIndex(t *testing.T) {
+	bin := fakeOp(t, `
+case "$1 $2" in
+"item list") echo '[{"id":"a"},{"id":"b"}]' ;;
+"item get")
+cat >/dev/null
+echo '`+fmt.Sprintf(inventoryItemTemplate, "a", "a")+`'
+echo '[ERROR] 2026/09/05 rate limit exceeded' >&2
+exit 1
+;;
+esac
+`)
+	ix, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err != nil {
+		t.Fatalf("Inventory: %v", err)
+	}
+	if ix.Items() != 1 || !strings.Contains(ix.Incomplete(), "rate limit exceeded") {
+		t.Errorf("Items/Incomplete = %d/%q, want 1 read and op's own error line", ix.Items(), ix.Incomplete())
+	}
+}
+
+// Nothing read at all before op fails is a failed enumeration, as before.
+func TestInventoryNoItemsThenFailureIsAnError(t *testing.T) {
+	bin := fakeOp(t, `
+case "$1 $2" in
+"item list") echo '[{"id":"a"}]' ;;
+"item get") cat >/dev/null; echo '[ERROR] vault not found' >&2; exit 1 ;;
+esac
+`)
+	_, err := (&Resolver{path: bin, verify: noVerify}).Inventory(nil)
+	if err == nil || !strings.Contains(err.Error(), "vault not found") {
+		t.Fatalf("err = %v, want op's own error", err)
 	}
 }

--- a/internal/onepassword/onepassword.go
+++ b/internal/onepassword/onepassword.go
@@ -80,7 +80,11 @@ func New() *Resolver {
 
 // ResolveRef resolves one op:// secret reference to the exact bytes of
 // the field it names, via `op read -n` (no trailing newline appended, so
-// injection stays byte-exact).
+// injection stays byte-exact). A reference pinned to an account
+// (account.go) resolves in that account, whatever op's default is today;
+// an unpinned one resolves under op's default, and when that fails on a
+// machine with several accounts the error says so, because that is the
+// likely cause.
 func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 	if err := ValidateRef(ref); err != nil {
 		return nil, err
@@ -89,6 +93,8 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	bare, account := SplitAccount(ref)
+	args := accountArgs(Account{ID: account}, "read", "-n", bare)
 
 	timeout := r.timeout
 	if timeout <= 0 {
@@ -98,7 +104,7 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 	defer cancel()
 
 	var stdout, stderr bytes.Buffer
-	cmd := exec.CommandContext(ctx, bin, "read", "-n", ref) // #nosec G204 -- bin is signature-verified above; ref is validated op:// syntax
+	cmd := exec.CommandContext(ctx, bin, args...) // #nosec G204 -- bin is signature-verified above; ref is validated op:// syntax, account is op's own id
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	// Without WaitDelay, a child op leaves behind (its cache daemon, a
@@ -112,6 +118,11 @@ func (r *Resolver) ResolveRef(ref string) ([]byte, error) {
 		detail := firstLine(stderr.String())
 		if detail == "" {
 			detail = err.Error()
+		}
+		if account == "" {
+			if accounts, aerr := r.Accounts(); aerr == nil && len(accounts) > 1 {
+				return nil, fmt.Errorf("op read failed: %s (op is signed in to %d accounts and this link names none; `jit vault link` it again to pin one)", detail, len(accounts))
+			}
 		}
 		return nil, fmt.Errorf("op read failed: %s", detail)
 	}


### PR DESCRIPTION
## Summary

Follow-up to #90. That PR stopped a refresh-only run from enumerating 1Password at all; this one fixes the enumeration itself for runs that do vault values.

- **Lazy.** The enumeration runs on the first value that could actually link (8+ bytes, not already `op://`). A run with only short or verbatim-reference values never contacts op.
- **Scoped.** `op item list` output is filtered client-side on `category` before piping to `op item get -`: Credit Card, Bank Account, Identity, Passport, Driver License, SSN, Medical Record, Membership, Reward Program, Outdoor License are skipped. Their CONCEALED fields are CVVs and PINs (verified with `op item template get`), which should never pass through jit to be hashed. Deny-list, so new categories are enumerated by default.
- **Streamed.** Items are decoded one at a time off op's stdout (one item's plaintext resident, not the whole account, and no unwiped `bytes.Buffer` growth copies). The get phase gets an idle-per-item watchdog instead of sharing the list call's 2-minute unlock budget. A partial read is kept and the shortfall reported with op's own error line.
- **Visible.** Spinner with a `37/174 items` counter on stderr while it runs; the `[1Password]` block now prints whenever the check ran, including `0 of N linked · M items checked`. Silence only when op was never consulted.
- **Duplicate index no longer resolves through op.** `buildVaultValueIndex` and `noteDuplicateValues` use `GetStored` and key linked entries by reference. Before, every linked secret cost one `op read` per env/MCP migration.

`design/1password-adapter.md` records the decisions.

## Test plan

- [x] `go test -race -timeout 2m ./...` green (two `internal/guard` hook tests failed once under full parallel load and pass alone, as their own message predicts)
- [x] gofmt, go vet, go mod tidy clean; docs-gen produces no drift (no flag changes)
- [x] New onepassword tests: PII filter reaches `op item get -` stdin, progress ticks per item, idle watchdog is per-item not total, stall and early-exit keep a partial index, zero-items-then-failure is still an error
- [x] New cli tests: hook is lazy (no enumeration for sub-floor or verbatim values, exactly one for a run), failed enumeration still links verbatim refs, tracker line appears, result block for nothing-matched and for a shortfall, duplicate index never calls the resolver
- [x] Live, personal account (`OP_ACCOUNT=my.1password.com`), dev build, three throwaway `.env` projects, all undone and removed afterwards:
  - no-match run: spinner counted `0/172 … 172/172 items`, settled to `✓ checked 1Password: 172 items`, block read `1 of 3 linked · 172 items checked` (the verbatim `op://` value)
  - match run against a throwaway `API Credential` item: `matchproj/MATCH_TOKEN → op://Personal/jit-live-test/credential`, 173 items checked; item deleted after
  - lazy run (short values + one verbatim reference): no `checking 1Password` line at all, block header `1Password not consulted`, and the by-reference duplicate note fired for the reference already stored under the first project — with no `op read`
  - the lazy run exposed one bug, fixed in the second commit: verbatim links were unreported when no enumeration ran

Two live observations, both fixed in the third commit:

- **Account pinning.** op resolves a reference against one account (`--account`, else `OP_ACCOUNT`, else most recent sign-in). With a personal and a Blockaid account signed in, a link made under one failed with "isn't a vault in this account" under the other. Links jit creates now carry `?account=<account uuid>` in the stored reference (op ignores the parameter, verified); the resolver strips it and passes `--account`. Migrate enumerates every signed-in account unless `OP_ACCOUNT` names one, pinning each match; `jit vault link` tries each account until the reference resolves and pins that one. Verified live: link created with op defaulting to the other account, stored pinned, resolved on `vault get` with no `OP_ACCOUNT`.
- **Touch ID notice once per process.** The per-RPC notifier fired on the slow RPCs after the single real unlock (audit log: one unlock, three to four lines).

Live, both accounts (`OP_ACCOUNT` unset, personal + Blockaid): the counter ran to `469/469 items`, the throwaway personal-account value linked, and the "Touch ID required" line printed exactly once. A migrate-created link read back with `OP_ACCOUNT` unset (op defaulting to the other account) came out stored as `op://<vault id>/<item id>/credential?account=<personal account uuid>` and resolved to the right value.

