### PR TITLE
migrate: claim cargo and Streamlit as real categories

### DIFF
--- a/docs/audit/index.md
+++ b/docs/audit/index.md
@@ -75,7 +75,9 @@ $ jit scan ./my-project token.txt
   (`.env` files, IaC variable files, MCP configs), and
   skips the usual noise directories (`node_modules`, `.git`, …).
 - A **file you name** is classified regardless of what it's called. A
-  shell/`.env`/MCP/IaC file is routed to its scanner; a private key is detected
+  shell/`.env`/MCP/IaC file is routed to its scanner (so are a
+  `.streamlit/secrets.toml` and cargo's own credential files, whose tokens
+  the generic sweep would miss); a private key is detected
   by its contents; and anything else is swept for known vendor tokens and JWTs.
   That last part is why `jit scan token.txt` catches a bare token that the
   whole-machine scan's naming rules would never look at.

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ then **[Install](./getting-started/install.md)** →
   [shell history](./migrate/shell-history.md) · [AWS](./migrate/aws.md) ·
   [Kubernetes](./migrate/kubernetes.md) · [Terraform](./migrate/terraform.md) ·
   [GCP](./migrate/gcp.md) · [npm](./migrate/npm.md) · [PyPI](./migrate/pypi.md) ·
+  [Cargo](./migrate/cargo.md) · [Streamlit](./migrate/streamlit.md) ·
   [netrc](./migrate/netrc.md) · [SOPS](./migrate/sops.md) · [MCP / AI tools](./migrate/mcp.md)
 - [Undo, unmount, and remove](./migrate/undo-and-remove.md) - every change is reversible
 

--- a/docs/migrate/cargo.md
+++ b/docs/migrate/cargo.md
@@ -55,5 +55,8 @@ fetch), and the answer never touches disk.
   including precedence, fallback, and login/logout routing - see
   `spike/cargo-credential-provider/FINDINGS.md`.
 - **Undo:** `jit migrate undo ~/.cargo/credentials.toml` restores the
-  original file byte-for-byte from its encrypted backup (and
-  `~/.cargo/config.toml` alongside it).
+  original file byte-for-byte from its encrypted backup, and pulls
+  `~/.cargo/config.toml` back with it automatically. The two are linked on
+  purpose: jit's provider registration outranks the credentials file, so
+  restoring the token without also unregistering the provider would leave
+  cargo still fetching from the vault - a "restored" file nothing reads.

--- a/docs/migrate/cargo.md
+++ b/docs/migrate/cargo.md
@@ -1,0 +1,59 @@
+---
+title: Migrating cargo registry tokens
+description: crates.io and private-registry publish tokens move to the vault; cargo fetches them through its own credential-provider protocol, and cargo login keeps working.
+---
+
+# Cargo (`~/.cargo/credentials.toml`)
+
+`cargo login` stores its registry token in `~/.cargo/credentials.toml` (and
+older cargos used a bare `~/.cargo/credentials`, which is still honored) in
+plaintext. This is a **publish** credential: with it an attacker ships a new
+version of any crate the account owns, straight into other people's builds.
+Same blast radius as the npm and PyPI tokens, and the same reason it rates
+High in [`jit scan`](../audit/index.md).
+
+`jit migrate ~/.cargo/credentials.toml` (category `cargo`) moves every
+registry's token into the vault and wires cargo's own stable
+credential-provider mechanism (cargo 1.74+) in its place - no intermediate
+file at all:
+
+- each token lands in a `cargo-<registry>` vault profile (crates.io uses
+  cargo's own reserved name, `cargo-crates-io`);
+- a `cargo-credential-jit` wrapper is written into `~/.cargo/`, invoking
+  `jit cargo-credential` (the provider protocol over stdin/stdout);
+- `~/.cargo/config.toml` gets
+  `global-credential-providers = ["cargo:token", ".../cargo-credential-jit"]`
+  under `[registry]` - jit last, because later entries take precedence;
+- the token lines are stripped from the credentials file(s), including a
+  stale copy in the legacy `~/.cargo/credentials`.
+
+Cargo asks jit for the token exactly when an operation needs one
+(`cargo publish`, `cargo yank`, `cargo owner`, a private registry's index
+fetch), and the answer never touches disk.
+
+## After migration
+
+- **`cargo publish` and friends just work** - cargo invokes the provider,
+  jit resolves the token from the vault (through the background service's
+  unlocked session, or a Touch ID prompt).
+- **`cargo login` keeps working, and lands in the vault.** jit's provider
+  takes precedence, so a re-login (rotation) stores the new token in the
+  vault instead of writing a fresh plaintext file. `cargo logout` removes it
+  from the vault.
+- **Unmigrated registries are untouched.** For a registry jit holds nothing
+  for, the provider answers the protocol's not-found and cargo falls back to
+  `cargo:token` (credentials.toml) exactly as if jit weren't installed.
+
+## Notes
+
+- **A pre-existing provider configuration is a hard stop.** If
+  `global-credential-providers` is already set in `~/.cargo/config.toml`
+  (say, `cargo:macos-keychain`), jit refuses rather than rewrite your own
+  deliberate configuration, and the error says how to add jit's provider by
+  hand (append it last - last wins).
+- **Every protocol shape was verified empirically** against a live cargo,
+  including precedence, fallback, and login/logout routing - see
+  `spike/cargo-credential-provider/FINDINGS.md`.
+- **Undo:** `jit migrate undo ~/.cargo/credentials.toml` restores the
+  original file byte-for-byte from its encrypted backup (and
+  `~/.cargo/config.toml` alongside it).

--- a/docs/migrate/index.md
+++ b/docs/migrate/index.md
@@ -43,14 +43,18 @@ jit migrate ~/.zshrc ~/code/myapp  # several targets at once
 Each named target is resolved on its own:
 
 - **A file** is routed to the right category by what it is. A project file
-  (`.env`, `*.tfvars`, `mcp.json`/`.mcp.json`, `.npmrc`) has its secrets
+  (`.env`, `*.tfvars`, `mcp.json`/`.mcp.json`, `.npmrc`,
+  `.streamlit/secrets.toml`) has its secrets
   moved into a profile and the vault, and the file keeps working. A
   machine-wide file at a known path - a shell config like `~/.zshrc`, a shell
   history file like `~/.zsh_history`, `~/.aws/credentials`, `~/.kube/config`, the Terraform Cloud token file,
-  `~/.docker/config.json`, `~/.git-credentials`, GCP application-default
+  `~/.docker/config.json`, `~/.git-credentials`, `~/.cargo/credentials.toml`,
+  GCP application-default
   credentials, the SOPS age key, `~/.netrc`, `~/.pypirc`, Claude Desktop's MCP config,
-  Claude Code's `~/.claude.json`, the global `~/.npmrc` - is routed to that credential type's handling.
-- **A directory** is walked for its `.env`/tfvars/`mcp.json`/`.npmrc`
+  Claude Code's `~/.claude.json`, the global `~/.npmrc`,
+  `~/.streamlit/secrets.toml` - is routed to that credential type's handling.
+- **A directory** is walked for its
+  `.env`/tfvars/`mcp.json`/`.npmrc`/`.streamlit/secrets.toml`
   findings only, never the machine-wide fixed-path files (those aren't
   "under" any project directory - name them explicitly to convert them).
 
@@ -157,6 +161,8 @@ Limit a run to specific categories with `--only`
 | `npmrc` | just the secret lines (`_authToken`, etc.) | a live-mounted pipe serving a template; everything else untouched | [npm](./npm.md) |
 | `netrc` | every `password` value in `~/.netrc` | a live-mounted pipe serving a template; `machine`/`login` lines and macdef scripts untouched | [netrc](./netrc.md) |
 | `pypirc` | every repository section's `password` in `~/.pypirc` | a live-mounted pipe serving a template; `[distutils]`, `repository` and `username` lines untouched | [PyPI](./pypi.md) |
+| `cargo` | each registry's publish token in `~/.cargo/credentials.toml` | a credential provider wired into `~/.cargo/config.toml`; `cargo login`/`logout` keep working, no file with the real value at all | [Cargo](./cargo.md) |
+| `streamlit` | every credential-shaped value in a `.streamlit/secrets.toml` (project or global) | a live-mounted pipe serving a template; table headers and connection settings untouched | [Streamlit](./streamlit.md) |
 | `loose` | secrets in a plain file you named that matches no format above: a bare token (a JWT in `token.txt`), and any secret-shaped `key = value` assignment (`db_password = ...`) whose value isn't obviously a setting | by default (whole-file token) the value moves to the vault and the file is replaced with a git-safe pointer; retrieve with `jit vault get`. With `--mount`, or for a token mixed with other content, the file stays live at its path as a mount (a template with `${VAR}` placeholders) serving the real value to `jit run` grants and a decoy otherwise | |
 
 The `loose` category never appears on its own, only when you explicitly name

--- a/docs/migrate/streamlit.md
+++ b/docs/migrate/streamlit.md
@@ -1,0 +1,91 @@
+---
+title: Migrating Streamlit secrets
+description: The credentials in .streamlit/secrets.toml move to the vault; st.secrets and streamlit run keep reading the file exactly as before.
+---
+
+# Streamlit (`.streamlit/secrets.toml`)
+
+`.streamlit/secrets.toml` is Streamlit's own secrets file: the docs tell you
+to put API keys and database passwords there, gitignore it, and read it
+through `st.secrets`. It exists in two places - `<project>/.streamlit/`
+alongside the app, and `~/.streamlit/` globally - and either way its entire
+purpose is holding credentials in plaintext.
+
+`jit migrate <project>` (category `streamlit`) finds a project's file;
+`jit migrate ~/.streamlit/secrets.toml` or a home-wide run reaches the global
+one. Credential lines move into the vault and the file is replaced with a
+[live mount](../run/mounts.md) serving a template: table headers, connection
+settings (`account`, `port`, `dialect`), comments and the original formatting
+all pass through byte-for-byte. Only the credential values are filled in from
+the vault, inside the line's own quotes, when a read is authorized.
+
+Which lines count follows the same two signals `jit scan` uses: a value
+matching a known vendor format (an `sk-proj-…` OpenAI key under any name),
+or a secret-shaped key name (`password`, `db_password`, `api_key`) whose
+value doesn't read as an ordinary setting.
+
+## Using it after migration
+
+**A project's file** is granted like any project mount - run the app through
+jit from the project directory:
+
+```sh
+jit run -- streamlit run app.py
+```
+
+**The global `~/.streamlit/secrets.toml`** is a machine-wide credential file,
+so it takes an explicit grant:
+
+```sh
+jit run --with streamlit -- streamlit run app.py
+```
+
+**Or just run it.** With per-process consent on (the default), run
+`streamlit run` as normal and approve the Touch ID prompt naming the reader.
+
+## What it looks like
+
+Before:
+
+```toml
+OPENAI_API_KEY = "sk-proj-..."
+db_password = "hunter2"
+
+[connections.snowflake]
+account = "ACME-PROD"
+user = "analyst"
+port = 443
+password = "sn0wf@ll"
+```
+
+After, the file is a live mount rendering this template - three secrets in
+the vault under the project's `streamlit-<project>` profile (or `streamlit`
+for the global file):
+
+```toml
+OPENAI_API_KEY = "${OPENAI_API_KEY}"
+db_password = "${DB_PASSWORD}"
+
+[connections.snowflake]
+account = "ACME-PROD"
+user = "analyst"
+port = 443
+password = "${CONNECTIONS_SNOWFLAKE_PASSWORD}"
+```
+
+The variable name folds in the **table**, not just the key - every
+connection's credential is literally named `password`, so without the table
+two databases would collide on one vault path.
+
+## Notes
+
+- **Only provably-rewritable lines move.** A value in a multi-line string
+  (`"""…"""`), one carrying escape sequences, or one sharing its line with a
+  trailing comment stays in place - rewriting those can't be guaranteed to
+  round-trip byte-for-byte, so the line keeps its `jit scan` finding instead.
+- **The two-part path gate is deliberate.** `secrets.toml` alone is a common
+  name (a Rust config, a Helm values file); only `.streamlit/secrets.toml`
+  is unambiguously Streamlit's. Name any other secrets.toml explicitly and
+  it is handled as a [loose secret file](./index.md) instead.
+- **Undo:** `jit migrate undo <path>` restores the original file
+  byte-for-byte from its encrypted backup.

--- a/docs/migrate/streamlit.md
+++ b/docs/migrate/streamlit.md
@@ -83,6 +83,10 @@ two databases would collide on one vault path.
   (`"""…"""`), one carrying escape sequences, or one sharing its line with a
   trailing comment stays in place - rewriting those can't be guaranteed to
   round-trip byte-for-byte, so the line keeps its `jit scan` finding instead.
+  A file where **no** value is rewritable is reported by the scan as a
+  manual fix with that reason, never as `jit migrate <path>` - scan asks
+  migrate before promising (the same rule Kubernetes Secret manifests
+  follow).
 - **The two-part path gate is deliberate.** `secrets.toml` alone is a common
   name (a Rust config, a Helm values file); only `.streamlit/secrets.toml`
   is unambiguously Streamlit's. Name any other secrets.toml explicitly and

--- a/docs/reference/commands/jit.md
+++ b/docs/reference/commands/jit.md
@@ -22,6 +22,7 @@ jit [flags]
 
 * [jit audit](jit_audit.md)	 - Show the audit log: what jit commands ran, when, by whom, and every unlock
 * [jit aws-credential-process](jit_aws-credential-process.md)	 - Print AWS credential_process JSON for a migrated profile
+* [jit cargo-credential](jit_cargo-credential.md)	 - Implement cargo's credential-provider protocol for a migrated registry token
 * [jit clisso-capture](jit_clisso-capture.md)	 - Run clisso, capturing minted AWS credentials into the vault
 * [jit completion](jit_completion.md)	 - Generate the autocompletion script for the specified shell
 * [jit docker-credential](jit_docker-credential.md)	 - Implement Docker's credential-helper protocol for migrated registry logins

--- a/docs/reference/commands/jit_cargo-credential.md
+++ b/docs/reference/commands/jit_cargo-credential.md
@@ -1,0 +1,37 @@
+## jit cargo-credential
+
+Implement cargo's credential-provider protocol for a migrated registry token
+
+### Synopsis
+
+Not typically run by hand: jit migrate writes a cargo-credential-jit
+wrapper that invokes this command and registers it (last, so it takes
+precedence) in ~/.cargo/config.toml's global-credential-providers, so
+cargo fetches its registry token from the vault with no plaintext file
+on disk.
+
+The protocol's three kinds map to the vault: `get` serves the token from
+the registry's cargo-<name> profile (answering not-found for a registry
+jit holds nothing for, so cargo falls back to credentials.toml exactly
+as if jit weren't installed); `login` (what `cargo login` calls) saves
+the new token to the vault, so a re-login lands in the vault instead of
+back in a plaintext file; `logout` removes it.
+
+Requires local auth to resolve the vault the same way jit run/export do:
+either a reachable jit background service with an already-unlocked session, or an
+interactive context able to show a Touch ID/passcode prompt.
+
+```
+jit cargo-credential [--cargo-plugin]
+```
+
+### Options inherited from parent commands
+
+```
+      --quiet   suppress the progress spinner/status trail (results still print)
+```
+
+### SEE ALSO
+
+* [jit](jit.md)	 - Local-first developer secret runtime
+

--- a/docs/reference/commands/jit_migrate.md
+++ b/docs/reference/commands/jit_migrate.md
@@ -20,22 +20,24 @@ With arguments, discovery is scoped to the targets you name (plus the
 agent-cache sweep described below). Each target is resolved on its own:
 
   A file       is routed to the right category by what it is. A project file
-               (.env, *.tfvars, mcp.json/.mcp.json, .npmrc) has its secrets
+               (.env, *.tfvars, mcp.json/.mcp.json, .npmrc,
+               .streamlit/secrets.toml) has its secrets
                moved into a profile and the vault, the file keeps working as a
                live mount (a git-safe <file>.pointers companion is written
                alongside). A machine-wide file at a known path (a shell config
                like ~/.zshrc, a shell history file like ~/.zsh_history,
                ~/.aws/credentials, ~/.kube/config, Terraform Cloud creds,
-               ~/.docker/config.json, ~/.git-credentials, GCP
+               ~/.docker/config.json, ~/.git-credentials, ~/.cargo/credentials.toml, GCP
                application-default credentials, a SOPS age key, ~/.netrc,
                ~/.pypirc, Claude Desktop's MCP config, Claude Code's
-               ~/.claude.json, the global ~/.npmrc)
+               ~/.claude.json, the global ~/.npmrc, the global
+               ~/.streamlit/secrets.toml)
                is routed to that credential type's handling
                (credential_process, exec plugin, credential helper, live
                mount, or in-place redaction for a history file, where each
                recorded credential moves to the vault and the line keeps
                its shape, minus the secret).
-  A directory  is walked for its .env/tfvars/mcp/npmrc findings only, never
+  A directory  is walked for its .env/tfvars/mcp/npmrc/streamlit findings only, never
                the machine-wide fixed-path files (those aren't "under" any
                project directory) — name them explicitly to convert them.
 
@@ -86,7 +88,7 @@ jit migrate <file-or-dir>... [flags]
       --dry-run        preview the plan without changing anything
       --mount          for a loose secret file, keep it live at its path as a mount (real value to jit run grants, a decoy otherwise) instead of replacing it with a pointer; also required to protect a file that mixes a secret with other content
       --no-1password   store plain copies even when a value already lives in 1Password (default: matching values are vaulted as op:// references)
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,cargo,streamlit,loose,cache (default: all)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```
 

--- a/docs/reference/commands/jit_migrate_caches.md
+++ b/docs/reference/commands/jit_migrate_caches.md
@@ -38,7 +38,7 @@ jit migrate caches
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,cargo,streamlit,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/docs/reference/commands/jit_migrate_path.md
+++ b/docs/reference/commands/jit_migrate_path.md
@@ -21,7 +21,7 @@ jit migrate path <file-or-dir>... [flags]
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,cargo,streamlit,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/docs/reference/commands/jit_migrate_remove.md
+++ b/docs/reference/commands/jit_migrate_remove.md
@@ -62,7 +62,7 @@ jit migrate remove <file-or-dir>... [flags]
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,cargo,streamlit,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
 ```
 

--- a/docs/reference/commands/jit_migrate_undo.md
+++ b/docs/reference/commands/jit_migrate_undo.md
@@ -55,7 +55,7 @@ jit migrate undo <path>...
 
 ```
       --dry-run        preview the plan without changing anything
-      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,loose,cache (default: all)
+      --only strings   scope a run to just these comma-separated categories: env,tfvars,k8s-secret,shell,history,mcp,aws,kube,terraform,docker,git,gcp,sops,npmrc,netrc,pypirc,cargo,streamlit,loose,cache (default: all)
       --quiet          suppress the progress spinner/status trail (results still print)
   -y, --yes            skip the confirmation prompt and proceed immediately
 ```

--- a/internal/audit/credfile.go
+++ b/internal/audit/credfile.go
@@ -331,6 +331,14 @@ func scanNpmrcFile(path string, cfg Config) ([]Finding, error) {
 const streamlitSecretsDir = ".streamlit"
 const streamlitSecretsFile = "secrets.toml" // #nosec G101 -- a filename, not a credential
 
+// IsStreamlitSecretsPath reports whether path is a Streamlit secrets file
+// — the same two-part gate classifyStreamlitSecrets applies, exported so
+// annotateRemedies (and any consumer of a finding's path) can recognize
+// the category without re-deriving the rule.
+func IsStreamlitSecretsPath(path string) bool {
+	return filepath.Base(path) == streamlitSecretsFile && filepath.Base(filepath.Dir(path)) == streamlitSecretsDir
+}
+
 // classifyStreamlitSecrets is the discovery half for Streamlit's secrets file.
 // Streamlit's own docs call this file "secrets", tell you to gitignore it, and
 // have `st.secrets` read it directly — so unlike a generic .toml, its entire
@@ -603,6 +611,19 @@ func mcpAuthTokenFindings(cfg Config, path string) []Finding {
 var cargoCredentialPaths = [][]string{
 	{".cargo", "credentials.toml"},
 	{".cargo", "credentials"},
+}
+
+// isCargoCredentialsPath reports whether path is one of cargo's two fixed
+// credential files — exact-path, not name-based: a project's own
+// credentials.toml is not cargo's. Exported to the targeted scan via
+// scanTargetFile, which has no fixed-path half of its own.
+func isCargoCredentialsPath(home, path string) bool {
+	for _, rel := range cargoCredentialPaths {
+		if path == filepath.Join(append([]string{home}, rel...)...) {
+			return true
+		}
+	}
+	return false
 }
 
 // scanCargoCredentials reports the crates.io API token (and any alternate

--- a/internal/audit/credfile_test.go
+++ b/internal/audit/credfile_test.go
@@ -785,7 +785,7 @@ providers:
 	// finding), and annotateRemedies must respect it — the
 	// selfRotatingCaches entry for this file exists for OTHER findings,
 	// not to override this one.
-	annotateRemedies(findings, home, nil)
+	annotateRemedies(findings, home, nil, nil)
 	f = findings[0]
 	if f.Remedy != RemedyWrap {
 		t.Errorf("Remedy = %q, want %q", f.Remedy, RemedyWrap)
@@ -845,5 +845,49 @@ func TestScanClissoConfigEmptySecretSkipped(t *testing.T) {
 	findings, err = scanClissoConfig(Config{HomeDir: home})
 	if err != nil || len(findings) != 0 {
 		t.Errorf("empty file: got (%d findings, %v), want (0, nil)", len(findings), err)
+	}
+}
+
+// TestTargetedScanReachesCargoCredentials: the machine-wide scan's fixed
+// half owns ~/.cargo/credentials.toml, but a targeted scan has no fixed
+// half — and a cargo token carries no vendor prefix, so the generic sweep
+// reports nothing. Naming the file must route to the cargo scanner (the
+// same reasoning as the explicit ~/.npmrc branch in scanTargetFile).
+func TestTargetedScanReachesCargoCredentials(t *testing.T) {
+	home := t.TempDir()
+	mkdirAll(t, filepath.Join(home, ".cargo"))
+	path := filepath.Join(home, ".cargo", "credentials.toml")
+	writeFile(t, path, "[registry]\ntoken = \"cioTargetedScanTokenQmPl4T\"\n")
+
+	findings, _, err := TargetedScan(Config{HomeDir: home}, []string{path})
+	if err != nil {
+		t.Fatalf("TargetedScan: %v", err)
+	}
+	var got *Finding
+	for i := range findings {
+		if findings[i].FindingType == FindingTypeCredentialFile {
+			got = &findings[i]
+			break
+		}
+	}
+	if got == nil {
+		t.Fatalf("no credential_file finding for the named cargo file, got %d findings", len(findings))
+	}
+	if got.KeyName == nil || *got.KeyName != "registry/token" {
+		t.Errorf("KeyName = %v, want registry/token", got.KeyName)
+	}
+	// And a project's own credentials.toml is NOT cargo's — exact-path
+	// gate, not name-based.
+	mkdirAll(t, filepath.Join(home, "proj"))
+	other := filepath.Join(home, "proj", "credentials.toml")
+	writeFile(t, other, "[registry]\ntoken = \"cioNotCargoQmPl4TzWhu\"\n")
+	findings, _, err = TargetedScan(Config{HomeDir: home}, []string{other})
+	if err != nil {
+		t.Fatalf("TargetedScan(project file): %v", err)
+	}
+	for _, f := range findings {
+		if f.FindingType == FindingTypeCredentialFile {
+			t.Errorf("project credentials.toml must not classify as cargo's, got %+v", f)
+		}
 	}
 }

--- a/internal/audit/finding.go
+++ b/internal/audit/finding.go
@@ -691,6 +691,16 @@ type Config struct {
 	// read-only and prompt-free — it runs inside `jit scan`, whose
 	// every mode is strictly read-only.
 	K8sMigratable func(path string) (reason string, ok bool)
+
+	// StreamlitMigratable is K8sMigratable's twin for .streamlit/
+	// secrets.toml findings: migrate's shape rule is deliberately
+	// stricter than this scanner's (only a single-line quoted value with
+	// no escapes rewrites provably right), so a file whose every flagged
+	// value falls outside it must not be promised as `jit migrate <path>`
+	// — the command would answer "nothing to migrate" at a file the
+	// report just flagged. Same contract: read-only, prompt-free, nil
+	// keeps the optimistic pre-hook behavior.
+	StreamlitMigratable func(path string) (reason string, ok bool)
 }
 
 // NewConfig builds a Config for a real run against the actual machine.

--- a/internal/audit/fixture_test.go
+++ b/internal/audit/fixture_test.go
@@ -62,7 +62,7 @@ func TestFixtureNotChargedToLedger(t *testing.T) {
 	}
 
 	findings := []Finding{fixture, real}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 	cov := ComputeCoverage("", "", findings)
 	if cov.Exposed != 1 {
 		t.Errorf("exposed = %d, want 1 (the fixture must not inflate the ledger)", cov.Exposed)

--- a/internal/audit/manualaction_test.go
+++ b/internal/audit/manualaction_test.go
@@ -38,7 +38,7 @@ func TestManualActionAgreesPerFile(t *testing.T) {
 			FilePath: "/Users/alex/reports/dump-b.html", KeyName: str("JSON Web Token"),
 			ValuePreview: str("eyJh**********")},
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 2 {
@@ -70,7 +70,7 @@ func TestManualActionCopiesBeatMount(t *testing.T) {
 			ValuePreview: str("pgpw**********"),
 		})
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 1 {
@@ -102,7 +102,7 @@ func TestManualActionStillOffersMountWhereItWorks(t *testing.T) {
 			FilePath: "/Users/alex/bin/deploy.sh", KeyName: str("Database connection string"),
 			ValuePreview: str("pgpw**********")},
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 
 	groups := triageGroupManual(findings, "/Users/alex")
 	if len(groups) != 1 {

--- a/internal/audit/remedy.go
+++ b/internal/audit/remedy.go
@@ -62,7 +62,7 @@ const (
 //     command as THE fix would dress the wound without treating it. The
 //     migrate result output carries the rotation advice for the ordinary
 //     case; for production, rotation IS the remedy and the report says so.
-func annotateRemedies(findings []Finding, home string, k8sMigratable func(string) (string, bool)) {
+func annotateRemedies(findings []Finding, home string, k8sMigratable, streamlitMigratable func(string) (string, bool)) {
 	// Purity is per file and can involve a re-read; cache it, since copies
 	// of one dump produce many findings for the same path.
 	pureCache := map[string]bool{}
@@ -89,6 +89,20 @@ func annotateRemedies(findings []Finding, home string, k8sMigratable func(string
 		if !cached {
 			v.reason, v.ok = k8sMigratable(path)
 			k8sCache[path] = v
+		}
+		return v.reason, v.ok
+	}
+	// Same probe-and-cache for Streamlit secrets files: one file carries a
+	// finding per flagged value, and the probe re-reads the file.
+	streamlitCache := map[string]k8sVerdict{}
+	streamlitRefusal := func(path string) (string, bool) {
+		if streamlitMigratable == nil {
+			return "", true
+		}
+		v, cached := streamlitCache[path]
+		if !cached {
+			v.reason, v.ok = streamlitMigratable(path)
+			streamlitCache[path] = v
 		}
 		return v.reason, v.ok
 	}
@@ -143,6 +157,18 @@ func annotateRemedies(findings []Finding, home string, k8sMigratable func(string
 			if reason, ok := k8sRefusal(f.FilePath); !ok {
 				f.Remedy = RemedyManual
 				f.Evidence = "kubernetes Secret manifest `jit migrate` can't rewrite provably right (" + reason + "); sealed-secrets/SOPS or a hand edit is the fix"
+			} else {
+				f.Remedy = RemedyMigrate
+				f.FixCommand = "jit migrate " + shellSafePath(home, f.FilePath)
+			}
+		case f.FindingType == FindingTypeCredentialFile && IsStreamlitSecretsPath(f.FilePath):
+			// The same D5 rule the ConfidenceHigh Secret-manifest case
+			// applies: migrate's shape rule for secrets.toml is stricter
+			// than this scanner's, and a file whose every flagged value
+			// falls outside it must not be promised as fixable.
+			if reason, ok := streamlitRefusal(f.FilePath); !ok {
+				f.Remedy = RemedyManual
+				f.Evidence = "Streamlit secrets file `jit migrate` can't rewrite provably right (" + reason + "); move the value out and rotate it, or quote it as a simple one-line string"
 			} else {
 				f.Remedy = RemedyMigrate
 				f.FixCommand = "jit migrate " + shellSafePath(home, f.FilePath)

--- a/internal/audit/remedy_test.go
+++ b/internal/audit/remedy_test.go
@@ -42,7 +42,7 @@ func TestAnnotateRemedies(t *testing.T) {
 		{FindingType: FindingTypeWrappableCLIToken, FilePath: filepath.Join(home, ".config/gh/hosts.yml"),
 			Remedy: RemedyWrap, FixCommand: "jit wrap gh", KeyName: str("oauth_token")},
 	}
-	annotateRemedies(findings, home, nil)
+	annotateRemedies(findings, home, nil, nil)
 
 	want := []struct {
 		remedy, fixContains string
@@ -387,6 +387,61 @@ data:
 	}
 
 	okFinding := find(Config{HomeDir: home, K8sMigratable: func(string) (string, bool) { return "", true }})
+	if okFinding.Remedy != RemedyMigrate || okFinding.FixCommand == "" {
+		t.Errorf("ok verdict: remedy=%q fix=%q, want migrate with a FixCommand", okFinding.Remedy, okFinding.FixCommand)
+	}
+
+	nilHook := find(Config{HomeDir: home})
+	if nilHook.Remedy != RemedyMigrate {
+		t.Errorf("nil hook must keep the pre-hook optimistic remedy, got %q", nilHook.Remedy)
+	}
+}
+
+// TestStreamlitMigratableHookFlipsUnrewritableFiles: Config.
+// StreamlitMigratable is how scan stops promising a secrets.toml whose
+// every flagged value falls outside migrate's stricter rewritable shape
+// (single-line quoted string, no escapes) — the same D5 rule
+// K8sMigratable enforces for Secret manifests.
+func TestStreamlitMigratableHookFlipsUnrewritableFiles(t *testing.T) {
+	home := t.TempDir()
+	dir := filepath.Join(home, "proj", ".streamlit")
+	mkdirAll(t, dir)
+	secrets := filepath.Join(dir, "secrets.toml")
+	writeFile(t, secrets, "db_password = \"Tr0ub4dor3xKq9ZmPq2Lr\"\n")
+
+	find := func(cfg Config) Finding {
+		t.Helper()
+		findings, _, err := TargetedScan(cfg, []string{secrets})
+		if err != nil {
+			t.Fatalf("TargetedScan: %v", err)
+		}
+		for _, f := range findings {
+			if f.FindingType == FindingTypeCredentialFile {
+				return f
+			}
+		}
+		t.Fatalf("no credential_file finding for the secrets file, got %d findings", len(findings))
+		return Finding{}
+	}
+
+	refused := find(Config{HomeDir: home, StreamlitMigratable: func(path string) (string, bool) {
+		if path != secrets {
+			t.Errorf("hook asked about %q, want %q", path, secrets)
+		}
+		return "its values aren't single-line quoted strings", false
+	}})
+	if refused.Remedy != RemedyManual {
+		t.Errorf("refused file remedy = %q, want %q", refused.Remedy, RemedyManual)
+	}
+	if !strings.Contains(refused.Evidence, "can't rewrite provably right") ||
+		!strings.Contains(refused.Evidence, "single-line quoted strings") {
+		t.Errorf("refused evidence should carry migrate's reason, got: %q", refused.Evidence)
+	}
+	if refused.FixCommand != "" {
+		t.Errorf("refused file must not carry a FixCommand, got %q", refused.FixCommand)
+	}
+
+	okFinding := find(Config{HomeDir: home, StreamlitMigratable: func(string) (string, bool) { return "", true }})
 	if okFinding.Remedy != RemedyMigrate || okFinding.FixCommand == "" {
 		t.Errorf("ok verdict: remedy=%q fix=%q, want migrate with a FixCommand", okFinding.Remedy, okFinding.FixCommand)
 	}

--- a/internal/audit/report_test.go
+++ b/internal/audit/report_test.go
@@ -452,7 +452,7 @@ func TestFirstFindingPathSkipsUnfixable(t *testing.T) {
 		{FindingType: FindingTypePrivateKeyRisk, FilePath: "/home/u/.ssh/id_ed25519", KeyName: &key},
 		{FindingType: FindingTypeCredentialFile, FilePath: "/home/u/.mcp-auth/mcp-remote-0.1.37/abc_tokens.json", KeyName: &key},
 	}
-	annotateRemedies(unfixable, "/home/u", nil)
+	annotateRemedies(unfixable, "/home/u", nil, nil)
 	if got := firstFindingPath(unfixable); got != "" {
 		t.Errorf("firstFindingPath = %q, want \"\" so the trailer falls back to its <path> placeholder", got)
 	}
@@ -464,7 +464,7 @@ func TestFirstFindingPathSkipsUnfixable(t *testing.T) {
 		FilePath:    "/home/u/proj/.streamlit/secrets.toml",
 		KeyName:     &key,
 	})
-	annotateRemedies(mixed, "/home/u", nil)
+	annotateRemedies(mixed, "/home/u", nil, nil)
 	if got := firstFindingPath(mixed); got != "/home/u/proj/.streamlit/secrets.toml" {
 		t.Errorf("firstFindingPath = %q, want the migratable file", got)
 	}

--- a/internal/audit/scan.go
+++ b/internal/audit/scan.go
@@ -145,7 +145,7 @@ func Scan(cfg Config) ([]Finding, ScanSummary, error) {
 	// Same seam, same reason: who can act on each finding (and the id that
 	// groups copies of one secret) is set once, centrally, so every renderer
 	// and consumer reads identical answers.
-	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable)
+	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable, cfg.StreamlitMigratable)
 
 	summary := buildScanSummary(cfg, all, countProtectedMounts(cfg.MountRegistryPath), time.Since(start))
 	summary.FilesScanned = filesWalked

--- a/internal/audit/selfrotating_test.go
+++ b/internal/audit/selfrotating_test.go
@@ -47,7 +47,7 @@ func TestSelfRotatingCacheIsNeverMigrated(t *testing.T) {
 			FilePath: "/Users/alex/.gemini/oauth_creds.json",
 			KeyName:  str("JSON Web Token"), ValuePreview: str("eyJh**********")},
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 
 	if findings[0].Remedy != RemedyManual {
 		t.Errorf("remedy = %q, want %q", findings[0].Remedy, RemedyManual)
@@ -128,7 +128,7 @@ func TestTerraformStateIsManualWithBackendAdvice(t *testing.T) {
 			FilePath: "/Users/alex/infra/terraform.tfstate",
 			KeyName:  str("AWS Secret Access Key"), ValuePreview: str("wJal**********")},
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 	if findings[0].Remedy != RemedyManual {
 		t.Errorf("remedy = %q, want %q", findings[0].Remedy, RemedyManual)
 	}

--- a/internal/audit/shellhistory_test.go
+++ b/internal/audit/shellhistory_test.go
@@ -460,7 +460,7 @@ func TestShellHistoryRemedySplitsOnProductionFlag(t *testing.T) {
 			ProductionIndicatorMatch: true,
 		},
 	}
-	annotateRemedies(findings, home, nil)
+	annotateRemedies(findings, home, nil, nil)
 	if findings[0].Remedy != RemedyMigrate {
 		t.Errorf("ordinary history remedy = %q, want %q", findings[0].Remedy, RemedyMigrate)
 	}

--- a/internal/audit/target.go
+++ b/internal/audit/target.go
@@ -80,7 +80,7 @@ func TargetedScan(cfg Config, targets []string) ([]Finding, ScanSummary, error) 
 	// be handed a repository full of test fixtures.
 	tagArchivedAndFixtures(all)
 	// And the same remedy/cause annotation, for the same no-drift reason.
-	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable)
+	annotateRemedies(all, cfg.HomeDir, cfg.K8sMigratable, cfg.StreamlitMigratable)
 
 	summary := buildScanSummary(cfg, all, countProtectedMounts(cfg.MountRegistryPath), time.Since(start))
 	summary.Targets = targets
@@ -180,6 +180,26 @@ func scanTargetFile(cfg Config, path string) ([]Finding, []ScannerFailure) {
 	if isTFVars, isK8s := iacNameGates(name); isTFVars || isK8s {
 		structured = true
 		findings = append(findings, classifyIACFile(cfg, path, name)...)
+	}
+	// The walk's two-part gate (.streamlit/secrets.toml) holds here too: a
+	// bare secrets.toml named explicitly is still ambiguous (a Rust
+	// config, a Helm values file) and falls through to the vendor-token
+	// sweep below instead.
+	if IsStreamlitSecretsPath(path) {
+		structured = true
+		if fs, err := scanStreamlitSecretsFile(cfg, path); err == nil {
+			findings = append(findings, fs...)
+		} else {
+			note("streamlit secrets", err)
+		}
+	}
+	// Cargo's registry tokens carry no vendor prefix, so the sweep below
+	// would report nothing at all for a named ~/.cargo/credentials.toml —
+	// the machine-wide scan's fixed half owns these paths, but a targeted
+	// scan has no fixed half (the same reasoning as ~/.npmrc above).
+	if isCargoCredentialsPath(cfg.HomeDir, path) {
+		structured = true
+		findings = append(findings, scanCargoCredentialFile(cfg, path)...)
 	}
 
 	// A content check that doesn't care what the file is named: the

--- a/internal/audit/triage_test.go
+++ b/internal/audit/triage_test.go
@@ -40,7 +40,7 @@ func triageFixture() ([]Finding, ScanSummary, Coverage) {
 			FilePath: "/Users/alex/Documents/archive/old/.env", KeyName: str("OLD_KEY"),
 			ValuePreview: str("xk92**********"), Archived: true},
 	}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 	cov := ComputeCoverage("", "", findings)
 	summary := buildScanSummary(Config{Endpoint: Endpoint{Username: "alex", Hostname: "mbp"}}, findings, 0, 2300)
 	summary.FilesScanned = 47312
@@ -518,7 +518,7 @@ func TestWriteTriageReportNeverLeaksRawValue(t *testing.T) {
 		RecordID: "x", FindingType: FindingTypeExposedSecret, Severity: SeverityHigh,
 		FilePath: "/Users/alex/creds.txt", KeyName: &key, ValuePreview: &preview,
 	}}
-	annotateRemedies(findings, "/Users/alex", nil)
+	annotateRemedies(findings, "/Users/alex", nil, nil)
 	cov := ComputeCoverage("", "", findings)
 	summary := buildScanSummary(Config{}, findings, 0, 0)
 

--- a/internal/cli/cargocred.go
+++ b/internal/cli/cargocred.go
@@ -1,0 +1,222 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jitpass/jit/internal/inject"
+	"github.com/jitpass/jit/internal/migrate"
+	"github.com/jitpass/jit/internal/profile"
+)
+
+// Cargo's credential-provider protocol (JSON lines over stdin/stdout,
+// cargo 1.74+): cargo spawns the provider with `--cargo-plugin` per
+// operation, the provider greets with {"v":[1]}, then answers one request
+// per line. Every shape here was verified empirically against cargo 1.98
+// — see spike/cargo-credential-provider/FINDINGS.md, including that
+// {"Err":{"kind":"not-found"}} falls back to `cargo:token` for a registry
+// jit holds nothing for, and that an "other" error's message surfaces in
+// cargo's own error chain.
+
+// cargoCredRequest is one request line from cargo.
+type cargoCredRequest struct {
+	V         int    `json:"v"`
+	Kind      string `json:"kind"`
+	Operation string `json:"operation,omitempty"`
+	Registry  struct {
+		IndexURL string `json:"index-url"`
+		Name     string `json:"name"`
+	} `json:"registry"`
+	Token string `json:"token,omitempty"`
+}
+
+type cargoCredGetOK struct {
+	Kind                 string `json:"kind"`
+	Token                string `json:"token"`
+	Cache                string `json:"cache"`
+	OperationIndependent bool   `json:"operation_independent"`
+}
+
+func cargoRespond(w io.Writer, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		// Marshalling a map/struct of strings can't fail in practice; a
+		// broken write is cargo's to report when the pipe closes.
+		return
+	}
+	fmt.Fprintln(w, string(data))
+}
+
+func cargoOK(w io.Writer, payload any) { cargoRespond(w, map[string]any{"Ok": payload}) }
+func cargoErr(w io.Writer, kind string) {
+	cargoRespond(w, map[string]any{"Err": map[string]any{"kind": kind}})
+}
+func cargoErrOther(w io.Writer, msg string) {
+	cargoRespond(w, map[string]any{"Err": map[string]any{"kind": "other", "message": msg}})
+}
+
+var cargoCredentialCmd = &cobra.Command{
+	// The [--cargo-plugin] placeholder is real: cargo invokes the provider
+	// with that marker argument, and flag parsing is disabled below, so it
+	// arrives as an ordinary arg.
+	Use:     "cargo-credential [--cargo-plugin]",
+	GroupID: groupPlumbing,
+	// Hidden only from shell tab-completion: helpVisibleAnnotation keeps
+	// it in the root help (rootUsageTemplate) and the generated docs.
+	Hidden:      true,
+	Annotations: map[string]string{helpVisibleAnnotation: "1"},
+	Short:       "Implement cargo's credential-provider protocol for a migrated registry token",
+	Long: "Not typically run by hand: jit migrate writes a cargo-credential-jit\n" +
+		"wrapper that invokes this command and registers it (last, so it takes\n" +
+		"precedence) in ~/.cargo/config.toml's global-credential-providers, so\n" +
+		"cargo fetches its registry token from the vault with no plaintext file\n" +
+		"on disk.\n\n" +
+		"The protocol's three kinds map to the vault: `get` serves the token from\n" +
+		"the registry's cargo-<name> profile (answering not-found for a registry\n" +
+		"jit holds nothing for, so cargo falls back to credentials.toml exactly\n" +
+		"as if jit weren't installed); `login` (what `cargo login` calls) saves\n" +
+		"the new token to the vault, so a re-login lands in the vault instead of\n" +
+		"back in a plaintext file; `logout` removes it.\n\n" +
+		"Requires local auth to resolve the vault the same way jit run/export do:\n" +
+		"either a reachable jit background service with an already-unlocked session, or an\n" +
+		"interactive context able to show a Touch ID/passcode prompt.",
+	// cargo passes --cargo-plugin; parse nothing and accept anything.
+	DisableFlagParsing: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		for _, a := range args {
+			if a == "--help" || a == "-h" {
+				return cmd.Help()
+			}
+		}
+		out := cmd.OutOrStdout()
+		cargoRespond(out, map[string]any{"v": []int{1}})
+
+		scanner := bufio.NewScanner(cmd.InOrStdin())
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if len(line) == 0 {
+				continue
+			}
+			var req cargoCredRequest
+			if err := json.Unmarshal(line, &req); err != nil {
+				cargoErrOther(out, fmt.Sprintf("jit cargo-credential: malformed request: %v", err))
+				continue
+			}
+			handleCargoCredRequest(out, req)
+		}
+		return scanner.Err()
+	},
+}
+
+// handleCargoCredRequest answers one protocol request. Every answer is a
+// protocol response, never a process error: cargo owns the conversation,
+// and a provider that dies mid-stream reports worse than one that says
+// what went wrong (spike finding 7).
+func handleCargoCredRequest(out io.Writer, req cargoCredRequest) {
+	registry := req.Registry.Name
+	if registry == "" {
+		// jit keys profiles by registry NAME (the [registries.<name>] the
+		// migration read; crates.io is cargo's own reserved "crates-io").
+		// A nameless invocation (source-replacement setups) can't match
+		// one, so fall through to the next provider rather than guess.
+		cargoErr(out, "not-found")
+		return
+	}
+	profileName := "cargo-" + registry
+
+	switch req.Kind {
+	case "get":
+		// A registry jit holds nothing for must NOT be an error or a
+		// prompt: checked against the global manifest directly (cargo
+		// profiles are always global-store), BEFORE openVault() — an
+		// unknown registry must never cost a Touch ID prompt, and
+		// not-found lets cargo fall back to credentials.toml (spike
+		// finding 6).
+		globalRoot, err := profile.GlobalRoot()
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		manifestPath, err := profile.Path(globalRoot, profileName)
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		p, err := profile.LoadFile(manifestPath)
+		if errors.Is(err, os.ErrNotExist) {
+			cargoErr(out, "not-found")
+			return
+		}
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		v, err := openVault()
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		values, err := inject.Resolve(v, p)
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		if values["TOKEN"] == "" {
+			cargoErr(out, "not-found")
+			return
+		}
+		// cache "session" spans one cargo invocation; the next cargo
+		// process asks again — exactly the just-in-time model.
+		cargoOK(out, cargoCredGetOK{Kind: "get", Token: values["TOKEN"], Cache: "session", OperationIndependent: true})
+
+	case "login":
+		if req.Token == "" {
+			cargoErrOther(out, "jit cargo-credential: login carried no token")
+			return
+		}
+		v, err := openVault()
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		if err := migrate.StoreCargoToken(v, registry, req.Token); err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		cargoOK(out, map[string]any{"kind": "login"})
+
+	case "logout":
+		// Removing a secret never decrypts anything, so `cargo logout`
+		// must never cost a Touch ID prompt — read-only construction,
+		// same as terraform-credentials forget.
+		v, err := openVaultReadOnly()
+		if err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		if err := migrate.ForgetCargoToken(v, registry); err != nil {
+			cargoErrOther(out, fmt.Sprintf("jit cargo-credential: %v", err))
+			return
+		}
+		cargoOK(out, map[string]any{"kind": "logout"})
+
+	default:
+		cargoErr(out, "operation-not-supported")
+	}
+}
+
+func init() {
+	rootCmd.AddCommand(cargoCredentialCmd)
+}

--- a/internal/cli/cargocred_test.go
+++ b/internal/cli/cargocred_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+//go:build darwin
+
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// An unknown registry must be the protocol's not-found answer — never an
+// error and never a Touch ID prompt (the manifest check runs before
+// openVault()) — so cargo falls back to `cargo:token` exactly as if jit
+// weren't installed (spike/cargo-credential-provider finding 6).
+func TestCargoCredGetUnknownRegistryAnswersNotFound(t *testing.T) {
+	withFixtureHome(t)
+
+	var buf bytes.Buffer
+	handleCargoCredRequest(&buf, cargoCredRequest{
+		V:    1,
+		Kind: "get",
+		Registry: struct {
+			IndexURL string `json:"index-url"`
+			Name     string `json:"name"`
+		}{IndexURL: "sparse+https://never.example/index/", Name: "never-migrated"},
+	})
+	if got := strings.TrimSpace(buf.String()); got != `{"Err":{"kind":"not-found"}}` {
+		t.Errorf("output = %q, want the protocol's not-found answer", got)
+	}
+}
+
+// A nameless invocation (source-replacement setups pass only the index
+// URL) can't match a cargo-<name> profile, so it must fall through, not
+// guess.
+func TestCargoCredGetNamelessRegistryAnswersNotFound(t *testing.T) {
+	withFixtureHome(t)
+
+	var buf bytes.Buffer
+	handleCargoCredRequest(&buf, cargoCredRequest{V: 1, Kind: "get"})
+	if got := strings.TrimSpace(buf.String()); got != `{"Err":{"kind":"not-found"}}` {
+		t.Errorf("output = %q, want not-found for a nameless registry", got)
+	}
+}
+
+func TestCargoCredUnknownKindAnswersOperationNotSupported(t *testing.T) {
+	withFixtureHome(t)
+
+	var buf bytes.Buffer
+	req := cargoCredRequest{V: 1, Kind: "read"}
+	req.Registry.Name = "crates-io"
+	handleCargoCredRequest(&buf, req)
+	if got := strings.TrimSpace(buf.String()); got != `{"Err":{"kind":"operation-not-supported"}}` {
+		t.Errorf("output = %q, want operation-not-supported", got)
+	}
+}
+
+// The full command conversation: greeting first ({"v":[1]}), then one
+// answer per request line — the handshake cargo 1.98 was verified to
+// accept in the spike.
+func TestCargoCredCommandConversation(t *testing.T) {
+	withFixtureHome(t)
+	withFixtureCwd(t)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetIn(strings.NewReader(`{"v":1,"registry":{"index-url":"sparse+https://x.example/","name":"never-migrated"},"kind":"get","operation":"read"}` + "\n"))
+	rootCmd.SetArgs([]string{"cargo-credential", "--cargo-plugin"})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("cargo-credential: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines %q, want greeting + one answer", len(lines), lines)
+	}
+	if lines[0] != `{"v":[1]}` {
+		t.Errorf("greeting = %q, want {\"v\":[1]}", lines[0])
+	}
+	if lines[1] != `{"Err":{"kind":"not-found"}}` {
+		t.Errorf("answer = %q, want not-found", lines[1])
+	}
+}

--- a/internal/cli/migrate.go
+++ b/internal/cli/migrate.go
@@ -50,7 +50,7 @@ var (
 // post-migrate agent-cache sweep, which rewrites files under $HOME that the
 // run's other categories never name. Before it existed, --only env still ran
 // the sweep and NO token could scope it out (issue #79).
-var migrateCategories = []string{"env", "tfvars", "k8s-secret", "shell", "history", "mcp", "aws", "kube", "terraform", "docker", "git", "gcp", "sops", "npmrc", "netrc", "pypirc", "loose", "cache"}
+var migrateCategories = []string{"env", "tfvars", "k8s-secret", "shell", "history", "mcp", "aws", "kube", "terraform", "docker", "git", "gcp", "sops", "npmrc", "netrc", "pypirc", "cargo", "streamlit", "loose", "cache"}
 
 // discovered holds one run's findings per category. runMigratePath resolves
 // each named target into one of these and hands it to applyMigrate — the
@@ -80,6 +80,8 @@ type discovered struct {
 	npmrcFiles              []string
 	netrcFiles              []string
 	pypircFiles             []string
+	cargoRegistries         []string
+	streamlitFiles          []string
 	looseSecretFiles        []string
 	// looseEmbeddedSkipped is note-only (like tfvarsComplexOnly): files that
 	// mix a secret with other content, which neutralize can't move whole.
@@ -416,22 +418,24 @@ var migrateCmd = &cobra.Command{
 		"With arguments, discovery is scoped to the targets you name (plus the\n" +
 		"agent-cache sweep described below). Each target is resolved on its own:\n\n" +
 		"  A file       is routed to the right category by what it is. A project file\n" +
-		"               (.env, *.tfvars, mcp.json/.mcp.json, .npmrc) has its secrets\n" +
+		"               (.env, *.tfvars, mcp.json/.mcp.json, .npmrc,\n" +
+		"               .streamlit/secrets.toml) has its secrets\n" +
 		"               moved into a profile and the vault, the file keeps working as a\n" +
 		"               live mount (a git-safe <file>.pointers companion is written\n" +
 		"               alongside). A machine-wide file at a known path (a shell config\n" +
 		"               like ~/.zshrc, a shell history file like ~/.zsh_history,\n" +
 		"               ~/.aws/credentials, ~/.kube/config, Terraform Cloud creds,\n" +
-		"               ~/.docker/config.json, ~/.git-credentials, GCP\n" +
+		"               ~/.docker/config.json, ~/.git-credentials, ~/.cargo/credentials.toml, GCP\n" +
 		"               application-default credentials, a SOPS age key, ~/.netrc,\n" +
 		"               ~/.pypirc, Claude Desktop's MCP config, Claude Code's\n" +
-		"               ~/.claude.json, the global ~/.npmrc)\n" +
+		"               ~/.claude.json, the global ~/.npmrc, the global\n" +
+		"               ~/.streamlit/secrets.toml)\n" +
 		"               is routed to that credential type's handling\n" +
 		"               (credential_process, exec plugin, credential helper, live\n" +
 		"               mount, or in-place redaction for a history file, where each\n" +
 		"               recorded credential moves to the vault and the line keeps\n" +
 		"               its shape, minus the secret).\n" +
-		"  A directory  is walked for its .env/tfvars/mcp/npmrc findings only, never\n" +
+		"  A directory  is walked for its .env/tfvars/mcp/npmrc/streamlit findings only, never\n" +
 		"               the machine-wide fixed-path files (those aren't \"under\" any\n" +
 		"               project directory) — name them explicitly to convert them.\n\n" +
 		"Targets are explicit, so nothing is skipped for looking archived/backup-like:\n" +
@@ -540,6 +544,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 	npmrcFiles := d.npmrcFiles
 	netrcFiles := d.netrcFiles
 	pypircFiles := d.pypircFiles
+	cargoRegistries := d.cargoRegistries
+	streamlitFiles := d.streamlitFiles
 	looseSecretFiles := d.looseSecretFiles
 	looseEmbeddedSkipped := d.looseEmbeddedSkipped
 	historyKeyOnly := d.historyKeyOnly
@@ -579,6 +585,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		"npmrc":      &npmrcFiles,
 		"netrc":      &netrcFiles,
 		"pypirc":     &pypircFiles,
+		"cargo":      &cargoRegistries,
+		"streamlit":  &streamlitFiles,
 		"loose":      &looseSecretFiles,
 	}
 	// len-1: "cache" is file-less (the sweep, not a file list) and lives
@@ -697,6 +705,8 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		npmrcFiles:       npmrcFiles,
 		netrcFiles:       netrcFiles,
 		pypircFiles:      pypircFiles,
+		cargoRegistries:  cargoRegistries,
+		streamlitFiles:   streamlitFiles,
 		looseSecretFiles: looseSecretFiles,
 		jitPaths:         jitPaths,
 		jitPathTarget:    d.jitPathTarget,
@@ -1380,6 +1390,64 @@ func applyMigrate(cmd *cobra.Command, home string, d *discovered, extras *planEx
 		fmt.Fprintln(out)
 	}
 
+	if n := len(cargoRegistries); n > 0 {
+		summary.checkGitHistory(migrate.CargoCredentialPaths(home)[0])
+		printMigrateResultCategory(out, pluralWord(n, "cargo registry token", "cargo registry tokens")+" migrated", n)
+		for _, cargoRegistry := range cargoRegistries {
+			result, err := migrate.ApplyCargoRegistry(v, home, cargoRegistry, backups)
+			if err != nil {
+				return false, fmt.Errorf("jit migrate: %w", err)
+			}
+			backupNotes := fmt.Sprintf("`jit vault get %s`", result.CredentialsBackup)
+			if result.ConfigBackup != "" {
+				backupNotes += fmt.Sprintf(", `jit vault get %s`", result.ConfigBackup)
+			}
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %q -> vault profile %q (%s); backups: %s\n",
+				cargoRegistry, result.VaultProfileName, countWord(len(result.Variables), "var", "vars"), backupNotes)))
+		}
+		fmt.Fprintln(out, hlCmds("  `cargo login`/`logout` keep working — a re-login lands in the vault, not a file."))
+		fmt.Fprintln(out)
+	}
+
+	if n := len(streamlitFiles); n > 0 {
+		printMigrateResultCategory(out, pluralWord(n, "Streamlit secrets file", "Streamlit secrets files")+" migrated", n)
+		for _, slPath := range streamlitFiles {
+			summary.checkGitHistory(slPath)
+
+			// The project root is the parent of .streamlit — the file's
+			// location inside a project is fixed by Streamlit, so the root
+			// derives from the path itself, never from the invoking cwd
+			// (the deriveProfileName lesson recorded in migrate/doc.go).
+			// When that parent IS $HOME, this is the global file.
+			globalStreamlit := slPath == migrate.StreamlitGlobalPath(home)
+			slRoot := filepath.Dir(filepath.Dir(slPath))
+			result, err := migrate.ApplyStreamlitSecrets(v, slRoot, slPath, globalStreamlit)
+			if err != nil {
+				return false, fmt.Errorf("jit migrate: %w", err)
+			}
+			if err := addMount(mount.Entry{MountPath: slPath, ProfilePath: result.ProfilePath, TemplatePath: result.TemplatePath}); err != nil {
+				return false, fmt.Errorf("jit migrate: registering mount for %s: %w", slPath, err)
+			}
+			if err := summary.writePointerFile(slPath, result.ProfilePath); err != nil {
+				return false, fmt.Errorf("jit migrate: %w", err)
+			}
+			fmt.Fprint(out, hlCmds(fmt.Sprintf("  "+glyphBullet+" %s -> profile %q (%s); backup: `jit vault get %s`\n",
+				displayPath(home, slPath), result.ProfileName, countWord(len(result.Variables), "var", "vars"), result.BackupPath)))
+			noteNamespaceMove(out, result.NamespaceMovedFrom, result.ProfileName)
+			if globalStreamlit {
+				// The global ~/.streamlit/secrets.toml is a machine-wide
+				// mount, same as ~/.pypirc: usage is explicit `jit run
+				// --with streamlit` intent (plan §12a). A project's own
+				// file needs no reminder — `jit run` grants it from the
+				// project directory like any project template mount.
+				if g, ok := globalMountGuidanceForPath(home, slPath); ok {
+					fmt.Fprintf(out, "    %s read it with: jit run --with %s <command>\n", g.tools, g.name)
+				}
+			}
+		}
+		fmt.Fprintln(out)
+	}
+
 	opLinks.print(out)
 
 	// Best-effort: an unreadable marker means no nudge, never a failed
@@ -1791,6 +1859,15 @@ func discoverDirTarget(d *discovered, home, dir string) error {
 		return err
 	}
 	d.npmrcFiles = append(d.npmrcFiles, npms...)
+	// One walk finds both a project's .streamlit/secrets.toml and — when
+	// dir IS $HOME — the global ~/.streamlit/secrets.toml, which is just
+	// the copy that happens to sit there (audit's scanner takes the same
+	// one-walk stance; see migrate.DiscoverStreamlitSecrets).
+	sls, err := migrate.DiscoverStreamlitSecrets(dir)
+	if err != nil {
+		return err
+	}
+	d.streamlitFiles = append(d.streamlitFiles, sls...)
 	return nil
 }
 
@@ -1919,6 +1996,16 @@ func discoverFileTarget(d *discovered, home, path string) error {
 			return err
 		}
 		d.netrcFiles = append(d.netrcFiles, filterToTarget(files, path)...)
+		return nil
+	case migrate.CargoCredentialPaths(home)[0], migrate.CargoCredentialPaths(home)[1]:
+		// Name-keyed like aws/kube/terraform: naming either credentials
+		// file migrates every registry it holds (and strips the stale
+		// copy in the sibling file too — cargo reads only the first).
+		regs, err := migrate.DiscoverCargoRegistries(home)
+		if err != nil {
+			return err
+		}
+		d.cargoRegistries = append(d.cargoRegistries, regs...)
 		return nil
 	case migrate.PypircPath(home):
 		files, err := migrate.DiscoverPypirc(home)
@@ -2065,7 +2152,7 @@ func (d *discovered) dedupe() {
 		&d.k8sManifests, &d.k8sManifestsComplexOnly, &d.shellConfigs,
 		&d.historyFiles, &d.mcpConfigs, &d.awsProfiles, &d.k8sUsers, &d.terraformHosts,
 		&d.dockerRegistries, &d.gitHosts, &d.gcpADCFiles, &d.sopsAgeFiles,
-		&d.npmrcFiles, &d.netrcFiles, &d.pypircFiles, &d.looseSecretFiles, &d.looseEmbeddedSkipped,
+		&d.npmrcFiles, &d.netrcFiles, &d.pypircFiles, &d.cargoRegistries, &d.streamlitFiles, &d.looseSecretFiles, &d.looseEmbeddedSkipped,
 		&d.historyKeyOnly, &d.wrapOwnedSkipped, &d.jitPathRefused,
 	} {
 		dedupeStrings(s)
@@ -2091,7 +2178,7 @@ func (d *discovered) total() int {
 		d.envFiles, d.tfvarsFiles, d.k8sManifests, d.shellConfigs, d.historyFiles, d.mcpConfigs, d.awsProfiles,
 		d.k8sUsers, d.terraformHosts, d.dockerRegistries, d.gitHosts,
 		d.gcpADCFiles, d.sopsAgeFiles, d.npmrcFiles, d.netrcFiles, d.pypircFiles,
-		d.looseSecretFiles,
+		d.cargoRegistries, d.streamlitFiles, d.looseSecretFiles,
 	} {
 		n += len(s)
 	}

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -201,9 +201,9 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		printMigratePlanCategory(w,
 			pluralWord(len(npmrcScoped), "npmrc file", "npmrc files")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount",
 			shorten(npmrcScoped))
-		printMigratePlanCategory(w,
+		printMigratePlanCategoryAnnotated(w,
 			pluralWord(len(streamlitScoped), "Streamlit secrets file", "Streamlit secrets files")+" "+glyphAction+" credentials move to the vault; the file keeps working via a live, auto-updating mount (other settings untouched)",
-			shorten(streamlitScoped))
+			shorten(streamlitScoped), streamlitPlanAnnotation(home))
 		looseName := pluralWord(len(d.looseSecretFiles), "loose secret file", "loose secret files")
 		looseHeadline := looseName + " " + glyphAction + " the whole file is a bare token; it moves to the vault and the file is replaced with a git-safe pointer (retrieve with `jit vault get`)"
 		if migrateMount {
@@ -314,9 +314,9 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		printMigratePlanCategory(w,
 			pluralWord(len(d.cargoRegistries), "cargo registry token", "cargo registry tokens")+" in ~/.cargo/credentials.toml "+glyphAction+" "+pluralWord(len(d.cargoRegistries), "the token moves", "tokens move")+" to the vault; fetched automatically whenever cargo needs "+pluralWord(len(d.cargoRegistries), "it", "them")+" (cargo login/logout keep working)",
 			d.cargoRegistries)
-		printMigratePlanCategory(w,
+		printMigratePlanCategoryAnnotated(w,
 			pluralWord(len(streamlitFixed), "Streamlit secrets file", "Streamlit secrets files")+" "+glyphAction+" credentials move to the vault; the file keeps working via a live, auto-updating mount (other settings untouched)",
-			shorten(streamlitFixed))
+			shorten(streamlitFixed), streamlitPlanAnnotation(home))
 
 		// --only filters by CATEGORY, not by this scoped/machine-wide
 		// split — selecting "mcp" or "npmrc" always pulls in their own
@@ -443,6 +443,25 @@ func splitNpmrcByScope(home string, npmrcFiles []string) (scoped, fixed []string
 		}
 	}
 	return scoped, fixed
+}
+
+// streamlitPlanAnnotation counts each secrets.toml's migratable
+// credentials for the plan row, the same per-file number the .env rows
+// carry. The callback receives the display-shortened path, so it expands
+// "~" back through home; best-effort — an unreadable file annotates as
+// nothing, never fails the plan.
+func streamlitPlanAnnotation(home string) func(string) string {
+	return func(item string) string {
+		path := item
+		if strings.HasPrefix(path, "~/") {
+			path = filepath.Join(home, path[2:])
+		}
+		n, err := migrate.StreamlitFilePreview(path)
+		if err != nil || n == 0 {
+			return ""
+		}
+		return countWord(n, "credential", "credentials")
+	}
 }
 
 // splitStreamlitByScope separates the global ~/.streamlit/secrets.toml

--- a/internal/cli/migrateplan.go
+++ b/internal/cli/migrateplan.go
@@ -109,6 +109,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 	// "~"-shortened copy would never match them.
 	mcpScoped, mcpFixed := splitMCPByScope(home, d.mcpConfigs)
 	npmrcScoped, npmrcFixed := splitNpmrcByScope(home, d.npmrcFiles)
+	streamlitScoped, streamlitFixed := splitStreamlitByScope(home, d.streamlitFiles)
 
 	shorten := func(items []string) []string {
 		out := make([]string, len(items))
@@ -125,8 +126,8 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		mcpOriginal[shorten([]string{p})[0]] = p
 	}
 
-	hasScoped := len(d.envFiles) > 0 || len(d.tfvarsFiles) > 0 || len(d.k8sManifests) > 0 || len(mcpScoped) > 0 || len(npmrcScoped) > 0 || len(d.looseSecretFiles) > 0
-	hasFixed := len(d.shellConfigs) > 0 || len(d.historyFiles) > 0 || len(mcpFixed) > 0 || len(d.awsProfiles) > 0 || len(d.k8sUsers) > 0 || len(d.terraformHosts) > 0 || len(d.dockerRegistries) > 0 || len(d.gitHosts) > 0 || len(d.gcpADCFiles) > 0 || len(d.sopsAgeFiles) > 0 || len(npmrcFixed) > 0 || len(d.netrcFiles) > 0 || len(d.pypircFiles) > 0 || len(d.jitPaths) > 0
+	hasScoped := len(d.envFiles) > 0 || len(d.tfvarsFiles) > 0 || len(d.k8sManifests) > 0 || len(mcpScoped) > 0 || len(npmrcScoped) > 0 || len(streamlitScoped) > 0 || len(d.looseSecretFiles) > 0
+	hasFixed := len(d.shellConfigs) > 0 || len(d.historyFiles) > 0 || len(mcpFixed) > 0 || len(d.awsProfiles) > 0 || len(d.k8sUsers) > 0 || len(d.terraformHosts) > 0 || len(d.dockerRegistries) > 0 || len(d.gitHosts) > 0 || len(d.gcpADCFiles) > 0 || len(d.sopsAgeFiles) > 0 || len(npmrcFixed) > 0 || len(d.netrcFiles) > 0 || len(d.pypircFiles) > 0 || len(d.cargoRegistries) > 0 || len(streamlitFixed) > 0 || len(d.jitPaths) > 0
 
 	if hasScoped {
 		// The annotation callback below is handed the display-shortened path,
@@ -200,6 +201,9 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		printMigratePlanCategory(w,
 			pluralWord(len(npmrcScoped), "npmrc file", "npmrc files")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount",
 			shorten(npmrcScoped))
+		printMigratePlanCategory(w,
+			pluralWord(len(streamlitScoped), "Streamlit secrets file", "Streamlit secrets files")+" "+glyphAction+" credentials move to the vault; the file keeps working via a live, auto-updating mount (other settings untouched)",
+			shorten(streamlitScoped))
 		looseName := pluralWord(len(d.looseSecretFiles), "loose secret file", "loose secret files")
 		looseHeadline := looseName + " " + glyphAction + " the whole file is a bare token; it moves to the vault and the file is replaced with a git-safe pointer (retrieve with `jit vault get`)"
 		if migrateMount {
@@ -305,6 +309,14 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 		printMigratePlanCategory(w,
 			pluralWord(len(d.pypircFiles), "~/.pypirc credential", "~/.pypirc credentials")+" "+glyphAction+" secrets move to the vault; the file keeps working via a live, auto-updating mount (repository/username lines untouched)",
 			shorten(d.pypircFiles))
+		// Cargo items are registry NAMES like terraform's hosts — nothing
+		// to shorten.
+		printMigratePlanCategory(w,
+			pluralWord(len(d.cargoRegistries), "cargo registry token", "cargo registry tokens")+" in ~/.cargo/credentials.toml "+glyphAction+" "+pluralWord(len(d.cargoRegistries), "the token moves", "tokens move")+" to the vault; fetched automatically whenever cargo needs "+pluralWord(len(d.cargoRegistries), "it", "them")+" (cargo login/logout keep working)",
+			d.cargoRegistries)
+		printMigratePlanCategory(w,
+			pluralWord(len(streamlitFixed), "Streamlit secrets file", "Streamlit secrets files")+" "+glyphAction+" credentials move to the vault; the file keeps working via a live, auto-updating mount (other settings untouched)",
+			shorten(streamlitFixed))
 
 		// --only filters by CATEGORY, not by this scoped/machine-wide
 		// split — selecting "mcp" or "npmrc" always pulls in their own
@@ -335,7 +347,7 @@ func printMigratePlan(w io.Writer, home string, d *discovered, extras *planExtra
 	printPlanExtras(w, home, extras)
 
 	categories, total := 0, 0
-	for _, items := range [][]string{d.envFiles, d.tfvarsFiles, d.k8sManifests, d.shellConfigs, d.historyFiles, d.mcpConfigs, d.awsProfiles, d.k8sUsers, d.terraformHosts, d.dockerRegistries, d.gitHosts, d.gcpADCFiles, d.sopsAgeFiles, d.npmrcFiles, d.netrcFiles, d.pypircFiles, d.looseSecretFiles} {
+	for _, items := range [][]string{d.envFiles, d.tfvarsFiles, d.k8sManifests, d.shellConfigs, d.historyFiles, d.mcpConfigs, d.awsProfiles, d.k8sUsers, d.terraformHosts, d.dockerRegistries, d.gitHosts, d.gcpADCFiles, d.sopsAgeFiles, d.npmrcFiles, d.netrcFiles, d.pypircFiles, d.cargoRegistries, d.streamlitFiles, d.looseSecretFiles} {
 		if len(items) > 0 {
 			categories++
 		}
@@ -424,6 +436,21 @@ func splitMCPByScope(home string, mcpConfigs []string) (scoped, fixed []string) 
 func splitNpmrcByScope(home string, npmrcFiles []string) (scoped, fixed []string) {
 	globalPath := migrate.GlobalNpmrcPath(home)
 	for _, path := range npmrcFiles {
+		if path == globalPath {
+			fixed = append(fixed, path)
+		} else {
+			scoped = append(scoped, path)
+		}
+	}
+	return scoped, fixed
+}
+
+// splitStreamlitByScope separates the global ~/.streamlit/secrets.toml
+// from any project-scoped .streamlit/secrets.toml findings in the same
+// DiscoverStreamlitSecrets result — same reasoning as splitNpmrcByScope.
+func splitStreamlitByScope(home string, streamlitFiles []string) (scoped, fixed []string) {
+	globalPath := migrate.StreamlitGlobalPath(home)
+	for _, path := range streamlitFiles {
 		if path == globalPath {
 			fixed = append(fixed, path)
 		} else {

--- a/internal/cli/scan.go
+++ b/internal/cli/scan.go
@@ -39,6 +39,7 @@ func newAuditConfig() (audit.Config, error) {
 		return cfg, err
 	}
 	cfg.K8sMigratable = k8sMigratableForScan
+	cfg.StreamlitMigratable = streamlitMigratableForScan
 	return cfg, nil
 }
 
@@ -60,6 +61,23 @@ func k8sMigratableForScan(path string) (reason string, ok bool) {
 		// Recognized but with nothing migrate can move (fully
 		// SOPS-encrypted, an empty scaffold).
 		return "no plaintext Secret values migrate can move", false
+	}
+}
+
+// streamlitMigratableForScan answers the hook with migrate's own probe, so
+// scan and migrate can never disagree about a secrets.toml. Read-only and
+// prompt-free, as the hook's contract requires.
+func streamlitMigratableForScan(path string) (reason string, ok bool) {
+	n, err := migrate.StreamlitFilePreview(path)
+	switch {
+	case err != nil:
+		// Unreadable where audit could read it moments ago (racing edit,
+		// permissions): don't promise a migrate that will error.
+		return err.Error(), false
+	case n == 0:
+		return "its values aren't single-line quoted strings", false
+	default:
+		return "", true
 	}
 }
 

--- a/internal/cli/withmounts.go
+++ b/internal/cli/withmounts.go
@@ -39,6 +39,10 @@ func globalMountKinds(home string) map[string][]string {
 		"npm":   {migrate.GlobalNpmrcPath(home)},
 		"netrc": {migrate.NetrcPath(home)},
 		"pypi":  {migrate.PypircPath(home)},
+		// The GLOBAL ~/.streamlit/secrets.toml only — a project's own
+		// .streamlit/secrets.toml is a project template mount, granted by
+		// running from the project directory like a project .npmrc.
+		"streamlit": {migrate.StreamlitGlobalPath(home)},
 	}
 }
 
@@ -138,6 +142,8 @@ func globalMountGuidanceForPath(home, mountPath string) (globalMountGuidance, bo
 		return globalMountGuidance{name: "netrc", tools: "curl, git, ftp, wget"}, true
 	case migrate.PypircPath(home):
 		return globalMountGuidance{name: "pypi", tools: "twine, uv publish, poetry publish"}, true
+	case migrate.StreamlitGlobalPath(home):
+		return globalMountGuidance{name: "streamlit", tools: "streamlit run"}, true
 	}
 	for _, p := range migrate.SOPSAgeKeyPaths(home) {
 		if mountPath == p {

--- a/internal/consent/policy.go
+++ b/internal/consent/policy.go
@@ -29,16 +29,20 @@ package consent
 // importing it (consent stays a pure package); the TEST imports vault, which
 // is where the coupling belongs.
 var credentialClasses = map[string]bool{
-	"aws":           true,
-	"terraform":     true,
-	"docker":        true,
-	"git":           true,
-	"kube":          true,
-	"gcp":           true,
-	"sops":          true,
-	"npmrc":         true,
-	"netrc":         true,
-	"pypirc":        true,
+	"aws":       true,
+	"terraform": true,
+	"docker":    true,
+	"git":       true,
+	"kube":      true,
+	"gcp":       true,
+	"sops":      true,
+	"npmrc":     true,
+	"netrc":     true,
+	"pypirc":    true,
+	// cargo is a crates.io/registry publish token — the same
+	// supply-chain blast radius as npmrc's and pypirc's, gated for the
+	// same reason.
+	"cargo":         true,
 	"k8s_secret":    true,
 	"shell_history": true,
 	// 1password is a secret linked from the user's password manager (`jit
@@ -65,6 +69,14 @@ var ungatedClasses = map[string]bool{
 	"manual":     true,
 	"loose_file": true,
 	"wrap":       true,
+	// streamlit is a .streamlit/secrets.toml — the application's own
+	// secrets (database passwords, API keys the app itself uses), read by
+	// st.secrets exactly the way a .env's values are read by the app. It
+	// sits in dotenv's half of the partition for dotenv's reason: a
+	// project's own secrets, delivered through a jit run the user
+	// launched. It is NOT a registry/publish credential like npmrc or
+	// pypirc, which is what puts those on the gated side.
+	"streamlit": true,
 }
 
 // RequiresConsent reports whether a secret of the given provenance class is

--- a/internal/migrate/backuptracker.go
+++ b/internal/migrate/backuptracker.go
@@ -83,6 +83,30 @@ func (t *BackupTracker) backupOnce(v *vault.Vault, path string) (string, error) 
 	return vp, nil
 }
 
+// backupOnceLinking is backupOnce for a migration whose undo is only
+// correct if other files come back in the same run (see
+// BackupRecord.RestoreWith). The link is recorded on the FIRST backup of
+// path — later dedup'd calls return the cached vault path, exactly like
+// backupOnce, and the first call's links stand for the run.
+func (t *BackupTracker) backupOnceLinking(v *vault.Vault, path string, restoreWith []string) (string, error) {
+	if t == nil {
+		return backupSecretFileLinking(v, path, restoreWith)
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolving %s: %w", path, err)
+	}
+	if vp, ok := t.backups[absPath]; ok {
+		return vp, nil
+	}
+	vp, err := backupSecretFileLinking(v, path, restoreWith)
+	if err != nil {
+		return "", err
+	}
+	t.backups[absPath] = vp
+	return vp, nil
+}
+
 // alreadyHandled reports whether an earlier unit in this run already gave
 // path a disposition — either backed it up (backupOnce) or created it fresh
 // (markCreated). A later unit that sees true must not add a second undo-index

--- a/internal/migrate/cargocreds.go
+++ b/internal/migrate/cargocreds.go
@@ -1,0 +1,513 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jitpass/jit/internal/profile"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// Cargo registry migration (RFC.md Pillar III Tier 2, same shape as
+// Terraform's credentials_helper): `cargo login` stores a plain publish
+// token in ~/.cargo/credentials.toml. Cargo's stable credential-provider
+// mechanism (1.74+) is the native hook: a cargo-credential-jit wrapper
+// exec'ing `jit cargo-credential` (the JSON protocol over stdin/stdout),
+// registered LAST in [registry] global-credential-providers so it takes
+// precedence — spike/cargo-credential-provider/FINDINGS.md verified every
+// protocol shape empirically, including that later entries win, that
+// `cargo login`/`logout` route through the provider (so a re-login lands
+// in the vault, never back in the plaintext file), and that a not-found
+// answer falls back to `cargo:token` cleanly for unmigrated registries.
+
+// cargoProfilePrefix namespaces the global vault profile for a registry:
+// "cargo-crates-io", "cargo-<name>". Global-store because cargo invokes
+// its provider from whatever directory a build happens to use, same
+// reasoning as terraform's.
+const cargoProfilePrefix = "cargo-"
+
+// cargoCratesIOName is the registry name cargo itself reserves for
+// crates.io — the `[registry]` table in credentials.toml — and the name
+// the credential-provider protocol reports for it.
+const cargoCratesIOName = "crates-io"
+
+// CargoMigration describes what jit migrate did to one registry's token.
+type CargoMigration struct {
+	Registry          string
+	CredentialsPath   string // the file the token was found in
+	CredentialsBackup string
+	ConfigPath        string
+	ConfigBackup      string // "" when ~/.cargo/config.toml didn't exist before this run
+	HelperPath        string
+	VaultProfileName  string // "cargo-<registry>"
+	VaultProfilePath  string
+	Variables         []string
+}
+
+// CargoCredentialPaths returns the two files cargo reads a registry token
+// from: credentials.toml, and the pre-1.39 bare "credentials" it still
+// honors. Mirrors audit's cargoCredentialPaths (scanCargoCredentials) —
+// cargo only reads the first that exists, but a stale copy in the other
+// is still a plaintext credential, so migration strips both.
+func CargoCredentialPaths(home string) []string {
+	return []string{
+		filepath.Join(home, ".cargo", "credentials.toml"),
+		filepath.Join(home, ".cargo", "credentials"),
+	}
+}
+
+// CargoConfigPath returns ~/.cargo/config.toml, where the
+// credential-provider registration lives.
+func CargoConfigPath(home string) string {
+	return filepath.Join(home, ".cargo", "config.toml")
+}
+
+// CargoHelperPath returns where the wrapper executable lives. Unlike
+// Terraform (which discovers helpers by name in a fixed plugin dir),
+// cargo takes the provider as a path in config.toml, so the wrapper sits
+// beside cargo's own files in ~/.cargo. The cargo-credential-<name>
+// naming follows cargo's convention for provider executables.
+func CargoHelperPath(home string) string {
+	return filepath.Join(home, ".cargo", "cargo-credential-jit")
+}
+
+// cargoSectionPattern matches the two token-holding table headers
+// credentials.toml uses: [registry] (crates.io) and [registries.<name>].
+var cargoSectionPattern = regexp.MustCompile(`^\s*\[\s*(registry|registries\.([A-Za-z0-9_-]+))\s*\]\s*$`)
+
+// cargoTokenLinePattern matches the `token = "..."` line within a table.
+var cargoTokenLinePattern = regexp.MustCompile(`^\s*token\s*=\s*"([^"]*)"\s*$`)
+
+// cargoRegistryToken is one registry's token and where it was found.
+type cargoRegistryToken struct {
+	Registry string // "crates-io" or the [registries.<name>] name
+	Token    string
+	Path     string // which credentials file held it
+	Line     int    // 0-based line index in that file
+}
+
+// findCargoTokens parses one credentials file line-orientedly (the same
+// line-oriented TOML subset audit's scanCargoCredentialFile reads via
+// parseINISections) and returns every non-empty registry token in it.
+func findCargoTokens(path string) ([]cargoRegistryToken, error) {
+	lines, err := readLines(path)
+	if err != nil {
+		return nil, err
+	}
+	var out []cargoRegistryToken
+	registry := ""
+	for i, line := range lines {
+		if m := cargoSectionPattern.FindStringSubmatch(line); m != nil {
+			if m[2] != "" {
+				registry = m[2]
+			} else {
+				registry = cargoCratesIOName
+			}
+			continue
+		}
+		if strings.HasPrefix(strings.TrimSpace(line), "[") {
+			registry = "" // some other table — its keys are not registry tokens
+			continue
+		}
+		if registry == "" {
+			continue
+		}
+		m := cargoTokenLinePattern.FindStringSubmatch(line)
+		if m == nil || m[1] == "" {
+			continue
+		}
+		out = append(out, cargoRegistryToken{Registry: registry, Token: m[1], Path: path, Line: i})
+	}
+	return out, nil
+}
+
+// DiscoverCargoRegistries returns every registry name with a non-empty
+// token in either cargo credentials file, sorted for determinism. A
+// missing file yields nothing; cargo reads the first file that exists, so
+// when both hold a token for one registry the first file's value is the
+// live one and wins (findCargoTokensAll keeps that order).
+func DiscoverCargoRegistries(home string) ([]string, error) {
+	tokens, err := findCargoTokensAll(home)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var names []string
+	for _, t := range tokens {
+		if !seen[t.Registry] {
+			seen[t.Registry] = true
+			names = append(names, t.Registry)
+		}
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func findCargoTokensAll(home string) ([]cargoRegistryToken, error) {
+	var all []cargoRegistryToken
+	for _, path := range CargoCredentialPaths(home) {
+		// Lstat + IsRegular before reading, the same guard every Discover
+		// here applies: a FIFO from an earlier migration must never be
+		// opened for read (it would block forever with no agent writing).
+		info, err := os.Lstat(path)
+		if err != nil || !info.Mode().IsRegular() {
+			continue
+		}
+		tokens, err := findCargoTokens(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		all = append(all, tokens...)
+	}
+	return all, nil
+}
+
+// cargoProvidersPattern finds an existing global-credential-providers
+// line in ~/.cargo/config.toml. Cargo allows a LIST of providers, but
+// merging jit's entry into someone's hand-written TOML array by string
+// surgery is exactly the kind of edit that can't be done provably right
+// line-orientedly — so like Terraform's one-helper conflict, an existing
+// configuration that isn't jit's own is a hard stop with instructions,
+// never a silent rewrite.
+var cargoProvidersPattern = regexp.MustCompile(`(?m)^\s*global-credential-providers\s*=\s*(.*)$`)
+
+// checkCargoConfigConflict inspects ~/.cargo/config.toml before anything
+// is mutated: returns the error to fail with if a provider list jit
+// didn't write is already configured, and whether jit's own line is
+// already present (a re-run — idempotent, nothing to add).
+func checkCargoConfigConflict(configPath, helperPath string) (alreadyInstalled bool, err error) {
+	data, err := os.ReadFile(configPath) // #nosec G304 -- fixed ~/.cargo path, not external input
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("reading %s: %w", configPath, err)
+	}
+	m := cargoProvidersPattern.FindSubmatch(data)
+	if m == nil {
+		return false, nil
+	}
+	if strings.Contains(string(m[1]), helperPath) {
+		return true, nil
+	}
+	return false, fmt.Errorf("%s already configures global-credential-providers, so jit won't rewrite it; add %q as the LAST entry yourself (last wins) if you want jit to serve these tokens", configPath, helperPath)
+}
+
+// upsertCargoProfile merges TOKEN -> its vault path into the registry's
+// global profile manifest, the same merge-not-overwrite discipline
+// upsertTerraformProfile follows.
+func upsertCargoProfile(v *vault.Vault, registry string, token []byte, meta vault.Meta) (name, manifestPath, secretPath string, err error) {
+	name = cargoProfilePrefix + registry
+	globalRoot, err := profile.GlobalRoot()
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving global profile root: %w", err)
+	}
+	manifestPath, err = profile.Path(globalRoot, name)
+	if err != nil {
+		return "", "", "", err
+	}
+
+	entries := profile.Profile{}
+	switch existing, lerr := profile.LoadFile(manifestPath); {
+	case lerr == nil:
+		for k, v2 := range existing {
+			entries[k] = v2
+		}
+	case errors.Is(lerr, os.ErrNotExist):
+		// no existing profile yet — start fresh
+	default:
+		return "", "", "", fmt.Errorf("loading existing profile %s: %w", manifestPath, lerr)
+	}
+
+	secretPath = name + "/TOKEN"
+	if err := v.SetWithMeta(secretPath, token, meta); err != nil {
+		return "", "", "", fmt.Errorf("storing token in vault: %w", err)
+	}
+	entries["TOKEN"] = secretPath
+	if err := writeProfileManifest(manifestPath, entries, nil); err != nil {
+		return "", "", "", fmt.Errorf("writing profile %s: %w", manifestPath, err)
+	}
+	return name, manifestPath, secretPath, nil
+}
+
+// ApplyCargoRegistry moves one registry's token out of cargo's
+// credentials file(s) and into v's vault under a home-rooted global
+// profile ("cargo-<registry>"), writes the cargo-credential-jit wrapper,
+// registers it in ~/.cargo/config.toml, and strips the token line(s) from
+// every credentials file that held one. Standard ordering: conflict check
+// first, then vault writes -> profile manifest -> backups -> wiring ->
+// rewrite the source files, so a run that can't complete never
+// half-mutates.
+//
+// dedup, if non-nil, makes a run migrating several registries back each
+// shared file up once, at its pristine pre-run state (BackupTracker,
+// GAPS.md #65).
+func ApplyCargoRegistry(v *vault.Vault, home, registry string, dedup ...*BackupTracker) (CargoMigration, error) {
+	var tracker *BackupTracker
+	if len(dedup) > 0 {
+		tracker = dedup[0]
+	}
+
+	tokens, err := findCargoTokensAll(home)
+	if err != nil {
+		return CargoMigration{}, err
+	}
+	var live *cargoRegistryToken
+	for i := range tokens {
+		if tokens[i].Registry == registry {
+			live = &tokens[i]
+			break // first file wins — the copy cargo actually reads
+		}
+	}
+	if live == nil {
+		return CargoMigration{}, fmt.Errorf("registry %q not found (or has no token) in %s", registry, CargoCredentialPaths(home)[0])
+	}
+
+	configPath := CargoConfigPath(home)
+	helperPath := CargoHelperPath(home)
+	// The provider registration is a whitespace-split string in cargo's
+	// config, so a path containing whitespace cannot be registered at all.
+	// Fail loud before mutating anything rather than write a config cargo
+	// would misparse.
+	if strings.ContainsAny(helperPath, " \t") {
+		return CargoMigration{}, fmt.Errorf("cargo's credential-provider config splits on whitespace and %q contains it; jit can't register a provider from this home directory", helperPath)
+	}
+	alreadyInstalled, err := checkCargoConfigConflict(configPath, helperPath)
+	if err != nil {
+		return CargoMigration{}, err
+	}
+
+	meta, err := newProvenance(vault.ClassCargo, live.Path)
+	if err != nil {
+		return CargoMigration{}, err
+	}
+	profileName, manifestPath, _, err := upsertCargoProfile(v, registry, []byte(live.Token), meta)
+	if err != nil {
+		return CargoMigration{}, err
+	}
+
+	credBackup, err := tracker.backupOnce(v, live.Path)
+	if err != nil {
+		return CargoMigration{}, fmt.Errorf("backing up %s: %w", live.Path, err)
+	}
+
+	// ~/.cargo/config.toml is shared across every registry in this run and
+	// may not exist yet — same discipline as ~/.terraformrc: back it up
+	// once at its pristine state if it existed; if jit creates it, record
+	// it for removal on undo.
+	configHandled := tracker.alreadyHandled(configPath)
+	_, configStatErr := os.Stat(configPath)
+	configExisted := configStatErr == nil
+	var configBackup string
+	if configExisted && !configHandled {
+		configBackup, err = tracker.backupOnce(v, configPath)
+		if err != nil {
+			return CargoMigration{}, fmt.Errorf("backing up %s: %w", configPath, err)
+		}
+	}
+
+	if err := writeCargoHelper(home); err != nil {
+		return CargoMigration{}, err
+	}
+	if !alreadyInstalled {
+		if err := appendCargoProviders(configPath, helperPath); err != nil {
+			return CargoMigration{}, err
+		}
+	}
+	if !configExisted && !configHandled {
+		absConfig, err := filepath.Abs(configPath)
+		if err != nil {
+			return CargoMigration{}, fmt.Errorf("resolving %s: %w", configPath, err)
+		}
+		if err := RecordCreatedFile(v.Root, absConfig); err != nil {
+			return CargoMigration{}, fmt.Errorf("recording created %s in the undo index: %w", configPath, err)
+		}
+		tracker.markCreated(configPath)
+	}
+
+	// Strip the registry's token line from EVERY credentials file holding
+	// one — cargo reads the first file that exists, but the stale copy in
+	// the other is the same plaintext credential.
+	for _, t := range tokens {
+		if t.Registry != registry {
+			continue
+		}
+		if _, err := tracker.backupOnce(v, t.Path); err != nil {
+			return CargoMigration{}, fmt.Errorf("backing up %s: %w", t.Path, err)
+		}
+		if err := removeCargoTokenLine(t.Path, registry); err != nil {
+			return CargoMigration{}, err
+		}
+	}
+
+	return CargoMigration{
+		Registry:          registry,
+		CredentialsPath:   live.Path,
+		CredentialsBackup: credBackup,
+		ConfigPath:        configPath,
+		ConfigBackup:      configBackup,
+		HelperPath:        helperPath,
+		VaultProfileName:  profileName,
+		VaultProfilePath:  manifestPath,
+		Variables:         []string{"TOKEN"},
+	}, nil
+}
+
+// writeCargoHelper writes the cargo-credential-jit executable — a
+// two-line shell wrapper exec-ing this jit binary, the same shape as
+// terraform-credentials-jit and for the same reason: the provider is an
+// executable of its own, and jit can't rename itself. Overwrites
+// unconditionally so a rebuilt/moved jit refreshes it on the next
+// migrate.
+func writeCargoHelper(home string) error {
+	jitPath, err := resolveJitExecutable()
+	if err != nil {
+		return fmt.Errorf("resolving jit's own executable path: %w", err)
+	}
+	helperPath := CargoHelperPath(home)
+	if err := os.MkdirAll(filepath.Dir(helperPath), 0o700); err != nil {
+		return fmt.Errorf("creating %s: %w", filepath.Dir(helperPath), err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\n# Written by jit migrate, cargo credential provider. See `jit cargo-credential --help`.\nexec %s cargo-credential \"$@\"\n", singleQuote(jitPath))
+	if err := os.WriteFile(helperPath, []byte(script), 0o700); err != nil { // #nosec G306 -- must be executable; helper runs as this same user
+		return fmt.Errorf("writing %s: %w", helperPath, err)
+	}
+	return nil
+}
+
+// appendCargoProviders registers jit's provider in ~/.cargo/config.toml:
+// `global-credential-providers = ["cargo:token", "<helper>"]` under the
+// [registry] table. cargo:token stays FIRST so an unmigrated registry's
+// credentials.toml token keeps working (jit answers not-found and cargo
+// falls back — spike finding 6); jit sits LAST because later entries take
+// precedence (finding 2), which also routes every future `cargo login`
+// into the vault instead of a plaintext file.
+//
+// If a [registry] table already exists the key is inserted right after
+// its header; otherwise the table is appended. Callers must have already
+// run checkCargoConfigConflict, so the key itself is known absent.
+func appendCargoProviders(configPath, helperPath string) error {
+	keyLine := fmt.Sprintf("global-credential-providers = [\"cargo:token\", %q]", helperPath)
+
+	data, err := os.ReadFile(configPath) // #nosec G304 -- fixed ~/.cargo path, not external input
+	if os.IsNotExist(err) {
+		if mkErr := os.MkdirAll(filepath.Dir(configPath), 0o700); mkErr != nil {
+			return fmt.Errorf("creating %s: %w", filepath.Dir(configPath), mkErr)
+		}
+		content := "[registry]\n" + keyLine + "\n"
+		if wErr := os.WriteFile(configPath, []byte(content), 0o600); wErr != nil {
+			return fmt.Errorf("writing %s: %w", configPath, wErr)
+		}
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", configPath, err)
+	}
+
+	lines := strings.Split(string(data), "\n")
+	inserted := false
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "[registry]" {
+			lines = append(lines[:i+1], append([]string{keyLine}, lines[i+1:]...)...)
+			inserted = true
+			break
+		}
+	}
+	content := strings.Join(lines, "\n")
+	if !inserted {
+		if content != "" && !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		if content != "" {
+			content += "\n"
+		}
+		content += "[registry]\n" + keyLine + "\n"
+	}
+	if err := os.WriteFile(configPath, []byte(content), 0o600); err != nil { // #nosec G703 -- fixed ~/.cargo path, not external input
+		return fmt.Errorf("writing %s: %w", configPath, err)
+	}
+	return nil
+}
+
+// removeCargoTokenLine rewrites one credentials file with the named
+// registry's token line(s) removed and every other byte untouched. The
+// table header stays even if now empty — harmless to cargo, and a smaller
+// diff for the user to review.
+func removeCargoTokenLine(path, registry string) error {
+	lines, err := readLines(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+	var out []string
+	current := ""
+	for _, line := range lines {
+		if m := cargoSectionPattern.FindStringSubmatch(line); m != nil {
+			if m[2] != "" {
+				current = m[2]
+			} else {
+				current = cargoCratesIOName
+			}
+		} else if strings.HasPrefix(strings.TrimSpace(line), "[") {
+			current = ""
+		} else if current == registry && cargoTokenLinePattern.MatchString(line) {
+			continue // the migrated token — the vault holds it now
+		}
+		out = append(out, line)
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(out, "\n")), 0o600); err != nil {
+		return fmt.Errorf("writing %s: %w", path, err)
+	}
+	return nil
+}
+
+// StoreCargoToken implements the provider protocol's "login" kind
+// (`cargo login` after migration): the token goes into the vault and the
+// registry's global profile, so a re-login keeps working through jit
+// instead of landing a fresh plaintext token in credentials.toml.
+func StoreCargoToken(v *vault.Vault, registry, token string) error {
+	if token == "" {
+		return fmt.Errorf("empty token for registry %q", registry)
+	}
+	// Live `cargo login` after migration: no credentials file to point at,
+	// so class-only provenance (fresh group, no origin) — same shape as
+	// StoreTerraformToken.
+	meta, err := newProvenance(vault.ClassCargo, "")
+	if err != nil {
+		return err
+	}
+	_, _, _, err = upsertCargoProfile(v, registry, []byte(token), meta)
+	return err
+}
+
+// ForgetCargoToken implements the provider protocol's "logout" kind:
+// removes the registry's token from the vault and its profile manifest.
+// Idempotent, matching ForgetTerraformToken.
+func ForgetCargoToken(v *vault.Vault, registry string) error {
+	name := cargoProfilePrefix + registry
+	globalRoot, err := profile.GlobalRoot()
+	if err != nil {
+		return fmt.Errorf("resolving global profile root: %w", err)
+	}
+	manifestPath, err := profile.Path(globalRoot, name)
+	if err != nil {
+		return err
+	}
+	if err := v.Remove(name + "/TOKEN"); err != nil && !errors.Is(err, vault.ErrNotFound) {
+		return err
+	}
+	if err := os.Remove(manifestPath); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/migrate/cargocreds.go
+++ b/internal/migrate/cargocreds.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -84,7 +85,11 @@ func CargoHelperPath(home string) string {
 var cargoSectionPattern = regexp.MustCompile(`^\s*\[\s*(registry|registries\.([A-Za-z0-9_-]+))\s*\]\s*$`)
 
 // cargoTokenLinePattern matches the `token = "..."` line within a table.
-var cargoTokenLinePattern = regexp.MustCompile(`^\s*token\s*=\s*"([^"]*)"\s*$`)
+// Both TOML string forms: basic ("...") and literal ('...') — audit's
+// unquote strips either, so migrate accepting only one would flag-but-
+// refuse a single-quoted token (the D5 divergence this category exists to
+// close).
+var cargoTokenLinePattern = regexp.MustCompile(`^\s*token\s*=\s*(?:"([^"]*)"|'([^']*)')\s*$`)
 
 // cargoRegistryToken is one registry's token and where it was found.
 type cargoRegistryToken struct {
@@ -121,10 +126,17 @@ func findCargoTokens(path string) ([]cargoRegistryToken, error) {
 			continue
 		}
 		m := cargoTokenLinePattern.FindStringSubmatch(line)
-		if m == nil || m[1] == "" {
+		if m == nil {
 			continue
 		}
-		out = append(out, cargoRegistryToken{Registry: registry, Token: m[1], Path: path, Line: i})
+		token := m[1]
+		if token == "" {
+			token = m[2] // the single-quoted (TOML literal string) form
+		}
+		if token == "" {
+			continue
+		}
+		out = append(out, cargoRegistryToken{Registry: registry, Token: token, Path: path, Line: i})
 	}
 	return out, nil
 }
@@ -297,11 +309,6 @@ func ApplyCargoRegistry(v *vault.Vault, home, registry string, dedup ...*BackupT
 		return CargoMigration{}, err
 	}
 
-	credBackup, err := tracker.backupOnce(v, live.Path)
-	if err != nil {
-		return CargoMigration{}, fmt.Errorf("backing up %s: %w", live.Path, err)
-	}
-
 	// ~/.cargo/config.toml is shared across every registry in this run and
 	// may not exist yet — same discipline as ~/.terraformrc: back it up
 	// once at its pristine state if it existed; if jit creates it, record
@@ -309,9 +316,37 @@ func ApplyCargoRegistry(v *vault.Vault, home, registry string, dedup ...*BackupT
 	configHandled := tracker.alreadyHandled(configPath)
 	_, configStatErr := os.Stat(configPath)
 	configExisted := configStatErr == nil
+
+	// Undo linkage (BackupRecord.RestoreWith): cargo is the category where
+	// restoring the credentials file ALONE is silently ineffective — jit's
+	// provider registered in config.toml outranks credentials.toml (later
+	// wins, spike finding 2), so cargo would keep fetching the stale vault
+	// token and the "restored" file would never be read. Terraform has the
+	// opposite precedence (a static credentials entry beats the helper),
+	// which is why its records need no link. The link is recorded when this
+	// run touches config.toml (appends the provider line, creates the file,
+	// or an earlier registry in the run already handled it); a config left
+	// untouched because a PREVIOUS run registered jit must not be yanked
+	// back to that older backup by this run's undo.
+	var credLink []string
+	if !alreadyInstalled || configHandled {
+		credLink = []string{configPath}
+	}
+	var credFiles []string
+	for _, t := range tokens {
+		if !slices.Contains(credFiles, t.Path) {
+			credFiles = append(credFiles, t.Path)
+		}
+	}
+
+	credBackup, err := tracker.backupOnceLinking(v, live.Path, credLink)
+	if err != nil {
+		return CargoMigration{}, fmt.Errorf("backing up %s: %w", live.Path, err)
+	}
+
 	var configBackup string
 	if configExisted && !configHandled {
-		configBackup, err = tracker.backupOnce(v, configPath)
+		configBackup, err = tracker.backupOnceLinking(v, configPath, credFiles)
 		if err != nil {
 			return CargoMigration{}, fmt.Errorf("backing up %s: %w", configPath, err)
 		}
@@ -343,7 +378,7 @@ func ApplyCargoRegistry(v *vault.Vault, home, registry string, dedup ...*BackupT
 		if t.Registry != registry {
 			continue
 		}
-		if _, err := tracker.backupOnce(v, t.Path); err != nil {
+		if _, err := tracker.backupOnceLinking(v, t.Path, credLink); err != nil {
 			return CargoMigration{}, fmt.Errorf("backing up %s: %w", t.Path, err)
 		}
 		if err := removeCargoTokenLine(t.Path, registry); err != nil {

--- a/internal/migrate/cargocreds_test.go
+++ b/internal/migrate/cargocreds_test.go
@@ -270,3 +270,62 @@ func TestStoreAndForgetCargoToken(t *testing.T) {
 		t.Errorf("second ForgetCargoToken must be a no-op, got %v", err)
 	}
 }
+
+// TestFindCargoTokensAcceptsLiteralStrings pins quote parity with audit:
+// its unquote strips single quotes (a TOML literal string) exactly like
+// double quotes, so migrate accepting only one form would flag-but-refuse
+// a single-quoted token — the D5 divergence this category exists to close.
+func TestFindCargoTokensAcceptsLiteralStrings(t *testing.T) {
+	tokens, err := findCargoTokens(writeTempCargo(t, "[registry]\ntoken = 'cioSingleQuotedTokenQmPl4T'\n"))
+	if err != nil {
+		t.Fatalf("findCargoTokens: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].Token != "cioSingleQuotedTokenQmPl4T" {
+		t.Errorf("tokens = %+v, want the single-quoted value", tokens)
+	}
+}
+
+// TestApplyCargoRegistryLinksUndoToConfig pins the RestoreWith linkage:
+// jit's provider registered in config.toml OUTRANKS credentials.toml
+// (later wins), so restoring the credentials file alone would be silently
+// ineffective — cargo would keep fetching the stale vault token. The
+// credentials backup must name config.toml as a file that comes back with
+// it, and the config backup names the credentials file(s) in return.
+func TestApplyCargoRegistryLinksUndoToConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	credPath := CargoCredentialPaths(home)[0]
+	writeFile(t, credPath, cargoCredsFixture)
+	writeFile(t, CargoConfigPath(home), "[build]\njobs = 4\n")
+
+	v := newTestVault(t)
+	if _, err := ApplyCargoRegistry(v, home, "work", NewBackupTracker()); err != nil {
+		t.Fatalf("ApplyCargoRegistry: %v", err)
+	}
+
+	recs, err := LoadBackupRecords(v.Root)
+	if err != nil {
+		t.Fatalf("LoadBackupRecords: %v", err)
+	}
+	byPath := map[string]BackupRecord{}
+	for _, r := range LatestBackups(recs) {
+		byPath[r.OriginalPath] = r
+	}
+	absCred, _ := filepath.Abs(credPath)
+	absConfig, _ := filepath.Abs(CargoConfigPath(home))
+
+	credRec, ok := byPath[absCred]
+	if !ok {
+		t.Fatalf("no backup record for %s (have %v)", absCred, byPath)
+	}
+	if len(credRec.RestoreWith) != 1 || credRec.RestoreWith[0] != CargoConfigPath(home) {
+		t.Errorf("credentials RestoreWith = %v, want [%s]", credRec.RestoreWith, CargoConfigPath(home))
+	}
+	configRec, ok := byPath[absConfig]
+	if !ok {
+		t.Fatalf("no backup record for %s", absConfig)
+	}
+	if len(configRec.RestoreWith) != 1 || configRec.RestoreWith[0] != credPath {
+		t.Errorf("config RestoreWith = %v, want [%s]", configRec.RestoreWith, credPath)
+	}
+}

--- a/internal/migrate/cargocreds_test.go
+++ b/internal/migrate/cargocreds_test.go
@@ -1,0 +1,272 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const cargoCredsFixture = `[registry]
+token = "cioFirstPartyTokenQmPl4TzWhu"
+
+[registries.work]
+token = "cioWorkRegistryTokenu2qcwnu9"
+
+[http]
+timeout = 30
+`
+
+func TestDiscoverCargoRegistries(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, CargoCredentialPaths(home)[0], cargoCredsFixture)
+
+	regs, err := DiscoverCargoRegistries(home)
+	if err != nil {
+		t.Fatalf("DiscoverCargoRegistries: %v", err)
+	}
+	if len(regs) != 2 || regs[0] != "crates-io" || regs[1] != "work" {
+		t.Errorf("registries = %v, want [crates-io work]", regs)
+	}
+}
+
+func TestDiscoverCargoRegistriesQuietCases(t *testing.T) {
+	t.Run("no file", func(t *testing.T) {
+		regs, err := DiscoverCargoRegistries(t.TempDir())
+		if err != nil || len(regs) != 0 {
+			t.Errorf("got (%v, %v), want (nil, nil)", regs, err)
+		}
+	})
+	t.Run("no tokens", func(t *testing.T) {
+		home := t.TempDir()
+		writeFile(t, CargoCredentialPaths(home)[0], "[http]\ntimeout = 30\n")
+		regs, err := DiscoverCargoRegistries(home)
+		if err != nil || len(regs) != 0 {
+			t.Errorf("got (%v, %v), want (nil, nil)", regs, err)
+		}
+	})
+	t.Run("legacy bare credentials file counts too", func(t *testing.T) {
+		home := t.TempDir()
+		writeFile(t, CargoCredentialPaths(home)[1], "[registry]\ntoken = \"cioLegacyFileTokenQmPl4Tz\"\n")
+		regs, err := DiscoverCargoRegistries(home)
+		if err != nil || len(regs) != 1 || regs[0] != "crates-io" {
+			t.Errorf("got (%v, %v), want ([crates-io], nil)", regs, err)
+		}
+	})
+}
+
+func TestFindCargoTokensIgnoresOtherTables(t *testing.T) {
+	tokens, err := findCargoTokens(writeTempCargo(t, "[http]\ntoken = \"not-a-registry-token\"\n\n[registry]\ntoken = \"cioRealTokenQmPl4TzWhu\"\n"))
+	if err != nil {
+		t.Fatalf("findCargoTokens: %v", err)
+	}
+	if len(tokens) != 1 || tokens[0].Registry != "crates-io" || tokens[0].Token != "cioRealTokenQmPl4TzWhu" {
+		t.Errorf("tokens = %+v, want only [registry]'s token as crates-io", tokens)
+	}
+}
+
+func writeTempCargo(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "credentials.toml")
+	writeFile(t, path, content)
+	return path
+}
+
+func TestApplyCargoRegistryEndToEnd(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home) // upsertCargoProfile writes the global store under $HOME
+	credPath := CargoCredentialPaths(home)[0]
+	writeFile(t, credPath, cargoCredsFixture)
+
+	v := newTestVault(t)
+	tracker := NewBackupTracker()
+	result, err := ApplyCargoRegistry(v, home, "work", tracker)
+	if err != nil {
+		t.Fatalf("ApplyCargoRegistry: %v", err)
+	}
+	if result.VaultProfileName != "cargo-work" {
+		t.Errorf("VaultProfileName = %q, want cargo-work", result.VaultProfileName)
+	}
+
+	got, err := v.Get("cargo-work/TOKEN")
+	if err != nil || string(got) != "cioWorkRegistryTokenu2qcwnu9" {
+		t.Errorf("vault token = (%q, %v), want the work registry token", got, err)
+	}
+
+	// The token line is gone; every other line survives byte-oriented —
+	// including crates-io's token, which was NOT migrated in this call.
+	after, err := os.ReadFile(credPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading credentials after: %v", err)
+	}
+	if strings.Contains(string(after), "cioWorkRegistryTokenu2qcwnu9") {
+		t.Error("migrated token still present in credentials.toml")
+	}
+	for _, keep := range []string{"cioFirstPartyTokenQmPl4TzWhu", "[registries.work]", "[http]", "timeout = 30"} {
+		if !strings.Contains(string(after), keep) {
+			t.Errorf("credentials.toml lost %q:\n%s", keep, after)
+		}
+	}
+
+	// The wrapper exists, is executable, and execs jit's cargo-credential.
+	helper, err := os.ReadFile(result.HelperPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading helper: %v", err)
+	}
+	if !strings.Contains(string(helper), "cargo-credential") {
+		t.Errorf("helper does not invoke jit cargo-credential:\n%s", helper)
+	}
+	if info, err := os.Stat(result.HelperPath); err != nil || info.Mode()&0o100 == 0 {
+		t.Errorf("helper must be executable, got %v (err=%v)", info, err)
+	}
+
+	// config.toml registers cargo:token FIRST (unmigrated registries keep
+	// working via fallback) and jit LAST (later wins).
+	config, err := os.ReadFile(result.ConfigPath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+	line := ""
+	for _, l := range strings.Split(string(config), "\n") {
+		if strings.Contains(l, "global-credential-providers") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("config.toml has no global-credential-providers line:\n%s", config)
+	}
+	tokenIdx := strings.Index(line, "cargo:token")
+	jitIdx := strings.Index(line, result.HelperPath)
+	if tokenIdx < 0 || jitIdx < 0 || tokenIdx > jitIdx {
+		t.Errorf("provider order must be [cargo:token, jit-helper], got %q", line)
+	}
+
+	// Second registry through the same tracker: config already carries
+	// jit's line (alreadyInstalled) and must not be duplicated.
+	if _, err := ApplyCargoRegistry(v, home, "crates-io", tracker); err != nil {
+		t.Fatalf("ApplyCargoRegistry(crates-io): %v", err)
+	}
+	config2, _ := os.ReadFile(result.ConfigPath) // #nosec G304 -- test-controlled path
+	if n := strings.Count(string(config2), "global-credential-providers"); n != 1 {
+		t.Errorf("provider line appears %d times after two migrations, want 1:\n%s", n, config2)
+	}
+	after2, _ := os.ReadFile(credPath) // #nosec G304 -- test-controlled path
+	if strings.Contains(string(after2), "cio") {
+		t.Errorf("all tokens should be gone after migrating both registries:\n%s", after2)
+	}
+}
+
+// TestApplyCargoRegistryStripsStaleLegacyCopy pins that a token duplicated
+// in the pre-1.39 bare `credentials` file is stripped too: cargo only
+// reads the first file that exists, but the stale copy is the same
+// plaintext credential.
+func TestApplyCargoRegistryStripsStaleLegacyCopy(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeFile(t, CargoCredentialPaths(home)[0], "[registry]\ntoken = \"cioLiveTokenQmPl4TzWhu\"\n")
+	writeFile(t, CargoCredentialPaths(home)[1], "[registry]\ntoken = \"cioStaleCopyTokenu2qcwn\"\n")
+
+	v := newTestVault(t)
+	if _, err := ApplyCargoRegistry(v, home, "crates-io", NewBackupTracker()); err != nil {
+		t.Fatalf("ApplyCargoRegistry: %v", err)
+	}
+	// The FIRST file's value is the one cargo reads, so it's what vaults.
+	got, err := v.Get("cargo-crates-io/TOKEN")
+	if err != nil || string(got) != "cioLiveTokenQmPl4TzWhu" {
+		t.Errorf("vault token = (%q, %v), want the first file's value", got, err)
+	}
+	for i, path := range CargoCredentialPaths(home) {
+		data, err := os.ReadFile(path) // #nosec G304 -- test-controlled path
+		if err != nil {
+			t.Fatalf("reading file %d: %v", i, err)
+		}
+		if strings.Contains(string(data), "cio") {
+			t.Errorf("file %d still holds a token after migration:\n%s", i, data)
+		}
+	}
+}
+
+// TestApplyCargoRegistryConflict pins the fail-loud rule: a
+// global-credential-providers list jit didn't write is the user's own
+// deliberate configuration, and merging into a hand-written TOML array by
+// string surgery can't be done provably right — so nothing is mutated.
+func TestApplyCargoRegistryConflict(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	credPath := CargoCredentialPaths(home)[0]
+	writeFile(t, credPath, cargoCredsFixture)
+	writeFile(t, CargoConfigPath(home), "[registry]\nglobal-credential-providers = [\"cargo:macos-keychain\"]\n")
+
+	v := newTestVault(t)
+	_, err := ApplyCargoRegistry(v, home, "work", NewBackupTracker())
+	if err == nil {
+		t.Fatal("expected a conflict error for a foreign provider list, got nil")
+	}
+	if !strings.Contains(err.Error(), "global-credential-providers") {
+		t.Errorf("error should name the conflicting key, got %v", err)
+	}
+	after, _ := os.ReadFile(credPath) // #nosec G304 -- test-controlled path
+	if string(after) != cargoCredsFixture {
+		t.Error("a refused migration must leave credentials.toml untouched")
+	}
+}
+
+// TestAppendCargoProvidersMergesIntoExistingRegistryTable pins the config
+// surgery: an existing [registry] table (holding, say, default = "…")
+// gets the key inserted under its header rather than a second [registry]
+// table appended — two tables with one name is invalid TOML.
+func TestAppendCargoProvidersMergesIntoExistingRegistryTable(t *testing.T) {
+	home := t.TempDir()
+	configPath := CargoConfigPath(home)
+	writeFile(t, configPath, "[build]\njobs = 4\n\n[registry]\ndefault = \"work\"\n")
+
+	if err := appendCargoProviders(configPath, "/usr/local/bin/cargo-credential-jit"); err != nil {
+		t.Fatalf("appendCargoProviders: %v", err)
+	}
+	data, _ := os.ReadFile(configPath) // #nosec G304 -- test-controlled path
+	content := string(data)
+	if strings.Count(content, "[registry]") != 1 {
+		t.Errorf("config must keep exactly one [registry] table:\n%s", content)
+	}
+	for _, keep := range []string{"[build]", "jobs = 4", "default = \"work\"", "global-credential-providers"} {
+		if !strings.Contains(content, keep) {
+			t.Errorf("config lost %q:\n%s", keep, content)
+		}
+	}
+	// The key must sit inside [registry], i.e. after its header and before
+	// any subsequent table header.
+	regIdx := strings.Index(content, "[registry]")
+	keyIdx := strings.Index(content, "global-credential-providers")
+	if keyIdx < regIdx {
+		t.Errorf("key inserted outside the [registry] table:\n%s", content)
+	}
+}
+
+func TestStoreAndForgetCargoToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	v := newTestVault(t)
+
+	if err := StoreCargoToken(v, "crates-io", "cioFreshLoginTokenQmPl4Tz"); err != nil {
+		t.Fatalf("StoreCargoToken: %v", err)
+	}
+	got, err := v.Get("cargo-crates-io/TOKEN")
+	if err != nil || string(got) != "cioFreshLoginTokenQmPl4Tz" {
+		t.Errorf("vault token = (%q, %v), want the stored login token", got, err)
+	}
+
+	if err := ForgetCargoToken(v, "crates-io"); err != nil {
+		t.Fatalf("ForgetCargoToken: %v", err)
+	}
+	if _, err := v.Get("cargo-crates-io/TOKEN"); err == nil {
+		t.Error("token still readable after ForgetCargoToken")
+	}
+	// Idempotent: forgetting again is a no-op, matching cargo's own logout
+	// with nothing saved.
+	if err := ForgetCargoToken(v, "crates-io"); err != nil {
+		t.Errorf("second ForgetCargoToken must be a no-op, got %v", err)
+	}
+}

--- a/internal/migrate/jitpathrefresh.go
+++ b/internal/migrate/jitpathrefresh.go
@@ -52,6 +52,7 @@ func jitPathArtifacts(home string) []RecordedJitPath {
 		{Label: "the docker credential helper", Path: DockerHelperPath(home), Category: "docker", Key: "exec "},
 		{Label: "the git credential helper", Path: GitHelperPath(home), Category: "git", Key: "exec "},
 		{Label: "the terraform credentials helper", Path: TerraformHelperPath(home), Category: "terraform", Key: "exec "},
+		{Label: "the cargo credential provider", Path: CargoHelperPath(home), Category: "cargo", Key: "exec "},
 	}
 }
 

--- a/internal/migrate/streamlit.go
+++ b/internal/migrate/streamlit.go
@@ -1,0 +1,406 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jitpass/jit/internal/audit"
+	"github.com/jitpass/jit/internal/mount"
+	"github.com/jitpass/jit/internal/vault"
+)
+
+// This file is the Streamlit secrets category: .streamlit/secrets.toml,
+// the file Streamlit's own docs call "secrets" and have st.secrets read
+// directly. It follows npmrc's five-function shape (Path/Discover/Apply/
+// VarName/Template) — like npmrc it exists both per-project
+// (<project>/.streamlit/secrets.toml) and globally
+// (~/.streamlit/secrets.toml), it mixes credentials with settings that
+// must survive byte-for-byte, and Streamlit has no credential hook of any
+// kind, so a template-based mount is the only migration shape that keeps
+// `streamlit run` working unchanged.
+//
+// Before this category existed the file was audit's promise and migrate's
+// dead end: scanStreamlitSecretsFile flagged it as a credential_file with
+// remedy "migrate", but no category claimed the path, so it fell through
+// to loose-secret classification, judged "mixes a secret with other
+// content", and the recommended `jit migrate <path>` answered with a skip
+// note — exactly the scan-contradicts-migrate shape design/
+// dry-run-refactor.md D5 exists to prevent.
+
+// streamlitDirName / streamlitFileName mirror audit's own two-part gate
+// (streamlitSecretsDir/streamlitSecretsFile): "secrets.toml" alone is a
+// common name (a Rust config, a Helm values file), while
+// ".streamlit/secrets.toml" is unambiguous.
+const streamlitDirName = ".streamlit"
+const streamlitFileName = "secrets.toml" // #nosec G101 -- a filename, not a credential
+
+// streamlitSectionPattern matches a TOML table header, "[db]" or
+// "[[nested.servers]]", capturing the dotted name.
+var streamlitSectionPattern = regexp.MustCompile(`^\s*\[+\s*([^\]]+?)\s*\]+\s*$`)
+
+// streamlitAssignPattern matches a bare-key single-line assignment,
+// capturing (1) indent, (2) key, (3) the "=" and spacing around it, and
+// (4) the raw value with trailing whitespace trimmed. The key charset is
+// the same line-oriented TOML subset audit's scanner reads (a dotted or
+// quoted key simply doesn't match, on both sides).
+var streamlitAssignPattern = regexp.MustCompile(`^(\s*)([A-Za-z_][A-Za-z0-9_-]*)(\s*=\s*)(.+?)\s*$`)
+
+// streamlitQuotedValue matches the only value shape this migrator will
+// rewrite: one single-line quoted string with no backslash and no embedded
+// quote of its own kind. That restriction is what makes the template
+// round-trip provably right — the vaulted value is exactly the bytes
+// between the quotes, and mount.FormatTemplate substituting those bytes
+// back between the same quotes reproduces the original line and stays
+// valid TOML (no escape sequence can appear or be needed). A value that
+// needs escaping is left in place; `jit scan` keeps reporting it.
+var streamlitQuotedValue = regexp.MustCompile(`^"([^"\\]*)"$|^'([^'\\]*)'$`)
+
+// streamlitVarSanitizer / streamlitMultiUnderscore mirror pypirc's pair:
+// turn a section+key into a valid ${VAR_NAME} placeholder component.
+var streamlitVarSanitizer = regexp.MustCompile(`[^A-Za-z0-9_]+`)
+var streamlitMultiUnderscore = regexp.MustCompile(`_+`)
+
+// StreamlitMigration describes what jit migrate did to one secrets.toml.
+type StreamlitMigration struct {
+	FilePath     string
+	BackupPath   string
+	TemplatePath string
+	ProfileName  string
+	ProfilePath  string
+	Variables    []string
+	// NamespaceMovedFrom mirrors EnvFileMigration's field of the same name:
+	// the profile name this file would have used had the vault not already
+	// held another migration's secret there (GAPS.md #55).
+	NamespaceMovedFrom string
+}
+
+// StreamlitGlobalPath returns the machine-wide secrets file Streamlit
+// documents alongside the per-project one: ~/.streamlit/secrets.toml.
+func StreamlitGlobalPath(home string) string {
+	return filepath.Join(home, streamlitDirName, streamlitFileName)
+}
+
+// DiscoverStreamlitSecrets walks root for .streamlit/secrets.toml files
+// holding at least one line this migrator can move. Rooting at a project
+// directory finds that project's file; rooting at $HOME additionally finds
+// the global ~/.streamlit/secrets.toml, which is just the copy that
+// happens to sit there — the same one-walk stance audit's
+// classifyStreamlitSecrets takes, and unlike npmrc there is no separate
+// fixed path to check. WalkDir over one regular file yields just that
+// file, which is how an explicitly named secrets.toml routes here too.
+func DiscoverStreamlitSecrets(root string) ([]string, error) {
+	var found []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// See DiscoverEnvFiles' identical guard: a permission-denied
+			// error partway through the tree must skip that path, not
+			// abort the whole discovery.
+			if path == root {
+				return err
+			}
+			return filepath.SkipDir
+		}
+		if d.IsDir() {
+			if skipDiscoveryDir(root, path, d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		// Regular files only, same rule as audit's walk: an
+		// already-mounted FIFO would block the read below forever, and a
+		// symlinked secrets.toml must not be rewritten through the link.
+		if !d.Type().IsRegular() {
+			return nil
+		}
+		if d.Name() != streamlitFileName || filepath.Base(filepath.Dir(path)) != streamlitDirName {
+			return nil
+		}
+		lines, err := readLines(path)
+		if err != nil {
+			return nil // unreadable — skip it, the scan keeps reporting it
+		}
+		if len(findSecretStreamlitLines(lines)) > 0 {
+			found = append(found, path)
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("walking %s: %w", root, err)
+	}
+	sort.Strings(found)
+	return found, nil
+}
+
+// ApplyStreamlitSecrets moves every credential-shaped quoted value out of
+// a secrets.toml and into v's vault, then replaces the file with a FIFO
+// serving a template-substituted reconstruction (mount.FormatTemplate):
+// table headers, non-secret settings and comments pass through
+// byte-for-byte, only each credential's value is filled in from the vault
+// at serve time, inside the original line's own quotes.
+//
+// profilesRoot follows npmrc's convention: the project directory (the
+// parent of .streamlit) for a project file, $HOME for the global file.
+// global must be true for exactly ~/.streamlit/secrets.toml — the two get
+// different profile names (see deriveStreamlitProfileName).
+func ApplyStreamlitSecrets(v *vault.Vault, profilesRoot, path string, global bool) (StreamlitMigration, error) {
+	lines, err := readLines(path)
+	if err != nil {
+		return StreamlitMigration{}, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	matches := findSecretStreamlitLines(lines)
+	if len(matches) == 0 {
+		return StreamlitMigration{}, fmt.Errorf("%s has no credentials to migrate", path)
+	}
+
+	varNames := make([]string, 0, len(matches))
+	seenVar := map[string]bool{}
+	for _, m := range matches {
+		if seenVar[m.VarName] {
+			continue // a repeated key; last value wins, as TOML readers do
+		}
+		seenVar[m.VarName] = true
+		varNames = append(varNames, m.VarName)
+	}
+	sort.Strings(varNames)
+
+	// Position-blind byte substitution (ApplyNetrc's own guard):
+	// mount.FormatTemplate fills ${VAR} wherever it appears, so a
+	// placeholder already sitting in the file literally would get the real
+	// value written into it at serve time, and the mount would no longer
+	// round-trip the original bytes. Refuse rather than corrupt.
+	joined := strings.Join(lines, "\n")
+	for _, name := range varNames {
+		if strings.Contains(joined, "${"+name+"}") {
+			return StreamlitMigration{}, fmt.Errorf("%s already contains the literal ${%s}, refusing to migrate", path, name)
+		}
+	}
+
+	// Same merge-and-guard as ApplyEnvFile/ApplyNpmrc: move to "<name>-2"
+	// if the vault already holds another migration's value at one of these
+	// paths (GAPS.md #55).
+	profileName, profilePath, entries, movedFrom, err := claimNamespace(v, profilesRoot, deriveStreamlitProfileName(profilesRoot, global), varNames)
+	if err != nil {
+		return StreamlitMigration{}, err
+	}
+
+	values := map[string]string{}
+	for _, m := range matches {
+		values[m.VarName] = m.Value
+	}
+	meta, err := newProvenance(vault.ClassStreamlit, path)
+	if err != nil {
+		return StreamlitMigration{}, err
+	}
+	for _, name := range varNames {
+		secretPath := profileName + "/" + name
+		if err := v.SetWithMeta(secretPath, []byte(values[name]), meta); err != nil {
+			return StreamlitMigration{}, fmt.Errorf("storing %s in vault: %w", name, err)
+		}
+		entries[name] = secretPath
+	}
+
+	if err := writeProfileManifest(profilePath, entries, nil); err != nil {
+		return StreamlitMigration{}, fmt.Errorf("writing profile %s: %w", profilePath, err)
+	}
+
+	backupPath, err := backupSecretFile(v, path)
+	if err != nil {
+		return StreamlitMigration{}, fmt.Errorf("backing up %s: %w", path, err)
+	}
+
+	template := rewriteStreamlitAsTemplate(lines, matches)
+	templatePath := strings.TrimSuffix(profilePath, ".yaml") + ".secrets.toml.tmpl"
+	if err := os.WriteFile(templatePath, template, 0o600); err != nil {
+		return StreamlitMigration{}, fmt.Errorf("writing template %s: %w", templatePath, err)
+	}
+
+	if err := mount.CreateFIFO(path); err != nil {
+		return StreamlitMigration{}, fmt.Errorf("mounting %s: %w", path, err)
+	}
+
+	return StreamlitMigration{
+		FilePath:           path,
+		BackupPath:         backupPath,
+		TemplatePath:       templatePath,
+		ProfileName:        profileName,
+		ProfilePath:        profilePath,
+		Variables:          varNames,
+		NamespaceMovedFrom: movedFrom,
+	}, nil
+}
+
+type streamlitSecretMatch struct {
+	Index   int
+	Section string
+	Key     string
+	Value   string // the unquoted value — exactly the bytes between the quotes
+	Quote   byte   // the original quote character, '"' or '\''
+	VarName string
+}
+
+// findSecretStreamlitLines returns every credential line this migrator
+// will move, tagged with the TOML table it belongs to so two sections'
+// identically named keys can't collide on one variable name (the exact
+// collision audit's scanner tolerates for a read-only finding and its own
+// doc comment says a migrator must not — see scanStreamlitSecretsFile).
+//
+// Detection mirrors the scanner's two-signal split through the same
+// exported helpers, so the two judge a line the same way: a value matching
+// a known vendor format migrates on the value alone; otherwise a
+// secret-shaped key name (audit.LooksLikeSecretKey) migrates unless the
+// name or value reads as a non-secret. On top of that sits this side's own
+// stricter shape rule: only a single-line quoted string with no escapes is
+// rewritable provably right (streamlitQuotedValue), so a flagged line
+// outside that shape stays in place and keeps its scan finding.
+//
+// Multi-line strings ("""...""" / ”'...”') are skipped wholesale: a
+// line INSIDE one can look exactly like an assignment, and rewriting it
+// would corrupt the string.
+func findSecretStreamlitLines(lines []string) []streamlitSecretMatch {
+	var matches []streamlitSecretMatch
+	section := ""
+	inMultiline := false
+	for i, line := range lines {
+		if strings.Count(line, `"""`)%2 == 1 || strings.Count(line, `'''`)%2 == 1 {
+			inMultiline = !inMultiline
+			continue
+		}
+		if inMultiline {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if m := streamlitSectionPattern.FindStringSubmatch(line); m != nil {
+			section = m[1]
+			continue
+		}
+		m := streamlitAssignPattern.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		key, raw := m[2], m[4]
+		q := streamlitQuotedValue.FindStringSubmatch(raw)
+		if q == nil {
+			continue // unquoted, escaped, commented or multi-part — not rewritable provably right
+		}
+		value, quote := q[1], byte('"')
+		if raw[0] == '\'' {
+			value, quote = q[2], '\''
+		}
+		if value == "" || audit.IsAlreadyMasked(value) {
+			continue
+		}
+		if _, _, ok := audit.MatchKnownTokenPattern(value); !ok {
+			// The value check ran even though the KEY decides below, which
+			// is the point of having it: `foo = "sk-proj-..."` is still a
+			// live OpenAI key. From here the weaker name signal carries.
+			if !audit.LooksLikeSecretKey(key) || audit.LooksLikeNonSecretName(key) || audit.LooksLikeNonSecretValue(value) {
+				continue
+			}
+		}
+		matches = append(matches, streamlitSecretMatch{
+			Index:   i,
+			Section: section,
+			Key:     key,
+			Value:   value,
+			Quote:   quote,
+			VarName: streamlitVarName(section, key),
+		})
+	}
+	// Two DISTINCT section/key pairs can sanitize to one variable name
+	// ([my-db] password and [my_db] password both become MY_DB_PASSWORD);
+	// disambiguate so each keeps its own vault entry and placeholder.
+	// Repeats of one pair still share a name — last-value-wins above.
+	identities := make([]string, len(matches))
+	base := make([]string, len(matches))
+	for i, m := range matches {
+		identities[i] = m.Section + "\x00" + m.Key
+		base[i] = m.VarName
+	}
+	for i, name := range assignUniqueVarNames(identities, base) {
+		matches[i].VarName = name
+	}
+	return matches
+}
+
+// streamlitVarName builds the placeholder / vault-path name from the table
+// and key, e.g. table "db" + key "password" -> "DB_PASSWORD", and a
+// top-level key stands alone. Including the table is what keeps two tables
+// each holding a "password" from landing on the same vault path — the
+// collision pypircVarName folds the section in to avoid, and the one
+// audit's own scanner doc flags as unacceptable in a migrator.
+func streamlitVarName(section, key string) string {
+	name := key
+	if section != "" {
+		name = section + "_" + key
+	}
+	upper := strings.ToUpper(name)
+	replaced := streamlitVarSanitizer.ReplaceAllString(upper, "_")
+	replaced = streamlitMultiUnderscore.ReplaceAllString(replaced, "_")
+	trimmed := strings.Trim(replaced, "_")
+	if trimmed == "" {
+		trimmed = "STREAMLIT_SECRET"
+	}
+	if trimmed[0] >= '0' && trimmed[0] <= '9' {
+		trimmed = "_" + trimmed
+	}
+	return trimmed
+}
+
+// deriveStreamlitProfileName names the profile "streamlit" for the global
+// ~/.streamlit/secrets.toml and "streamlit-<project>" for a project's own
+// file, mirroring deriveNpmrcProfileName. The project part comes from
+// profilesRoot's basename (the directory holding .streamlit), not from a
+// relative path — the file's location inside the project is fixed by
+// Streamlit, so unlike npmrc there is no subdirectory to encode.
+func deriveStreamlitProfileName(profilesRoot string, global bool) string {
+	if global {
+		return "streamlit"
+	}
+	part := sanitizeNamePart(filepath.Base(profilesRoot))
+	if part == "" {
+		return "streamlit"
+	}
+	return "streamlit-" + part
+}
+
+// rewriteStreamlitAsTemplate replaces each credential's value with its
+// ${VAR_NAME} placeholder inside the line's original quotes, preserving
+// indentation, key and spacing around "=" — and every other line
+// byte-for-byte. Serving substitutes the vaulted bytes back between those
+// same quotes, which streamlitQuotedValue guarantees is valid TOML (the
+// value holds no quote of that kind and no backslash).
+func rewriteStreamlitAsTemplate(lines []string, matches []streamlitSecretMatch) []byte {
+	byIndex := make(map[int]streamlitSecretMatch, len(matches))
+	for _, m := range matches {
+		byIndex[m.Index] = m
+	}
+
+	out := make([]string, len(lines))
+	for i, line := range lines {
+		match, ok := byIndex[i]
+		if !ok {
+			out[i] = line
+			continue
+		}
+		// Capture groups: 1 = indent, 2 = key, 3 = the "=" and spacing.
+		// Reusing them keeps `password = "x"` from being normalized to
+		// `password="x"`, so a re-migration of an unchanged file
+		// reproduces the original formatting exactly.
+		m := streamlitAssignPattern.FindStringSubmatch(line)
+		q := string(match.Quote)
+		out[i] = m[1] + m[2] + m[3] + q + "${" + match.VarName + "}" + q
+	}
+	return []byte(strings.Join(out, "\n"))
+}

--- a/internal/migrate/streamlit.go
+++ b/internal/migrate/streamlit.go
@@ -139,6 +139,20 @@ func DiscoverStreamlitSecrets(root string) ([]string, error) {
 	return found, nil
 }
 
+// StreamlitFilePreview reports how many credential lines this migrator
+// would move from one secrets.toml — the read-only probe behind
+// audit.Config.StreamlitMigratable (so scan never promises a file whose
+// every flagged value falls outside the rewritable shape) and the plan's
+// per-file annotation. Prompt-free by construction: it reads the file and
+// nothing else.
+func StreamlitFilePreview(path string) (migratable int, err error) {
+	lines, err := readLines(path)
+	if err != nil {
+		return 0, err
+	}
+	return len(findSecretStreamlitLines(lines)), nil
+}
+
 // ApplyStreamlitSecrets moves every credential-shaped quoted value out of
 // a secrets.toml and into v's vault, then replaces the file with a FIFO
 // serving a template-substituted reconstruction (mount.FormatTemplate):

--- a/internal/migrate/streamlit_test.go
+++ b/internal/migrate/streamlit_test.go
@@ -319,3 +319,21 @@ db_password = "Tr0ub4dor3xKq9ZmPq2Lr"
 		t.Errorf("refusal must leave the original file untouched, got %v (err=%v)", info, statErr)
 	}
 }
+
+// TestStreamlitFilePreview is the probe behind audit's StreamlitMigratable
+// hook: a file whose every flagged value is unrewritable must report 0, so
+// scan downgrades it to manual instead of promising `jit migrate <path>`.
+func TestStreamlitFilePreview(t *testing.T) {
+	root := t.TempDir()
+	rewritable := filepath.Join(root, "a", streamlitDirName, streamlitFileName)
+	writeFile(t, rewritable, streamlitFixture)
+	if n, err := StreamlitFilePreview(rewritable); err != nil || n != 3 {
+		t.Errorf("rewritable preview = (%d, %v), want (3, nil)", n, err)
+	}
+
+	unrewritable := filepath.Join(root, "b", streamlitDirName, streamlitFileName)
+	writeFile(t, unrewritable, "password = \"has a \\\" escape Xk92QmPl4Tz\"\n")
+	if n, err := StreamlitFilePreview(unrewritable); err != nil || n != 0 {
+		t.Errorf("unrewritable preview = (%d, %v), want (0, nil)", n, err)
+	}
+}

--- a/internal/migrate/streamlit_test.go
+++ b/internal/migrate/streamlit_test.go
@@ -1,0 +1,321 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+package migrate
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jitpass/jit/internal/mount"
+)
+
+// streamlitFixture is the same shape audit's TestClassifyStreamlitSecrets
+// pins as a real-world blind spot (2026-07-28): a vendor token under its own
+// name, a secret-shaped top-level key, and a sectioned password among
+// settings. The file audit's test flags is exactly the file this package
+// must migrate — the D5 promise in fixture form.
+const streamlitFixture = `# Streamlit secrets
+OPENAI_API_KEY = "sk-proj-Ab3xKq9ZmPq2LrTvWn5cUd8eFg1hJk0uf4"
+db_password = "Tr0ub4dor3xKq9ZmPq2Lr"
+
+[connections.snowflake]
+account = "ACME-PROD"
+user = "analyst"
+port = 443
+password = "Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA"
+`
+
+func TestDiscoverStreamlitSecretsFindsProjectAndGlobal(t *testing.T) {
+	home := t.TempDir()
+	project := filepath.Join(home, "proj", streamlitDirName, streamlitFileName)
+	writeFile(t, project, streamlitFixture)
+	writeFile(t, StreamlitGlobalPath(home), streamlitFixture)
+	// The two-part gate: a secrets.toml OUTSIDE .streamlit (a Rust config, a
+	// Helm values file) and a different file INSIDE .streamlit are both not
+	// Streamlit secrets — same rule as audit's classifyStreamlitSecrets.
+	writeFile(t, filepath.Join(home, "proj", streamlitFileName), streamlitFixture)
+	writeFile(t, filepath.Join(home, "proj", streamlitDirName, "config.toml"), `password = "Xk92QmPl4TzWhuCmu2qc"`)
+
+	found, err := DiscoverStreamlitSecrets(home)
+	if err != nil {
+		t.Fatalf("DiscoverStreamlitSecrets: %v", err)
+	}
+	want := []string{StreamlitGlobalPath(home), project}
+	if len(found) != 2 || found[0] != want[0] || found[1] != want[1] {
+		t.Errorf("found = %v, want %v", found, want)
+	}
+}
+
+func TestDiscoverStreamlitSecretsQuietCases(t *testing.T) {
+	t.Run("no file", func(t *testing.T) {
+		found, err := DiscoverStreamlitSecrets(t.TempDir())
+		if err != nil || len(found) != 0 {
+			t.Errorf("got (%v, %v), want (nil, nil)", found, err)
+		}
+	})
+
+	t.Run("settings only", func(t *testing.T) {
+		root := t.TempDir()
+		writeFile(t, filepath.Join(root, streamlitDirName, streamlitFileName), "[connections.snowflake]\naccount = \"ACME-PROD\"\nport = 443\n")
+		found, err := DiscoverStreamlitSecrets(root)
+		if err != nil || len(found) != 0 {
+			t.Errorf("got (%v, %v), want (nil, nil) — settings alone are nothing to move", found, err)
+		}
+	})
+}
+
+// TestFindSecretStreamlitLines pins which lines count and how they're named:
+// the vendor token migrates on its value alone, the secret-shaped keys on
+// their names, and the section folds into the variable name so two tables'
+// identically named keys keep distinct vault paths (the collision audit's
+// scanner doc explicitly leaves to a migrator).
+func TestFindSecretStreamlitLines(t *testing.T) {
+	matches := findSecretStreamlitLines(strings.Split(streamlitFixture, "\n"))
+	if len(matches) != 3 {
+		t.Fatalf("got %d matches, want 3: %+v", len(matches), matches)
+	}
+	byVar := map[string]string{}
+	for _, m := range matches {
+		byVar[m.VarName] = m.Value
+	}
+	if byVar["OPENAI_API_KEY"] != "sk-proj-Ab3xKq9ZmPq2LrTvWn5cUd8eFg1hJk0uf4" {
+		t.Errorf("vendor-valued key missing or wrong: %v", byVar)
+	}
+	if byVar["DB_PASSWORD"] != "Tr0ub4dor3xKq9ZmPq2Lr" {
+		t.Errorf("secret-shaped top-level key missing or wrong: %v", byVar)
+	}
+	if byVar["CONNECTIONS_SNOWFLAKE_PASSWORD"] != "Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA" {
+		t.Errorf("sectioned password must fold the table into its name: %v", byVar)
+	}
+}
+
+// TestFindSecretStreamlitLinesSkipsUnrewritableShapes pins this side's
+// stricter shape rule: only a single-line quoted string with no escapes is
+// rewritable provably right. Everything else stays in place (and keeps its
+// scan finding) rather than risking a corrupt template.
+func TestFindSecretStreamlitLinesSkipsUnrewritableShapes(t *testing.T) {
+	lines := strings.Split(`password = "has a \" escape Xk92QmPl4Tz"
+api_key = "trailing comment Xk92QmPl4Tz" # prod
+token = 12345
+secret_key = """
+password = "Xk92QmPl4TzWhuCmu2qcInsideMultiline"
+"""
+db_password = 'ok-single-quoted-Xk92QmPl4Tz'
+`, "\n")
+
+	matches := findSecretStreamlitLines(lines)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want only the clean single-quoted line: %+v", len(matches), matches)
+	}
+	m := matches[0]
+	if m.VarName != "DB_PASSWORD" || m.Value != "ok-single-quoted-Xk92QmPl4Tz" || m.Quote != '\'' {
+		t.Errorf("match = %+v, want DB_PASSWORD / the single-quoted value / quote '", m)
+	}
+}
+
+// TestStreamlitVarNameCollisions mirrors pypirc's guard: distinct
+// section/key pairs that sanitize to one name must be split apart, or the
+// second silently overwrites the first in the vault and the mount serves
+// table B's password for table A.
+func TestStreamlitVarNameCollisions(t *testing.T) {
+	lines := strings.Split(`[my-db]
+password = "FirstDBPasswordQmPl4TzWhu"
+
+[my_db]
+password = "SecondDBPasswordu2qcwnu9P"
+`, "\n")
+	matches := findSecretStreamlitLines(lines)
+	if len(matches) != 2 {
+		t.Fatalf("got %d matches, want 2: %+v", len(matches), matches)
+	}
+	if matches[0].VarName == matches[1].VarName {
+		t.Errorf("two tables must not collapse to one variable name, both got %q", matches[0].VarName)
+	}
+}
+
+func TestApplyStreamlitSecretsMovesSecretsAndPreservesSettings(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "acme-app")
+	path := filepath.Join(project, streamlitDirName, streamlitFileName)
+	writeFile(t, path, streamlitFixture)
+
+	v := newTestVault(t)
+	result, err := ApplyStreamlitSecrets(v, project, path, false)
+	if err != nil {
+		t.Fatalf("ApplyStreamlitSecrets: %v", err)
+	}
+	if result.ProfileName != "streamlit-acme-app" {
+		t.Errorf("ProfileName = %q, want streamlit-acme-app", result.ProfileName)
+	}
+	if len(result.Variables) != 3 {
+		t.Fatalf("Variables = %v, want 3", result.Variables)
+	}
+
+	got, err := v.Get(result.ProfileName + "/CONNECTIONS_SNOWFLAKE_PASSWORD")
+	if err != nil || string(got) != "Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA" {
+		t.Errorf("vault secret = (%q, %v), want the snowflake password", got, err)
+	}
+
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("Lstat: %v", err)
+	}
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		t.Error("expected secrets.toml to be a FIFO after migration — st.secrets reads the file directly, so it must stay live")
+	}
+
+	tmpl, err := os.ReadFile(result.TemplatePath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading template: %v", err)
+	}
+	content := string(tmpl)
+	for _, secret := range []string{"sk-proj-", "Tr0ub4dor3xKq9ZmPq2Lr", "Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA"} {
+		if strings.Contains(content, secret) {
+			t.Errorf("template must not contain the raw secret %q", secret)
+		}
+	}
+	// Placeholders sit INSIDE the line's own quotes, so the served file is
+	// valid TOML and byte-identical to the original.
+	if !strings.Contains(content, `password = "${CONNECTIONS_SNOWFLAKE_PASSWORD}"`) {
+		t.Errorf("template missing the quoted sectioned placeholder, got:\n%s", content)
+	}
+	for _, keep := range []string{"[connections.snowflake]", `account = "ACME-PROD"`, `user = "analyst"`, "port = 443", "# Streamlit secrets"} {
+		if !strings.Contains(content, keep) {
+			t.Errorf("template lost non-secret line %q, got:\n%s", keep, content)
+		}
+	}
+
+	backup, err := v.Get(result.BackupPath)
+	if err != nil {
+		t.Fatalf("reading backup from vault: %v", err)
+	}
+	if !strings.Contains(string(backup), "Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA") {
+		t.Error("backup should contain the original plaintext content")
+	}
+}
+
+func TestApplyStreamlitSecretsGlobalProfileName(t *testing.T) {
+	home := t.TempDir()
+	path := StreamlitGlobalPath(home)
+	writeFile(t, path, `openai_key = "sk-proj-Ab3xKq9ZmPq2LrTvWn5cUd8eFg1hJk0uf4"`)
+
+	v := newTestVault(t)
+	result, err := ApplyStreamlitSecrets(v, home, path, true)
+	if err != nil {
+		t.Fatalf("ApplyStreamlitSecrets: %v", err)
+	}
+	if result.ProfileName != "streamlit" {
+		t.Errorf("ProfileName = %q, want streamlit for the global file", result.ProfileName)
+	}
+}
+
+// TestApplyStreamlitSecretsRoundTripsLosslessly is the guarantee that matters
+// most for a mounted credential file: what the mount serves must be
+// byte-identical to what was there before. If it isn't, `streamlit run` reads
+// a secrets file that looks correct and isn't — the hardest failure mode to
+// diagnose.
+func TestApplyStreamlitSecretsRoundTripsLosslessly(t *testing.T) {
+	const original = `# Streamlit secrets
+OPENAI_API_KEY = "sk-proj-Ab3xKq9ZmPq2LrTvWn5cUd8eFg1hJk0uf4"
+
+[connections.snowflake]
+account = "ACME-PROD"
+port = 443
+password='Xk92QmPl4TzWhuCmu2qcwnu9PnWfMKNA'
+
+[notes]
+motd = """
+password = "not-a-real-one-just-prose"
+"""
+`
+	root := t.TempDir()
+	project := filepath.Join(root, "app")
+	path := filepath.Join(project, streamlitDirName, streamlitFileName)
+	writeFile(t, path, original)
+
+	v := newTestVault(t)
+	result, err := ApplyStreamlitSecrets(v, project, path, false)
+	if err != nil {
+		t.Fatalf("ApplyStreamlitSecrets: %v", err)
+	}
+
+	tmpl, err := os.ReadFile(result.TemplatePath) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading template: %v", err)
+	}
+	// The assignment-shaped line inside the multi-line string must survive
+	// verbatim in the template — rewriting it would corrupt the string.
+	if !strings.Contains(string(tmpl), `password = "not-a-real-one-just-prose"`) {
+		t.Errorf("template must leave multi-line string content untouched, got:\n%s", tmpl)
+	}
+
+	values := map[string]string{}
+	for _, name := range result.Variables {
+		got, err := v.Get(result.ProfileName + "/" + name)
+		if err != nil {
+			t.Fatalf("vault get %s: %v", name, err)
+		}
+		values[name] = string(got)
+	}
+	if rendered := string(mount.FormatTemplate(tmpl, values)); rendered != original {
+		t.Errorf("round-trip is lossy.\nrendered: %q\noriginal: %q", rendered, original)
+	}
+}
+
+// TestApplyStreamlitSecretsIsUndoable pins that a migration can be reversed:
+// the FIFO is replaced by a regular file holding the original bytes.
+func TestApplyStreamlitSecretsIsUndoable(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "app")
+	path := filepath.Join(project, streamlitDirName, streamlitFileName)
+	writeFile(t, path, streamlitFixture)
+
+	v := newTestVault(t)
+	result, err := ApplyStreamlitSecrets(v, project, path, false)
+	if err != nil {
+		t.Fatalf("ApplyStreamlitSecrets: %v", err)
+	}
+	if info, err := os.Lstat(path); err != nil || info.Mode()&os.ModeNamedPipe == 0 {
+		t.Fatalf("expected a FIFO after migrate, got %v (err=%v)", info, err)
+	}
+
+	if err := RestoreFromBackup(v, BackupRecord{OriginalPath: path, VaultPath: result.BackupPath}); err != nil {
+		t.Fatalf("RestoreFromBackup: %v", err)
+	}
+	restored, err := os.ReadFile(path) // #nosec G304 -- test-controlled path
+	if err != nil {
+		t.Fatalf("reading restored file: %v", err)
+	}
+	if string(restored) != streamlitFixture {
+		t.Errorf("restored bytes differ.\ngot:  %q\nwant: %q", restored, streamlitFixture)
+	}
+}
+
+// TestApplyStreamlitSecretsRefusesLiteralPlaceholder ports ApplyNetrc's
+// guard: mount.FormatTemplate is position-blind, so a file already
+// containing the literal ${DB_PASSWORD} would get the real value substituted
+// into that spot at serve time, and the served bytes would diverge from the
+// original. Refusal is the only safe answer.
+func TestApplyStreamlitSecretsRefusesLiteralPlaceholder(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "app")
+	path := filepath.Join(project, streamlitDirName, streamlitFileName)
+	writeFile(t, path, `# db_password = ${DB_PASSWORD}
+db_password = "Tr0ub4dor3xKq9ZmPq2Lr"
+`)
+
+	v := newTestVault(t)
+	_, err := ApplyStreamlitSecrets(v, project, path, false)
+	if err == nil {
+		t.Fatal("ApplyStreamlitSecrets should refuse a file already containing its own placeholder")
+	}
+	if !strings.Contains(err.Error(), "${DB_PASSWORD}") {
+		t.Errorf("error should name the offending placeholder, got %v", err)
+	}
+	if info, statErr := os.Lstat(path); statErr != nil || !info.Mode().IsRegular() {
+		t.Errorf("refusal must leave the original file untouched, got %v (err=%v)", info, statErr)
+	}
+}

--- a/internal/vault/envelope.go
+++ b/internal/vault/envelope.go
@@ -153,8 +153,13 @@ const (
 	ClassSOPS      = "sops"
 	ClassNpmrc     = "npmrc"
 	ClassPypirc    = "pypirc"
+	ClassCargo     = "cargo"
 	ClassGit       = "git"
 	ClassNetrc     = "netrc"
+	// ClassStreamlit is a value migrated out of a .streamlit/secrets.toml
+	// (project or global) — Streamlit's own application-secrets file, read
+	// directly by st.secrets. Origin is the file path.
+	ClassStreamlit = "streamlit"
 	ClassKube      = "kube"
 	ClassWrap      = "wrap"
 	// ClassLooseFile is a bare secret migrated out of a file the user named

--- a/spike/cargo-credential-provider/FINDINGS.md
+++ b/spike/cargo-credential-provider/FINDINGS.md
@@ -1,0 +1,81 @@
+# Cargo credential-provider spike — findings
+
+2026-09-06, cargo 1.98.0 (Homebrew), macOS. Method: a local HTTP server
+plays a minimal sparse registry (`config.json` with `auth-required` +
+the owners API endpoint) and records every Authorization header; cargo
+runs against it with a scratch `CARGO_HOME`. `go run .` reproduces
+everything below.
+
+## Verdict
+
+**Tier 2 holds up.** `jit migrate ~/.cargo/credentials.toml` can be a
+native credential hook like AWS's `credential_process` and Terraform's
+`credentials_helper`, with `cargo login`/`logout` kept working through
+the vault. Implement the full JSON protocol (a `cargo-credential-jit`
+wrapper exec'ing `jit cargo-credential`), NOT `cargo:token-from-stdout`
+— the stdout form is get-only and fails `cargo login` with
+"requested operation not supported".
+
+## What was verified empirically
+
+1. **`cargo:token-from-stdout <cmd>` works for reads.** The command runs
+   once per cargo invocation; its stdout is sent verbatim as the
+   `Authorization` header on API operations (`cargo owner --list`), and
+   on index fetches when the registry declares `auth-required`.
+
+2. **Precedence: LATER entries in `global-credential-providers` win.**
+   With `["cargo:token", "cargo:token-from-stdout …"]` and a token
+   present in credentials.toml, the provider's token was sent, not the
+   file's. So jit's provider appended last shadows any stale plaintext
+   token — and a post-migration `cargo login` cannot silently write a
+   new plaintext token that takes effect behind jit's back.
+
+3. **The JSON protocol is simple and the shapes below are accepted**
+   (cargo spawns the provider per operation with argv
+   `[path, "--cargo-plugin"]`, JSON lines over stdin/stdout):
+
+   - greeting, provider → cargo: `{"v":[1]}`
+   - get, cargo → provider:
+     `{"v":1,"registry":{"index-url":"…","name":"testreg"},"kind":"get","operation":"read"}`
+   - get response:
+     `{"Ok":{"kind":"get","token":"…","cache":"session","operation_independent":true}}`
+   - login, cargo → provider: same envelope with `"kind":"login"`,
+     `"token":"…"` (and a `login-url` when the registry advertises one);
+     response `{"Ok":{"kind":"login"}}`. **`cargo login` exits 0.**
+   - logout: `"kind":"logout"` / `{"Ok":{"kind":"logout"}}`. Exits 0.
+
+4. **Registry selection is provided, both ways.** token-from-stdout gets
+   `CARGO_REGISTRY_NAME_OPT` + `CARGO_REGISTRY_INDEX_URL` in the
+   environment; the JSON protocol carries `registry.index-url` and
+   `registry.name` in every request. Multi-registry vault lookup keys on
+   the index URL (stable), with the name as display.
+
+5. **Fallthrough works.** cargo:token configured first with no token for
+   the target registry falls through to the next provider cleanly.
+
+6. **`{"Err":{"kind":"not-found"}}` on get is accepted and falls back.**
+   With `["cargo:token", <jit>]` configured and jit answering not-found,
+   cargo used the credentials.toml token; with only jit configured it
+   failed clean ("no token found for `testreg` … log in using this
+   registry's credential provider"). So jit answers not-found for any
+   registry it holds nothing for, costs no prompt, and never blocks an
+   unmigrated registry.
+
+7. **`{"Err":{"kind":"other","message":"…"}}` surfaces the message.**
+   cargo prints it as the last `Caused by:` in its error chain — so a
+   locked/denied vault for a registry jit DOES hold reports itself in
+   jit's own words instead of decaying into "no token found".
+
+## Implementation notes for the real thing
+
+- Provider strings are whitespace-split, so the config must reference a
+  space-free path: a wrapper script exec'ing `jit cargo-credential`, the
+  same shape as `terraform-credentials-jit`.
+- `cache":"session"` keeps cargo from re-invoking the provider within
+  one invocation; each new cargo process asks again — exactly jit's
+  just-in-time model.
+- The provider is spawned fresh per operation (three argv lines in the
+  transcript for get/login/logout runs). No daemon assumptions.
+- `credentials.toml` is INI-shaped TOML (`[registry]` /
+  `[registries.<name>]`, one quoted `token = "…"` per table) — audit's
+  parseINISections already reads it (scanCargoCredentialFile).

--- a/spike/cargo-credential-provider/go.mod
+++ b/spike/cargo-credential-provider/go.mod
@@ -1,0 +1,3 @@
+module jit/spike/cargo-credential-provider
+
+go 1.26

--- a/spike/cargo-credential-provider/main.go
+++ b/spike/cargo-credential-provider/main.go
@@ -1,0 +1,242 @@
+// Copyright 2026 Meni Tasa
+// SPDX-License-Identifier: LicenseRef-PolyForm-Perimeter-1.0.0
+
+// Spike: can `jit` serve a cargo registry token through cargo's stable
+// credential-provider mechanism (cargo 1.74+), so `jit migrate
+// ~/.cargo/credentials.toml` can be a Tier 2 native hook (like AWS's
+// credential_process and Terraform's credentials_helper) instead of a
+// FIFO template mount?
+//
+// Questions this answers empirically (see FINDINGS.md for the verdicts):
+//  1. Does `cargo:token-from-stdout <command>` invoke the command and send
+//     its stdout as the Authorization header on an API operation?
+//  2. Precedence: with both `cargo:token` (credentials.toml) and
+//     token-from-stdout configured, which token does cargo send?
+//  3. Does an empty/absent credentials.toml fall through to the provider?
+//  4. What does `cargo login` do when only token-from-stdout is configured?
+//
+// Method: a local HTTP server plays a minimal sparse registry (config.json
+// + the owners API endpoint) and records every Authorization header; cargo
+// runs with a scratch CARGO_HOME pointing at it via `cargo owner --list`,
+// an API operation that must send the token.
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+type authLog struct {
+	mu      sync.Mutex
+	headers []string
+	paths   []string
+}
+
+func (a *authLog) record(r *http.Request) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.headers = append(a.headers, r.Header.Get("Authorization"))
+	a.paths = append(a.paths, r.URL.Path)
+}
+
+func (a *authLog) reset() {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.headers, a.paths = nil, nil
+}
+
+func (a *authLog) summary() string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	var b strings.Builder
+	for i, p := range a.paths {
+		fmt.Fprintf(&b, "  %s -> Authorization: %q\n", p, a.headers[i])
+	}
+	return b.String()
+}
+
+func main() {
+	log := &authLog{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		log.record(r)
+		switch {
+		case r.URL.Path == "/index/config.json":
+			fmt.Fprintf(w, `{"dl":"%s/dl","api":"%s","auth-required":true}`, srvURL(r), srvURL(r))
+		case strings.HasSuffix(r.URL.Path, "/owners"):
+			fmt.Fprint(w, `{"users":[]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	work, err := os.MkdirTemp("", "cargo-cred-spike")
+	must(err)
+	defer os.RemoveAll(work)
+
+	cargoHome := filepath.Join(work, "cargo-home")
+	must(os.MkdirAll(cargoHome, 0o700))
+
+	// The provider command cargo will run: prints a fixed token, and logs
+	// each invocation so we can tell the provider ran (vs a cached token).
+	tokScript := filepath.Join(work, "tok.sh")
+	tokLog := filepath.Join(work, "tok.log")
+	must(os.WriteFile(tokScript, []byte("#!/bin/sh\necho invoked >> "+tokLog+"\necho jit-served-token-from-stdout\n"), 0o700)) // #nosec G306 -- must be executable
+
+	baseConfig := fmt.Sprintf("[registries.testreg]\nindex = \"sparse+%s/index/\"\n", srv.URL)
+
+	scenario := func(name, extraConfig, credentials string, args ...string) {
+		log.reset()
+		_ = os.Remove(tokLog)
+		must(os.WriteFile(filepath.Join(cargoHome, "config.toml"), []byte(baseConfig+extraConfig), 0o600))
+		credPath := filepath.Join(cargoHome, "credentials.toml")
+		if credentials == "" {
+			_ = os.Remove(credPath)
+		} else {
+			must(os.WriteFile(credPath, []byte(credentials), 0o600))
+		}
+
+		cmd := exec.Command("cargo", args...) // #nosec G204 -- spike, fixed args
+		cmd.Env = append(os.Environ(), "CARGO_HOME="+cargoHome)
+		out, err := cmd.CombinedOutput()
+		fmt.Printf("=== %s\n$ cargo %s (err=%v)\n%s", name, strings.Join(args, " "), err, indent(string(out)))
+		fmt.Printf("requests seen:\n%s", log.summary())
+		if data, err := os.ReadFile(tokLog); err == nil { // #nosec G304 -- spike temp file
+			fmt.Printf("provider invocations: %d\n", strings.Count(string(data), "invoked"))
+		} else {
+			fmt.Println("provider invocations: 0")
+		}
+		fmt.Println()
+	}
+
+	providers := "[registry]\nglobal-credential-providers = [\"cargo:token\", \"cargo:token-from-stdout " + tokScript + "\"]\n"
+
+	// 1. Provider only, no credentials.toml: token must come from the script.
+	scenario("provider-only", providers, "", "owner", "--list", "somecrate", "--registry", "testreg")
+
+	// 2. Both sources hold a token: which wins? (docs say LATER entries in
+	// global-credential-providers take precedence)
+	scenario("both-sources", providers, "[registries.testreg]\ntoken = \"token-from-credentials-file\"\n",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+
+	// 3. cargo:token FIRST and provider LAST but credentials empty of this
+	// registry: falls through to the provider?
+	scenario("fallthrough", providers, "[registries.otherreg]\ntoken = \"unrelated\"\n",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+
+	// 4. Login under token-from-stdout only: expected to refuse (get-only
+	// provider), which decides whether `cargo login` keeps working after a
+	// jit migration that leaves ONLY the provider configured.
+	stdoutOnly := "[registry]\nglobal-credential-providers = [\"cargo:token-from-stdout " + tokScript + "\"]\n"
+	scenario("login-under-stdout-provider", stdoutOnly, "", "login", "--registry", "testreg", "ZZtestZZ")
+
+	// 5. Baseline sanity: cargo:token alone with a credentials.toml token.
+	scenario("credentials-baseline", "[registry]\nglobal-credential-providers = [\"cargo:token\"]\n",
+		"[registries.testreg]\ntoken = \"token-from-credentials-file\"\n",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+
+	// 6. What ENVIRONMENT does token-from-stdout's command get? Decides how
+	// `jit cargo-token` would pick the right secret for multi-registry
+	// setups (by index URL / registry name).
+	envScript := filepath.Join(work, "env.sh")
+	must(os.WriteFile(envScript, []byte("#!/bin/sh\nenv | grep -i cargo >> "+tokLog+"\necho envprobe-token\n"), 0o700)) // #nosec G306 -- must be executable
+	scenario("stdout-provider-env", "[registry]\nglobal-credential-providers = [\"cargo:token-from-stdout "+envScript+"\"]\n", "",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+	if data, err := os.ReadFile(tokLog); err == nil { // #nosec G304 -- spike temp file
+		fmt.Printf("provider environment (CARGO_*):\n%s\n", indent(string(data)))
+	}
+
+	// 7. Full JSON-protocol provider: a probe that logs argv + every request
+	// line cargo sends and answers get/login/logout. Decides whether a
+	// `cargo-credential-jit` (via `jit cargo-credential`) can keep
+	// `cargo login`/`logout` working post-migration, the way jit's
+	// terraform-credentials helper keeps `terraform login` working.
+	provScript := filepath.Join(work, "jsonprov.py")
+	provLog := filepath.Join(work, "jsonprov.log")
+	must(os.WriteFile(provScript, []byte(`#!/usr/bin/env python3
+import sys, json
+log = open(`+fmt.Sprintf("%q", provLog)+`, "a")
+def w(o):
+    sys.stdout.write(json.dumps(o)+"\n"); sys.stdout.flush()
+log.write("argv: %r\n" % (sys.argv,)); log.flush()
+w({"v":[1]})
+for line in sys.stdin:
+    log.write("recv: " + line); log.flush()
+    req = json.loads(line)
+    k = req.get("kind")
+    if k == "get":
+        w({"Ok":{"kind":"get","token":"json-provider-token","cache":"session","operation_independent":True}})
+    elif k == "login":
+        w({"Ok":{"kind":"login"}})
+    elif k == "logout":
+        w({"Ok":{"kind":"logout"}})
+    else:
+        w({"Err":{"kind":"operation-not-supported"}})
+`), 0o700)) // #nosec G306 -- must be executable
+	jsonProv := "[registry]\nglobal-credential-providers = [\"" + provScript + "\"]\n"
+	scenario("json-provider-get", jsonProv, "", "owner", "--list", "somecrate", "--registry", "testreg")
+	scenario("json-provider-login", jsonProv, "", "login", "--registry", "testreg", "ZZtestZZ")
+	scenario("json-provider-logout", jsonProv, "", "logout", "--registry", "testreg")
+	if data, err := os.ReadFile(provLog); err == nil { // #nosec G304 -- spike temp file
+		fmt.Printf("json provider transcript:\n%s", indent(string(data)))
+	}
+
+	// 8. The "provider holds nothing" answer: respond {"Err":{"kind":
+	// "not-found"}} on get — does cargo fall back to an EARLIER-listed
+	// cargo:token, and is the error kind accepted at all? Decides what
+	// `jit cargo-credential` answers for a registry jit never migrated.
+	nfScript := filepath.Join(work, "notfound.py")
+	must(os.WriteFile(nfScript, []byte(`#!/usr/bin/env python3
+import sys, json
+def w(o):
+    sys.stdout.write(json.dumps(o)+"\n"); sys.stdout.flush()
+w({"v":[1]})
+for line in sys.stdin:
+    w({"Err":{"kind":"not-found"}})
+`), 0o700)) // #nosec G306 -- must be executable
+	nfProviders := "[registry]\nglobal-credential-providers = [\"cargo:token\", \"" + nfScript + "\"]\n"
+	scenario("notfound-falls-back", nfProviders, "[registries.testreg]\ntoken = \"token-from-credentials-file\"\n",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+	scenario("notfound-no-fallback", "[registry]\nglobal-credential-providers = [\""+nfScript+"\"]\n", "",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+
+	// 9. The internal-failure answer: {"Err":{"kind":"other","message":…}}
+	// — is the message surfaced to the user? Decides how `jit
+	// cargo-credential` reports a locked/denied vault for a registry it
+	// DOES hold (where not-found would silently fall through to nothing).
+	errScript := filepath.Join(work, "errother.py")
+	must(os.WriteFile(errScript, []byte(`#!/usr/bin/env python3
+import sys, json
+def w(o):
+    sys.stdout.write(json.dumps(o)+"\n"); sys.stdout.flush()
+w({"v":[1]})
+for line in sys.stdin:
+    w({"Err":{"kind":"other","message":"vault locked: approve the jit Touch ID prompt and retry"}})
+`), 0o700)) // #nosec G306 -- must be executable
+	scenario("err-other-message", "[registry]\nglobal-credential-providers = [\""+errScript+"\"]\n", "",
+		"owner", "--list", "somecrate", "--registry", "testreg")
+
+	_ = time.Now // keep imports honest if scenarios change
+}
+
+func srvURL(r *http.Request) string { return "http://" + r.Host }
+
+func indent(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "  " + strings.ReplaceAll(strings.TrimRight(s, "\n"), "\n", "\n  ") + "\n"
+}
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
## What

`jit scan` flagged `~/.cargo/credentials.toml` and `.streamlit/secrets.toml` as credential files with FixCommand `jit migrate <path>`, but no migrate category claimed either path: both fell through to loose-secret classification, were judged mixed-content, and the recommended command answered with a skip note. That is the scan-contradicts-migrate shape design/dry-run-refactor.md D5 exists to prevent. Both are real categories now, so the promise is honored rather than reworded.

### Streamlit (`--only streamlit`)

A template-based FIFO mount like npmrc's: the file mixes credentials with settings that must survive byte-for-byte, and Streamlit has no credential hook. One walk finds the project file and the global `~/.streamlit/secrets.toml` (which joins the `--with` grant set as `streamlit`). Variable names fold in the TOML table, closing the collision audit's own scanner doc left to a migrator. Only single-line quoted values with no escapes migrate, so the served bytes provably round-trip; a file whose every flagged value falls outside that shape is downgraded to a manual finding at scan time through the new `Config.StreamlitMigratable` hook (K8sMigratable's twin), never promised as fixable. Class `streamlit` is ungated: the app's own secrets, dotenv's half of the consent partition.

### Cargo (`--only cargo`)

A Tier 2 native hook like Terraform's, via cargo's stable credential-provider protocol (1.74+): a `cargo-credential-jit` wrapper exec'ing the new `jit cargo-credential` plumbing command, registered last in `global-credential-providers` so it takes precedence. `cargo login`/`logout` keep working and land in the vault; an unmigrated registry gets the protocol's not-found and falls back to `credentials.toml` untouched; a foreign provider list is a fail-loud conflict. Token lines are stripped from both `credentials.toml` and the legacy bare file. Class `cargo` is consent-gated: a publish token, npmrc/pypirc's blast radius.

Every protocol shape was verified empirically against cargo 1.98 before implementation; `spike/cargo-credential-provider/FINDINGS.md` pins precedence order, login/logout routing, registry identification, fallback, and error surfacing.

### Parity and undo edges (second commit)

- Targeted-scan routing: `scanTargetFile` had no case for either category, so a named `.streamlit/secrets.toml` fell to the vendor-token sweep (missing every secret-shaped key) and a named `~/.cargo/credentials.toml` reported nothing at all, since cargo tokens carry no vendor prefix. Both now route to their scanners with the walk's gates kept.
- Cargo quote parity: single-quoted (TOML literal string) tokens now migrate; audit's unquote already accepted them.
- Cargo undo linkage: jit's provider registration outranks the credentials file, so restoring the token file alone was silently ineffective. Backup records for the two files now carry `RestoreWith` links (new `BackupTracker.backupOnceLinking`), so undoing either pulls the other back. Terraform needs no such link because its precedence is the opposite.
- Both helper artifacts join the recorded-jit-path refresh table; the plan preview struct now carries both categories.

## Testing

- Full gate green: build, gofmt, vet, `go test -race ./...`, gosec, govulncheck, `go mod tidy` clean, docs-gen no drift.
- Package tests cover discovery, apply, round-trip byte-identity, var-name collisions, placeholder refusal, undo restoration, provider-config conflict and merge, the RestoreWith linkage, the protocol conversation, and the scan-side hook (refused/ok/nil).
- Attended VM dogfood passed end to end with the branch build installed over the live service: scan, migrate (Touch ID), real `cargo owner` fetching the vaulted token through the provider against a local auth-required mock registry, `cargo login` rotating into the vault with nothing written to disk, `cargo logout` plus clean fallback, streamlit decoy vs `jit run --live` vs `--with streamlit`, and byte-exact undo that pulled `config.toml` back through the new linkage. Machine restored to shipped 0.99.1 and the baseline vault afterward.

Untested against a genuine registry: `cargo publish` itself (the mock covered the protocol, not crates.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6dDAKEdpdqrP2J1go4EAA
